### PR TITLE
build(workspace): set minimumReleaseAge to 10080

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,7 @@ onlyBuiltDependencies:
   - lmdb
   - msgpackr-extract
   - nx
+
+# Malicious releases are often detected and removed within a week.
+# 7 days x 24h x 60 min
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

pnpm ワークスペース設定に `minimumReleaseAge: 10080` を追加し、新規公開直後のパッケージ取り込みリスクを低減します。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #464

## What changed?

- `pnpm-workspace.yaml` に `minimumReleaseAge: 10080` を追加
- 設定意図を補足するコメントを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm-workspace.yaml` に `minimumReleaseAge: 10080` が存在することを確認
2. `pnpm-workspace.yaml` の YAML 構文が崩れていないことを確認
3. 既存開発フローに影響がないことを確認

## Environment (if relevant)

- Browser: N/A
- OS: macOS
- Node version: N/A
- pnpm version: N/A

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)