### PR TITLE
fix(xterm): resolve @types/w3c-web-serial type definitions

### DIFF
--- a/libs/xterm/src/lib/services/terminal.service.ts
+++ b/libs/xterm/src/lib/services/terminal.service.ts
@@ -1,5 +1,3 @@
-/// <reference types="@types/w3c-web-serial" />
-
 import { inject, Injectable } from '@angular/core';
 import {
   SerialConnectionService,

--- a/libs/xterm/tsconfig.lib.json
+++ b/libs/xterm/tsconfig.lib.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
-    "types": []
+    "types": ["w3c-web-serial"]
   },
   "exclude": [
     "src/**/*.spec.ts",


### PR DESCRIPTION
## 概要

xterm ライブラリで `@types/w3c-web-serial` の型定義ファイルが見つからないエラーを修正しました。

## 変更内容

- `libs/xterm/tsconfig.lib.json` の `types` 配列に `w3c-web-serial` を追加
- `terminal.service.ts` から冗長な triple-slash 参照を削除

## 理由

`tsconfig.lib.json` で `"types": []` が指定されていたため、`@types` パッケージが自動的に読み込まれていませんでした。`w3c-web-serial` を明示的に指定することで、`SerialPort` などの Web Serial API 型が正しく解決されるようになります。

Made with [Cursor](https://cursor.com)

#Fixes #282 