### PR TITLE
docs: add GitHub issue templates (bug report, feature request, config)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.ja.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.ja.yml
@@ -1,0 +1,98 @@
+name: 🐛 バグ報告
+description: chirimen-lite-console の不具合報告
+title: '[Bug]: '
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ありがとうございます！再現可能な情報があると調査が速くなります。
+
+  - type: input
+    id: environment
+    attributes:
+      label: 環境（Nx / Node / pnpm など）
+      description: '例: Nx 22.x, Node 20.x, pnpm 10.x'
+      placeholder: 'Nx x.x / Node x.x / pnpm x.x'
+    validations:
+      required: true
+
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: 対象アプリ
+      options:
+        - console (Angular)
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: ブラウザ / バージョン（web の場合）
+      description: '例: Chrome 120 / Edge 120'
+      placeholder: 'Chrome xx / Edge xx / 該当なし'
+    validations:
+      required: false
+
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: 'macOS / Windows / Linux'
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 何が起きましたか？
+      description: 実際に起きたこと（エラー内容や挙動）
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      description: 再現手順（番号付きで）
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待される動作
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: ログ / エラースタック
+      description: コンソールログ、スタックトレース、スクリーンショット（あれば）を貼ってください
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: チェックリスト
+      options:
+        - label: README の Quick Start を確認しました
+          required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ## 作業上の留意点
+
+        - 作業を実施する時は、Conventional Commits に準拠したブランチを作成して作業を開始してください
+        - 差分を Conventional Commits に準拠したコミットメッセージで、コミットしてください
+        - プッシュして `.github/pull_request_template.md` に沿った Conventional Commits に準拠したプルリクエストの概要とタイトルを作成してください

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 質問 / Q&A (Discussions)
+    url: https://github.com/gurezo/chirimen-lite-console/discussions
+    about: バグ報告・機能要望以外（質問、使い方相談）は Discussions へお願いします
+  - name: 📖 README / ドキュメント
+    url: https://github.com/gurezo/chirimen-lite-console#readme
+    about: まずは README（使い方、前提条件）をご確認ください

--- a/.github/ISSUE_TEMPLATE/feature_request.ja.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.ja.yml
@@ -1,0 +1,55 @@
+name: ✨ 機能要望
+description: 機能追加・改善の提案
+title: '[Feature]: '
+labels: ['enhancement']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        提案ありがとうございます！「何の課題を解決したいか → どうしたいか」を書いてもらえると助かります。
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 課題 / 背景
+      description: 解決したい課題・背景（なぜ必要か）
+      placeholder: '今は〜が難しい / 〜ができない、など'
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 提案する解決策
+      description: どういう挙動・API になってほしいか（例コード歓迎）
+      placeholder: |
+        例:
+        - xxx に ○○ オプションを追加したい
+        - xx の戻り値を ○○ にしたい
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 検討した代替案
+      description: 他の代替案（回避策）や既存ライブラリ比較があれば
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: 追加情報
+      description: 参考リンク、ユースケース、実装イメージなど
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ## 作業上の留意点
+
+        - 作業を実施する時は、Conventional Commits に準拠したブランチを作成して作業を開始してください
+        - 差分を Conventional Commits に準拠したコミットメッセージで、コミットしてください
+        - プッシュして `.github/pull_request_template.md` に沿った Conventional Commits に準拠したプルリクエストの概要とタイトルを作成してください


### PR DESCRIPTION
Closes #329

## 変更概要
chirimen-device-dashboard の .github/ISSUE_TEMPLATE を参考に、本リポジトリに以下を追加しました。

- `config.yml` … 空の Issue 無効化、Discussions / README への案内
- `bug_report.ja.yml` … バグ報告用テンプレート（日本語）
- `feature_request.ja.yml` … 機能要望用テンプレート（日本語）

## 主な調整
- リポジトリ名を chirimen-lite-console に合わせて URL・説明文を変更
- バグ報告の「対象アプリ」を `console (Angular)` / `Other` に変更（本リポジトリの構成に合わせて）