### PR TITLE
refactor(console): organize routes and apply connection guard (#357)

### DIFF
--- a/apps/console/src/app/app.routes.ts
+++ b/apps/console/src/app/app.routes.ts
@@ -1,17 +1,17 @@
 import { Routes } from '@angular/router';
-import { browserCheckGuard, connectionGuard } from '@libs-console-guards';
+import { browserCheckGuard } from '@libs-console-guards';
 
 export const routes: Routes = [
   {
     path: '',
     loadComponent: () =>
       import('@libs-console-shell-feature').then((m) => m.ConsoleShellComponent),
-    canActivate: [browserCheckGuard, connectionGuard],
+    canActivate: [browserCheckGuard],
   },
   {
     path: 'unsupported-browser',
     loadComponent: () => import('@libs-unsupported-browser'),
-    canActivate: [browserCheckGuard, connectionGuard],
+    canActivate: [browserCheckGuard],
   },
   {
     path: '**',


### PR DESCRIPTION
## Summary

ルーティングを目標構成に整理し、接続必須ルートにのみ connection.guard を適用しました。`''` と `unsupported-browser` から connectionGuard を削除し、browserCheckGuard のみを適用しています。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #357

## What changed?

- `app.routes.ts`: ルート `''` と `unsupported-browser` から connectionGuard を削除
- 接続不要ルートには browserCheckGuard のみ適用（接続必須ルートが追加される際は connectionGuard を付与する想定）

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. 対応ブラウザで `/` にアクセスし、接続前・接続後の遷移が意図どおり動作することを確認する
2. 非対応ブラウザで `/` にアクセスし、`/unsupported-browser` へリダイレクトされることを確認する
3. 存在しないパスにアクセスし、404（page-not-found）が表示されることを確認する

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant
