### PR TITLE
chore(deps): bump @gurezo/web-serial-rxjs to 0.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "21.1.6",
     "@angular/platform-browser-dynamic": "21.1.6",
     "@angular/router": "21.1.6",
-    "@gurezo/web-serial-rxjs": "0.1.8",
+    "@gurezo/web-serial-rxjs": "0.1.11",
     "@ngrx/component-store": "21.0.1",
     "@ngrx/effects": "21.0.1",
     "@ngrx/operators": "21.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 21.1.6
         version: 21.1.6(@angular/common@21.1.6(@angular/core@21.1.6(@angular/compiler@21.1.6)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1))(@angular/core@21.1.6(@angular/compiler@21.1.6)(rxjs@7.8.1)(zone.js@0.16.0))(@angular/platform-browser@21.1.6(@angular/animations@21.1.6(@angular/core@21.1.6(@angular/compiler@21.1.6)(rxjs@7.8.1)(zone.js@0.16.0)))(@angular/common@21.1.6(@angular/core@21.1.6(@angular/compiler@21.1.6)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1))(@angular/core@21.1.6(@angular/compiler@21.1.6)(rxjs@7.8.1)(zone.js@0.16.0)))(rxjs@7.8.1)
       '@gurezo/web-serial-rxjs':
-        specifier: 0.1.8
-        version: 0.1.8(rxjs@7.8.1)
+        specifier: 0.1.11
+        version: 0.1.11(rxjs@7.8.1)
       '@ngrx/component-store':
         specifier: 21.0.1
         version: 21.0.1(@angular/core@21.1.6(@angular/compiler@21.1.6)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1)
@@ -1752,8 +1752,8 @@ packages:
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@gurezo/web-serial-rxjs@0.1.8':
-    resolution: {integrity: sha512-ponhcAXpV424KiDtLZmb4cjBXNP/zYvj5d7j7sL9S07o5gKJrjAZXz42Y2+xe2y0yKwmVkYmm+aUrYaEkP4ooQ==}
+  '@gurezo/web-serial-rxjs@0.1.11':
+    resolution: {integrity: sha512-HzX55v+DhZM2ceEB1B3ftg1+4ZBhlLU14gTzJRQ0nVoderDM8sy/niVYJNIMLGtJw9bsT0lruQ5BJEn3e6rbJA==}
     peerDependencies:
       rxjs: ^7.8.0
 
@@ -12495,7 +12495,7 @@ snapshots:
 
   '@eslint/js@8.57.0': {}
 
-  '@gurezo/web-serial-rxjs@0.1.8(rxjs@7.8.1)':
+  '@gurezo/web-serial-rxjs@0.1.11(rxjs@7.8.1)':
     dependencies:
       rxjs: 7.8.1
 


### PR DESCRIPTION
## 概要

`@gurezo/web-serial-rxjs` を 0.1.8 から 0.1.11 に更新しました。

## 変更内容
- `package.json`: `@gurezo/web-serial-rxjs` のバージョンを 0.1.11 に変更
- `pnpm-lock.yaml`: 上記に合わせてロックファイルを更新

Fixes #293

Made with [Cursor](https://cursor.com)