### PR TITLE
feat(console-shell): implement shell layout and state store

### DIFF
--- a/libs/console-shell/feature/src/lib/console-shell/console-shell.component.html
+++ b/libs/console-shell/feature/src/lib/console-shell/console-shell.component.html
@@ -1,7 +1,9 @@
 <lib-header-toolbar
   [connected$]="connected$"
+  [rightNavOpen]="rightNavOpen()"
   (eventConnect)="onConnect()"
   (eventDisConnect)="onDisConnect()"
+  (toggleRightSidebar)="onToggleRightSidebar()"
 />
 @if (connected$ | async; as connected) {
   <div class="grid grid-cols-[auto_1fr_auto] grid-rows-[auto_1fr] gap-2 h-screen">
@@ -14,7 +16,7 @@
     <div class="min-h-0 overflow-auto">
       @switch (activePanel()) {
         @case ('terminal') {
-          <choh-pin-assign />
+          <p>Terminal panel (stub)</p>
         }
         @case ('editor') {
           <p>Editor panel (stub)</p>

--- a/libs/console-shell/feature/src/lib/console-shell/console-shell.component.ts
+++ b/libs/console-shell/feature/src/lib/console-shell/console-shell.component.ts
@@ -4,8 +4,11 @@ import {
   ConnectButtonComponent,
   ConnectionStatusComponent,
 } from '@libs-connect-ui';
-import { HeaderToolbarComponent } from '@libs-console-shell-ui';
-import { PinAssignComponent } from '@libs-pin-assign-panel-ui';
+import {
+  HeaderToolbarComponent,
+  LeftSidebarComponent,
+  RightSidebarComponent,
+} from '@libs-console-shell-ui';
 import { SerialNotificationService } from '@libs-web-serial-data-access';
 import {
   selectConnectionMessage,
@@ -21,10 +24,11 @@ import { ConsoleShellStore } from './console-shell.store';
   selector: 'lib-console-shell',
   imports: [
     AsyncPipe,
-    PinAssignComponent,
     ConnectButtonComponent,
     ConnectionStatusComponent,
     HeaderToolbarComponent,
+    LeftSidebarComponent,
+    RightSidebarComponent,
   ],
   templateUrl: './console-shell.component.html',
 })
@@ -79,5 +83,9 @@ export class ConsoleShellComponent implements OnInit, OnDestroy {
 
   onDisConnect() {
     this.store.dispatch(WebSerialActions.onDisConnect());
+  }
+
+  onToggleRightSidebar() {
+    this.shellStore.toggleRightNav();
   }
 }

--- a/libs/console-shell/feature/src/lib/console-shell/console-shell.store.ts
+++ b/libs/console-shell/feature/src/lib/console-shell/console-shell.store.ts
@@ -19,7 +19,7 @@ export class ConsoleShellStore {
   private readonly stateSignal = signal<ConsoleShellState>({
     activePanel: 'terminal',
     leftNavOpen: true,
-    rightNavOpen: false,
+    rightNavOpen: true,
     isConnected: false,
   });
 

--- a/libs/console-shell/ui/src/lib/header-toolbar/header-toolbar.component.html
+++ b/libs/console-shell/ui/src/lib/header-toolbar/header-toolbar.component.html
@@ -7,10 +7,19 @@
         class="w-64 h-[67px] my-4 mr-4"
       />
     </div>
-    <div class="flex items-center">
+    <div class="flex items-center gap-2">
+      <button mat-icon-button (click)="toggleRightSidebar.emit()">
+        <mat-icon>
+          @if (rightNavOpen()) {
+            right_panel_close
+          } @else {
+            right_panel_open
+          }
+        </mat-icon>
+      </button>
       <mat-icon [matMenuTriggerFor]="menu">menu</mat-icon>
       <mat-menu #menu="matMenu">
-        @if (connected$ | async; as connected) {
+        @if (connected$() | async; as connected) {
           <button mat-menu-item (click)="eventDisConnect.emit()">
             <mat-icon>sync_disabled</mat-icon>
             <span>Web Serial DisConnect</span>

--- a/libs/console-shell/ui/src/lib/header-toolbar/header-toolbar.component.ts
+++ b/libs/console-shell/ui/src/lib/header-toolbar/header-toolbar.component.ts
@@ -15,4 +15,6 @@ export class HeaderToolbarComponent {
   connected$ = input<Observable<boolean>>(of(false));
   eventConnect = output<void>();
   eventDisConnect = output<void>();
+  rightNavOpen = input<boolean>(true);
+  toggleRightSidebar = output<void>();
 }

--- a/libs/console-shell/ui/src/lib/right-sidebar/right-sidebar.component.ts
+++ b/libs/console-shell/ui/src/lib/right-sidebar/right-sidebar.component.ts
@@ -1,11 +1,13 @@
 import { Component } from '@angular/core';
+import { PinAssignComponent } from '@libs-pin-assign-panel-ui';
 
 @Component({
   selector: 'lib-right-sidebar',
   standalone: true,
+  imports: [PinAssignComponent],
   template: `
-    <div class="right-sidebar">
-      <p>Right sidebar (stub)</p>
+    <div class="right-sidebar min-h-0 overflow-auto">
+      <choh-pin-assign />
     </div>
   `,
 })


### PR DESCRIPTION
## Summary

console-shell のシェルレイアウトと状態管理用の Signal Store を実装し、接続後のメイン UI を pane 切替・左右サイドバー・接続状態と一体で扱えるようにしました。

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #411

## What changed?

- `ConsoleShellStore`（Signal Store）を追加し、以下の state を一元管理
  - `activePanel: 'terminal' | 'editor' | 'example'`
  - `leftNavOpen: boolean`
  - `rightNavOpen: boolean`（初期値 `true`）
  - `isConnected: boolean`
- `ConsoleShellComponent` に `ConsoleShellStore` を注入し、接続状態（NgRx `webSerial.isConnected`）と `isConnected` を同期
- テンプレートを `@switch` / `@if` を用いたシェルレイアウトに刷新
  - 左サイドバー（`lib-left-sidebar`）と右サイドバー（`lib-right-sidebar`）の開閉を store 経由で制御
  - 中央ペインで `activePanel` に応じて terminal / editor / example ペインを表示（現在は stub）
- 右サイドバーに `PinAssignComponent` を集約し、`RightSidebarComponent` 内で `choh-pin-assign` を表示
- `HeaderToolbarComponent` を Signal ベースの `input()` / `output()` API に移行し、右パネル開閉トグルボタンを追加
  - `right_panel_open` / `right_panel_close` アイコンで右サイドバーの開閉状態を表示・操作

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

（console-shell の内部 UI 構成と state 管理の実装追加であり、既存の public API には影響しません）

## How to test

1. `pnpm install` が済んでいなければ実行する
2. `pnpm nx serve console` でローカル開発サーバーを起動する
3. ブラウザで `http://localhost:4200` を開く
4. Web Serial を接続する
   - ヘッダーのメニューから接続を実施
5. 接続後、以下を確認する
   - 右サイドバーがデフォルトで開いており、`choh-pin-assign`（ピンアサイン UI）が表示されている
   - ヘッダー右上のパネルアイコンをクリックすると、右サイドバーが開閉する
   - 左サイドバー／中央パネルのレイアウトが崩れず、`activePanel` に応じて中央ペインが切り替わる（現在は stub 表示）

## Environment (if relevant)

- Browser: Chrome 最新版
- OS: macOS
- Node version: （プロジェクト推奨バージョン）
- pnpm version: （プロジェクト推奨バージョン）

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant