### PR TITLE
chore(workspace): post-migration verification and documentation update

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,31 @@
+# アーキテクチャ概要
+
+本リポジトリは Nx モノレポです。メインアプリと機能別ライブラリで構成されています。
+
+## 構成
+
+- **apps/console** — CHIRIMEN Lite Console のメイン Angular アプリ。ルーティング・レイアウト・各機能画面を束ねる。
+- **libs/** — ドメインまたは横断 concern ごとのライブラリ。アプリから `@libs-*` で参照する。
+
+## 主な lib の役割
+
+| カテゴリ | lib | 役割 |
+|----------|-----|------|
+| 接続・シェル | connect, console-shell | デバイス接続 UI・シェルレイアウト |
+| 端末・編集 | terminal, editor | ターミナル表示・コードエディタ |
+| 機能 | example, wifi, setup, file-manager, pin-assign-panel, remote, i2cdetect | サンプル一覧・Wi‑Fi・セットアップ・ファイル操作・ピン割り当て・リモート・I2C 検出 |
+| 共通 | dialogs, shared-ui, shared-guards, shared-util, shared-types | ダイアログ・共有 UI コンポーネント・ガード・ユーティリティ・型 |
+| 基盤 | web-serial | Web Serial API のラップ・状態管理 |
+| その他 | page-not-found, unsupported-browser, chirimen-panel | 404・非対応ブラウザ表示・CHIRIMEN パネル |
+
+## 依存関係
+
+- アプリ (`apps/console`) は必要な lib を `tsconfig.base.json` の path エイリアス（`@libs-*`）でインポートする。
+- lib 間の依存は Nx の `project.json` の `dependsOn: ["^build"]` とビルド順で管理される。
+- 詳細な path 一覧は `tsconfig.base.json` の `compilerOptions.paths` を参照。
+
+## ビルド・テスト
+
+- 全プロジェクトのビルド: `pnpm nx run-many -t build`
+- 全プロジェクトのテスト: `pnpm nx run-many -t test`
+- CI では `nx affected -t lint,build,test` により変更影響範囲のみ実行。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,18 +26,26 @@
 |----------|------|
 | `console` | メインアプリ (apps/console) |
 | `workspace` | ルート・共通設定（package.json, nx, ツール設定など） |
+| `connect` | 接続 lib（feature / ui / util） |
+| `console-shell` | コンソールシェル lib（feature / ui / util） |
 | `page-not-found` | 404 ページ lib |
-| `web-serial` | Web Serial lib |
-| `example` | サンプル lib |
-| `wifi` | Wi‑Fi lib |
-| `dialogs` | ダイアログ lib |
+| `web-serial` | Web Serial lib（util / data-access / state） |
+| `example` | サンプル lib（util / data-access / ui / feature） |
+| `wifi` | Wi‑Fi lib（util / data-access / ui / feature） |
+| `dialogs` | ダイアログ lib（feature / ui / util） |
 | `unsupported-browser` | 非対応ブラウザ lib |
-| `editor` | エディタ lib |
-| `terminal` | ターミナル lib |
+| `editor` | エディタ lib（data-access / feature / ui / util） |
+| `terminal` | ターミナル lib（feature / ui / util） |
 | `chirimen-panel` | CHIRIMEN パネル lib |
+| `file-manager` | ファイルマネージャ lib（data-access / feature / ui / util） |
+| `i2cdetect` / `i2cdetect-ui` / `i2cdetect-data-access` / `i2cdetect-util` | I2C 検出 lib（ui / data-access / util に分割） |
+| `pin-assign-panel` | ピン割り当てパネル lib（feature / ui / util） |
+| `remote` | リモート lib（data-access / feature / ui / util） |
+| `setup` | セットアップ lib（data-access / feature / ui / util） |
 | `shared-ui` | 共有 UI lib |
 | `shared-guards` | 共有ガード lib |
-| `i2cdetect` / `i2cdetect-ui` / `i2cdetect-data-access` / `i2cdetect-util` | I2C 検出 lib（ui / data-access / util に分割） |
+| `shared-types` | 共有型定義 lib |
+| `shared-util` | 共有ユーティリティ lib |
 
 ### 例
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # CHIRIMEN Lite Console
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 20.x.
+This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 20.x. It uses [Nx](https://nx.dev) as the monorepo build system.
+
+## プロジェクト構成
+
+- **apps/console** — メインの Web アプリ（CHIRIMEN Lite 接続・ターミナル・エディタ・Wi‑Fi 設定など）
+- **libs/** — 機能別ライブラリ（connect, console-shell, dialogs, editor, example, file-manager, i2cdetect, pin-assign-panel, remote, setup, shared, terminal, web-serial, wifi など）。`tsconfig.base.json` の `paths` と [CONTRIBUTING.md](CONTRIBUTING.md) のスコープ一覧を参照してください。
 
 ## 📚 リファクタリング履歴
 
@@ -13,26 +18,49 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 詳細は各ステップの `README.md` を参照してください。
 
-## Development server
+## 開発サーバー
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The application will automatically reload if you change any of the source files.
+```bash
+pnpm start
+```
 
-## Code scaffolding
+または
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+```bash
+pnpm nx run console:serve
+```
 
-## Build
+ブラウザで `http://localhost:4200/` を開きます。ソース変更時に自動リロードされます。
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
+## ビルド
 
-## Running unit tests
+```bash
+pnpm build
+```
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+または
 
-## Running end-to-end tests
+```bash
+pnpm nx run-many -t build
+```
 
-Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.
+ビルド成果物は `dist/` に出力されます。
 
-## Further help
+## ユニットテスト
 
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+```bash
+pnpm test
+```
+
+または
+
+```bash
+pnpm nx run-many -t test
+```
+
+Vitest で全プロジェクトのユニットテストを実行します。
+
+## その他
+
+- コード生成や開発のルールは [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。
+- Angular CLI の詳細は [Angular CLI Overview](https://angular.dev/tools/cli) を参照してください。


### PR DESCRIPTION
## Summary

移行完了後の全体ビルド・テストの確認、console serve による主要フロー手動確認、および README / CONTRIBUTING / ARCHITECTURE の新 lib 構成反映。Fixes #361

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #361

## What changed?

- 全プロジェクトで `nx run-many -t build` / `nx run-many -t test` が通ることを確認（修正なしで既に成功）。
- README を Nx および現行 lib 構成に合わせて更新（開発サーバー・ビルド・テストのコマンド、プロジェクト構成の簡潔な説明）。
- CONTRIBUTING のスコープ一覧を `tsconfig.base.json` の lib と整合するよう拡張。
- ARCHITECTURE.md を新規追加（apps/console と libs の役割・依存関係の概要）。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx run-many -t build` でビルド成功を確認。
2. `pnpm nx run-many -t test` でテスト成功を確認。
3. `pnpm nx run console:serve`（または `pnpm start`）で起動し、接続・ターミナル・エディタ・WiFi・サンプル・ピン割り当て等の主要フローを手動確認。

## Environment (if relevant)

- Browser: （手動確認時）
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [ ] I considered error handling where relevant
