### PR TITLE
docs(workspace): refine CONTRIBUTING commit message guidelines for Nx Release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,21 @@
 - **scope**: 変更対象のスコープ（下記一覧から指定）
 - **description**: 簡潔な説明（命令形・小文字始まり推奨）
 
+### ヘッダ / ボディ / フッタ
+
+Angular のコミットガイドラインに合わせ、コミットメッセージは「ヘッダ・ボディ・フッタ」で構成し、ヘッダとボディの間には空行を入れます。
+
+- ヘッダ（必須）: `<type>(<scope>): <description>`
+- ボディ（任意）: 変更の理由や背景（`docs` 型は省略可）
+- フッタ（任意）: `BREAKING CHANGE:` など、互換性やリリース生成に関する情報
+
+### 破壊的変更（BREAKING CHANGE）
+
+破壊的変更を含む場合は、次のいずれかで明示してください。
+
+- ヘッダに `!` を付ける: `<type>(<scope>)!: <description>`
+- footer に `BREAKING CHANGE: <summary>` を書く（その後に移行手順・詳細を記載）
+
 ### スコープ一覧
 
 | スコープ | 説明 |
@@ -52,6 +67,13 @@
 - `fix(terminal): prevent resize on reconnect`
 - `build(workspace): add commitlint and husky for Conventional Commits`
 - `docs(workspace): update CONTRIBUTING with scope list`
+
+### Nx Release（Conventional Commits による自動バージョン決定）
+
+Nx Release は、`nx.json` の `release.version.conventionalCommits` を `true` に設定した場合、最後のリリース以降の commit message を Conventional Commits として解釈し、バージョン bump を決めます。
+
+- `fix` -> `patch`
+- `feat` -> `minor`
 
 ## Git フック（husky）
 


### PR DESCRIPTION
## Summary
Nx Release（Conventional Commits）と Angular 運用に合わせ、CONTRIBUTING.md のコミットメッセージ指針と scope 一覧を更新しました。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #431

## What changed?
- `CONTRIBUTING.md` の scope 一覧を `commitlint.config.js` と整合
- `ヘッダ / ボディ / フッタ` と `BREAKING CHANGE` 記載方法を追記
- Nx Release の Conventional Commits による自動バージョン決定（`fix` -> `patch`、`feat` -> `minor`）を追記

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test
1. `CONTRIBUTING.md` の記載が `commitlint` が要求する形式（type/scope）と矛盾しないことを確認
2. 対応する Conventional Commits 形式で実際にコミットできることを確認
3. ドキュメント更新のため動作テストは不要

## Environment (if relevant)
- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist
- [ ] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [ ] I considered error handling where relevant