### PR TITLE
chore(workspace): add nx ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'pnpm'
+
+      - uses: nrwl/nx-set-shas@v4
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run affected tasks
+        run: pnpm nx affected -t lint,build,test
+


### PR DESCRIPTION
## Summary

Nx / pnpm 用の GitHub Actions CI ワークフローを追加し、push / PR 時に影響範囲の lint / build / test が自動実行されるようにしました。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #367

## What changed?

-  を追加
- , ,  を利用した CI ジョブを定義
- 
 NX   Affected criteria defaulted to --base=main --head=HEAD



 NX   No tasks were run を実行するステップを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. このブランチをチェックアウトする
2. ローカルで 
 NX   Affected criteria defaulted to --base=main --head=HEAD



 NX   No tasks were run を実行する
3. GitHub 上でこのブランチに対する push / PR を作成し、CI が成功することを確認する

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version: 24.x
- pnpm version: 9.x

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)