### PR TITLE
feat(console): add console-shell feature/ui/util libs

### DIFF
--- a/libs/console-shell/feature/.eslintrc.json
+++ b/libs/console-shell/feature/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "lib",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "lib",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/console-shell/feature/project.json
+++ b/libs/console-shell/feature/project.json
@@ -1,0 +1,28 @@
+{
+  "name": "libs-console-shell-feature",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/console-shell/feature/src",
+  "prefix": "lib",
+  "projectType": "library",
+  "tags": ["type:feature", "domain:console-shell"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}"],
+      "options": {
+        "command": "echo \"build libs-console-shell-feature\""
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "command": "vitest run --config libs/console-shell/feature/vitest.config.ts",
+        "cwd": "{workspaceRoot}"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/libs/console-shell/feature/src/index.ts
+++ b/libs/console-shell/feature/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/console-shell/console-shell.component';

--- a/libs/console-shell/feature/src/lib/console-shell/console-shell.component.ts
+++ b/libs/console-shell/feature/src/lib/console-shell/console-shell.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'lib-console-shell',
+  standalone: true,
+  template: `
+    <div class="console-shell">
+      <p>Console shell (stub)</p>
+    </div>
+  `,
+})
+export class ConsoleShellComponent {}

--- a/libs/console-shell/feature/src/test-setup.ts
+++ b/libs/console-shell/feature/src/test-setup.ts
@@ -1,0 +1,5 @@
+import '@angular/compiler';
+import '@analogjs/vitest-angular/setup-snapshots';
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
+
+setupTestBed({ zoneless: false });

--- a/libs/console-shell/feature/tsconfig.json
+++ b/libs/console-shell/feature/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "preserve"
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/console-shell/feature/tsconfig.lib.json
+++ b/libs/console-shell/feature/tsconfig.lib.json
@@ -1,0 +1,26 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts",
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/test-setup.ts"
+  ]
+}

--- a/libs/console-shell/feature/tsconfig.spec.json
+++ b/libs/console-shell/feature/tsconfig.spec.json
@@ -1,0 +1,29 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ]
+  },
+  "include": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ],
+  "files": ["src/test-setup.ts"]
+}

--- a/libs/console-shell/feature/vitest.config.ts
+++ b/libs/console-shell/feature/vitest.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+import angular from '@analogjs/vite-plugin-angular';
+
+export default defineConfig({
+  plugins: [angular()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: [resolve(__dirname, './src/test-setup.ts')],
+    passWithNoTests: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      reportsDirectory: resolve(
+        __dirname,
+        '../../coverage/libs/console-shell/feature',
+      ),
+    },
+    include: [
+      resolve(
+        __dirname,
+        './src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+      ),
+    ],
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+  esbuild: {
+    target: 'node22',
+  },
+});
+

--- a/libs/console-shell/ui/.eslintrc.json
+++ b/libs/console-shell/ui/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "lib",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "lib",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/console-shell/ui/project.json
+++ b/libs/console-shell/ui/project.json
@@ -1,0 +1,19 @@
+{
+  "name": "libs-console-shell-ui",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/console-shell/ui/src",
+  "projectType": "library",
+  "tags": ["type:ui", "domain:console-shell"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}"],
+      "options": {
+        "command": "echo \"build libs-console-shell-ui\""
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/libs/console-shell/ui/src/index.ts
+++ b/libs/console-shell/ui/src/index.ts
@@ -1,0 +1,4 @@
+export * from './lib/header-toolbar/header-toolbar.component';
+export * from './lib/left-sidebar/left-sidebar.component';
+export * from './lib/right-sidebar/right-sidebar.component';
+export * from './lib/main-layout/main-layout.component';

--- a/libs/console-shell/ui/src/lib/header-toolbar/header-toolbar.component.ts
+++ b/libs/console-shell/ui/src/lib/header-toolbar/header-toolbar.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'lib-header-toolbar',
+  standalone: true,
+  template: `
+    <div class="header-toolbar">
+      <p>Header toolbar (stub)</p>
+    </div>
+  `,
+})
+export class HeaderToolbarComponent {}

--- a/libs/console-shell/ui/src/lib/left-sidebar/left-sidebar.component.ts
+++ b/libs/console-shell/ui/src/lib/left-sidebar/left-sidebar.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'lib-left-sidebar',
+  standalone: true,
+  template: `
+    <div class="left-sidebar">
+      <p>Left sidebar (stub)</p>
+    </div>
+  `,
+})
+export class LeftSidebarComponent {}

--- a/libs/console-shell/ui/src/lib/main-layout/main-layout.component.ts
+++ b/libs/console-shell/ui/src/lib/main-layout/main-layout.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'lib-main-layout',
+  standalone: true,
+  template: `
+    <div class="main-layout">
+      <p>Main layout (stub)</p>
+    </div>
+  `,
+})
+export class MainLayoutComponent {}

--- a/libs/console-shell/ui/src/lib/right-sidebar/right-sidebar.component.ts
+++ b/libs/console-shell/ui/src/lib/right-sidebar/right-sidebar.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'lib-right-sidebar',
+  standalone: true,
+  template: `
+    <div class="right-sidebar">
+      <p>Right sidebar (stub)</p>
+    </div>
+  `,
+})
+export class RightSidebarComponent {}

--- a/libs/console-shell/util/.eslintrc.json
+++ b/libs/console-shell/util/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": ["plugin:@nx/typescript"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/console-shell/util/project.json
+++ b/libs/console-shell/util/project.json
@@ -1,0 +1,19 @@
+{
+  "name": "libs-console-shell-util",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/console-shell/util/src",
+  "projectType": "library",
+  "tags": ["type:util", "domain:console-shell"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}"],
+      "options": {
+        "command": "echo \"build libs-console-shell-util\""
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/libs/console-shell/util/src/index.ts
+++ b/libs/console-shell/util/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/console-shell.util';

--- a/libs/console-shell/util/src/lib/console-shell.util.ts
+++ b/libs/console-shell/util/src/lib/console-shell.util.ts
@@ -1,0 +1,6 @@
+/**
+ * Console shell ドメイン共通ユーティリティ（スタブ）
+ */
+export function consoleShellUtil(): string {
+  return 'console-shell';
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -69,6 +69,15 @@
       ],
       "@chirimen-lite/connect/util": [
         "libs/connect/util/src/index.ts"
+      ],
+      "@chirimen-lite/console-shell/feature": [
+        "libs/console-shell/feature/src/index.ts"
+      ],
+      "@chirimen-lite/console-shell/ui": [
+        "libs/console-shell/ui/src/index.ts"
+      ],
+      "@chirimen-lite/console-shell/util": [
+        "libs/console-shell/util/src/index.ts"
       ]
     }
   }


### PR DESCRIPTION
## Summary

Add console-shell feature, ui, and util libraries as stubs to support future console layout migration.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #340

## What changed?

- Added console-shell feature library with a stub `ConsoleShell` component and Vitest setup.
- Added console-shell ui library with header-toolbar, left/right sidebars, and main-layout stub components.
- Added console-shell util library with a shared `consoleShellUtil` stub and updated TypeScript path aliases.

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test

1. Run `npx nx run libs-console-shell-feature:build`.
2. Run `npx nx run libs-console-shell-ui:build`.
3. Run `npx nx run libs-console-shell-util:build`.
4. Run `npx nx run-many --target=test --all` and ensure `libs-console-shell-feature:test` passes.

## Environment (if relevant)

- Browser: n/a
- OS: macOS
- Node version: 22.x
- pnpm version: 9.x

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)