### PR TITLE
fix(libs-unsupported-browser): add ESLint config and missing peer dependency

### DIFF
--- a/libs/unsupported-browser/.eslintrc.json
+++ b/libs/unsupported-browser/.eslintrc.json
@@ -1,0 +1,54 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "choh",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "choh",
+            "style": "kebab-case"
+          }
+        ],
+        "@typescript-eslint/no-unused-vars": [
+          "warn",
+          {
+            "argsIgnorePattern": "^_"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredFiles": ["{projectRoot}/eslint.config.{js,cjs,mjs}"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/libs/unsupported-browser/package.json
+++ b/libs/unsupported-browser/package.json
@@ -2,7 +2,8 @@
   "name": "@libs-unsupported-browser",
   "version": "0.0.1",
   "peerDependencies": {
-    "@angular/core": "21.0.6"
+    "@angular/core": "21.0.6",
+    "@angular/material": "21.0.5"
   },
   "sideEffects": false
 }


### PR DESCRIPTION
## 概要
`libs-unsupported-browser`のlintタスクがエラーになる問題を修正しました。

## 変更内容
- `.eslintrc.json`を追加してESLint設定を整備
- `package.json`の`peerDependencies`に`@angular/material`を追加（コンポーネントで使用しているため必須）

## 問題
- `npx nx run libs-unsupported-browser:lint`を実行するとエラーが発生していた
- ESLint設定ファイルが存在しなかった
- `@angular/material`が`peerDependencies`に含まれていなかった

## 検証
- `pnpm nx run libs-unsupported-browser:lint`が正常に実行できることを確認済み