### PR TITLE
chore(deps): update @gurezo/web-serial-rxjs to 0.1.8

### DIFF
--- a/libs/web-serial/package.json
+++ b/libs/web-serial/package.json
@@ -7,7 +7,7 @@
     "@angular/core": "^21.0.0",
     "@ngrx/effects": "^21.0.0",
     "@ngrx/store": "^21.0.0",
-    "@gurezo/web-serial-rxjs": "^0.1.0",
+    "@gurezo/web-serial-rxjs": "^0.1.8",
     "rxjs": "~7.8.1",
     "ngx-toastr": "^19.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "21.0.6",
     "@angular/platform-browser-dynamic": "21.0.6",
     "@angular/router": "21.0.6",
-    "@gurezo/web-serial-rxjs": "0.1.5",
+    "@gurezo/web-serial-rxjs": "0.1.8",
     "@ngrx/component-store": "21.0.1",
     "@ngrx/effects": "21.0.1",
     "@ngrx/operators": "21.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 21.0.6
         version: 21.0.6(@angular/common@21.0.6(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1))(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.1)(zone.js@0.16.0))(@angular/platform-browser@21.0.6(@angular/animations@21.0.6(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.1)(zone.js@0.16.0)))(@angular/common@21.0.6(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1))(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.1)(zone.js@0.16.0)))(rxjs@7.8.1)
       '@gurezo/web-serial-rxjs':
-        specifier: 0.1.5
-        version: 0.1.5(rxjs@7.8.1)
+        specifier: 0.1.8
+        version: 0.1.8(rxjs@7.8.1)
       '@ngrx/component-store':
         specifier: 21.0.1
         version: 21.0.1(@angular/core@21.0.6(@angular/compiler@21.0.6)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1)
@@ -1790,8 +1790,8 @@ packages:
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@gurezo/web-serial-rxjs@0.1.5':
-    resolution: {integrity: sha512-dbpz9hKkvczfDIWGtlVocNp0kAOFsDPb46OeiND9zz59stzby8Ai2X36KuE/HHEdSjJEfSL/bWccX+uuDNg1+A==}
+  '@gurezo/web-serial-rxjs@0.1.8':
+    resolution: {integrity: sha512-ponhcAXpV424KiDtLZmb4cjBXNP/zYvj5d7j7sL9S07o5gKJrjAZXz42Y2+xe2y0yKwmVkYmm+aUrYaEkP4ooQ==}
     peerDependencies:
       rxjs: ^7.8.0
 
@@ -11908,7 +11908,7 @@ snapshots:
 
   '@eslint/js@8.57.0': {}
 
-  '@gurezo/web-serial-rxjs@0.1.5(rxjs@7.8.1)':
+  '@gurezo/web-serial-rxjs@0.1.8(rxjs@7.8.1)':
     dependencies:
       rxjs: 7.8.1
 


### PR DESCRIPTION
## 概要
`@gurezo/web-serial-rxjs`パッケージを`0.1.5`から`0.1.8`に更新しました。

## 変更内容
- `package.json`: `@gurezo/web-serial-rxjs`のバージョンを`0.1.5` → `0.1.8`に更新
- `libs/web-serial/package.json`: `peerDependencies`の`@gurezo/web-serial-rxjs`を`^0.1.0` → `^0.1.8`に更新

## 影響範囲
- `libs/web-serial`ライブラリ
- Serial接続機能を使用するすべてのコンポーネント

## テスト
- [x] ビルドが正常に完了することを確認
- [x] 既存のテストがすべて通過することを確認
- [x] Serial接続機能が正常に動作することを確認

## 関連Issue
Fixes #244
