### PR TITLE
fix(web-serial): show main shell immediately after serial connect

### DIFF
--- a/libs/web-serial/state/src/lib/web-serial.effects.ts
+++ b/libs/web-serial/state/src/lib/web-serial.effects.ts
@@ -62,13 +62,15 @@ export class WebSerialEffects {
                 })
               );
             }
-            return from(this.initializeAfterConnect()).pipe(
-              map(() =>
-                WebSerialActions.onConnectSuccess({
-                  isConnected: true,
-                  message: ERROR_MESSAGES.CONNECTION_SUCCESS,
-                })
-              )
+            // ポート確立直後に UI を接続済みへ（initializeAfterConnect はターミナル表示後に続行）
+            void this.initializeAfterConnect().catch((err) =>
+              console.warn('Post-connect initialization failed', err)
+            );
+            return of(
+              WebSerialActions.onConnectSuccess({
+                isConnected: true,
+                message: ERROR_MESSAGES.CONNECTION_SUCCESS,
+              })
             );
           }),
           catchError((error) => {


### PR DESCRIPTION
## Summary

Web Serial でポート接続が成功した直後に `onConnectSuccess` を dispatch し、メインシェル（ターミナル）へ即時遷移するようにしました。`initializeAfterConnect`（プロンプト待ち・TZ 設定）はバックグラウンドで続行し、オートログイン完了を待ってからでないと接続画面が切り替わらない問題を解消します。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #454

## What changed?

- `connect$` 内で `SerialFacadeService.connect()` が成功した直後に `WebSerialActions.onConnectSuccess` を返す
- `initializeAfterConnect()` は `void` で非同期起動し、未処理 reject を `console.warn` で捕捉

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `npx nx serve apps-console` を実行
2. `localhost:4200` を開き、Raspberry Pi Zero を USB 接続して Web Serial でポート接続
3. 接続操作直後にヘッダー付きメイン画面（ターミナル領域）が表示されること
4. オートログイン完了後もターミナルからコマンドが実行できること

## Environment (if relevant)

- Browser: Chrome（Web Serial 対応）
- OS: macOS
- Node version: 22.x
- pnpm version: （プロジェクトに合わせて記載）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)