### PR TITLE
feat(shared-ui): add left and right panel icons

### DIFF
--- a/libs/shared/ui/src/lib/services/icon.service.ts
+++ b/libs/shared/ui/src/lib/services/icon.service.ts
@@ -22,6 +22,10 @@ export class IconService {
     { name: 'file_open', path: '/file_open.png' },
     { name: 'schema', path: '/schema.png' },
     { name: 'segment', path: '/segment.png' },
+    { name: 'left_panel_open', path: '/left_panel_open.png' },
+    { name: 'left_panel_close', path: '/left_panel_close.png' },
+    { name: 'right_panel_open', path: '/right_panel_open.png' },
+    { name: 'right_panel_close', path: '/right_panel_close.png' },
   ] as const;
 
   registIcons() {


### PR DESCRIPTION
## Summary

左右パネルの開閉に利用するアイコンを登録するため、`IconService` の `ICONS` に新しいアイコン定義を追加しました。  
これにより、ヘッダツールバーなどから左右パネル用のアイコンを一貫した方法で利用できるようになります。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #426

## What changed?

- `libs/shared/ui/src/lib/services/icon.service.ts`
  - `ICONS` 配列に以下 4 つのアイコン定義を追加
    - `left_panel_open` → `/left_panel_open.png`
    - `left_panel_close` → `/left_panel_close.png`
    - `right_panel_open` → `/right_panel_open.png`
    - `right_panel_close` → `/right_panel_close.png`

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `npm install`（未実行の場合）を実行する。
2. `npm test -- --watch=false` を実行し、テストがすべて成功することを確認する。
3. （任意）`npm run start` または `nx serve console` でアプリを起動し、右パネル開閉ボタンのアイコンが正常に表示されることを確認する。

## Environment (if relevant)

- Browser: (例) Chrome 最新版
- OS: macOS
- Node version: （プロジェクト推奨バージョン）
- pnpm version: （利用している場合に記載）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant