### PR TITLE
feat: add pull_request_template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,46 @@
+## Summary
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Chore (build/test/ci)
+- [ ] Breaking change
+
+## Related issues
+
+- Fixes #
+
+## What changed?
+
+-
+-
+
+## API / Compatibility
+
+- [ ] Public API changes (export / function signature / behavior)
+ - Details:
+- [ ] This change is backward compatible
+- [ ] This change introduces a breaking change
+ - Migration notes:
+
+## How to test
+
+1.
+2.
+3.
+
+## Environment (if relevant)
+
+- Browser:
+- OS: macOS / Windows / Linux
+- Node version:
+- pnpm version:
+
+## Checklist
+
+- [ ] I ran tests locally (if available)
+- [ ] I updated docs/README if needed
+- [ ] I considered error handling where relevant


### PR DESCRIPTION
## Summary
chirimen-device-dashboard と同様の PR テンプレートを `.github/pull_request_template.md` として追加しました。新規 PR 作成時に説明・変更種別・関連 Issue・テスト方法などの入力が促されます。

## Reference
- 参照: [chirimen-device-dashboard の pull_request_template](https://github.com/gurezo/chirimen-device-dashboard/blob/main/.github/pull_request_template.md)

Closes #331

Made with [Cursor](https://cursor.com)