### PR TITLE
replace monaco-editor to ngx-monaco-editor-v2

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -20,15 +20,14 @@
             "outputPath": "dist/chirimen-ng-web-serial-console",
             "index": "src/index.html",
             "browser": "src/main.ts",
-            "polyfills": [
-              "zone.js"
-            ],
+            "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [
               {
                 "glob": "**/*",
-                "input": "public"
+                "input": "node_modules/monaco-editor",
+                "output": "/assets/monaco/"
               }
             ],
             "styles": [
@@ -79,16 +78,14 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": [
-              "zone.js",
-              "zone.js/testing"
-            ],
+            "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
             "assets": [
               {
                 "glob": "**/*",
-                "input": "public"
+                "input": "node_modules/monaco-editor",
+                "output": "/assets/monaco/"
               }
             ],
             "styles": [

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "^18.0.2",
     "@angular/platform-browser-dynamic": "^18.0.2",
     "@angular/router": "^18.0.2",
-    "monaco-editor": "^0.49.0",
+    "ngx-monaco-editor-v2": "^18.0.1",
     "rxjs": "~7.8.1",
     "tslib": "^2.6.3",
     "web-serial-polyfill": "^1.0.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,9 @@ importers:
       '@angular/router':
         specifier: ^18.0.2
         version: 18.0.2(@angular/common@18.0.2(@angular/core@18.0.2(rxjs@7.8.1)(zone.js@0.14.7))(rxjs@7.8.1))(@angular/core@18.0.2(rxjs@7.8.1)(zone.js@0.14.7))(@angular/platform-browser@18.0.2(@angular/animations@18.0.2(@angular/core@18.0.2(rxjs@7.8.1)(zone.js@0.14.7)))(@angular/common@18.0.2(@angular/core@18.0.2(rxjs@7.8.1)(zone.js@0.14.7))(rxjs@7.8.1))(@angular/core@18.0.2(rxjs@7.8.1)(zone.js@0.14.7)))(rxjs@7.8.1)
-      monaco-editor:
-        specifier: ^0.49.0
-        version: 0.49.0
+      ngx-monaco-editor-v2:
+        specifier: ^18.0.1
+        version: 18.0.1(@angular/common@18.0.2(@angular/core@18.0.2(rxjs@7.8.1)(zone.js@0.14.7))(rxjs@7.8.1))(@angular/core@18.0.2(rxjs@7.8.1)(zone.js@0.14.7))(monaco-editor@0.49.0)
       rxjs:
         specifier: ~7.8.1
         version: 7.8.1
@@ -3209,6 +3209,13 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  ngx-monaco-editor-v2@18.0.1:
+    resolution: {integrity: sha512-h2AGxuaCfnBnYHVbpjfP+4kC0OLf2vWdhPeULRoOcaE1yu0YxunR+r7ubYBZGQbFWGT8LVo8FR+L5CMCSOJm6A==}
+    peerDependencies:
+      '@angular/common': ^18.0.1
+      '@angular/core': ^18.0.1
+      monaco-editor: ^0.49.0
 
   nice-napi@1.0.2:
     resolution: {integrity: sha512-px/KnJAJZf5RuBGcfD+Sp2pAKq0ytz8j+1NehvgIGFkvtvFrDM3T8E4x/JJODXK9WZow8RRGrbA9QQ3hs+pDhA==}
@@ -8238,6 +8245,13 @@ snapshots:
   negotiator@0.6.3: {}
 
   neo-async@2.6.2: {}
+
+  ngx-monaco-editor-v2@18.0.1(@angular/common@18.0.2(@angular/core@18.0.2(rxjs@7.8.1)(zone.js@0.14.7))(rxjs@7.8.1))(@angular/core@18.0.2(rxjs@7.8.1)(zone.js@0.14.7))(monaco-editor@0.49.0):
+    dependencies:
+      '@angular/common': 18.0.2(@angular/core@18.0.2(rxjs@7.8.1)(zone.js@0.14.7))(rxjs@7.8.1)
+      '@angular/core': 18.0.2(rxjs@7.8.1)(zone.js@0.14.7)
+      monaco-editor: 0.49.0
+      tslib: 2.6.3
 
   nice-napi@1.0.2:
     dependencies:


### PR DESCRIPTION
ライブラリ移行 #1
[Monaco Editor](https://www.npmjs.com/package/monaco-editor)
　↓
[Monaco Editor Component for Angular 2 and above.](https://www.npmjs.com/package/ngx-monaco-editor-v2)
