### PR TITLE
feat(console-shell): toggle header toolbar row by Web Serial connection

### DIFF
--- a/libs/console-shell/feature/src/lib/console-shell/console-shell.component.html
+++ b/libs/console-shell/feature/src/lib/console-shell/console-shell.component.html
@@ -1,17 +1,21 @@
 @let connected = connected$ | async;
 
 <div class="flex h-[100dvh] min-h-0 flex-col overflow-hidden">
-  @if (connected) {
-    <div class="shrink-0 border-b border-gray-200">
-      <lib-header-toolbar
-        [connected$]="connected$"
-        (eventConnect)="onConnect()"
-        (eventDisConnect)="onDisConnect()"
-        (toolbarAction)="onToolbarAction($event)"
-      />
+  <div
+    class="shrink-0"
+    [class.border-b]="connected"
+    [class.border-gray-200]="connected"
+  >
+    <lib-header-toolbar
+      [connected$]="connected$"
+      (eventConnect)="onConnect()"
+      (eventDisConnect)="onDisConnect()"
+      (toolbarAction)="onToolbarAction($event)"
+    />
+    @if (connected) {
       <lib-breadcrumb [segments]="breadcrumbSegments()" />
-    </div>
-  }
+    }
+  </div>
   <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
     @if (connected) {
       <div

--- a/libs/console-shell/feature/src/lib/console-shell/console-shell.component.spec.ts
+++ b/libs/console-shell/feature/src/lib/console-shell/console-shell.component.spec.ts
@@ -297,7 +297,7 @@ describe('ConsoleShellComponent layout DOM (connected vs disconnected)', () => {
     const root = fixture.nativeElement as HTMLElement;
 
     expect(root.querySelector('lib-connect-page')).toBeTruthy();
-    expect(fixture.debugElement.query(By.css('lib-header-toolbar'))).toBeNull();
+    expect(fixture.debugElement.query(By.css('lib-header-toolbar'))).toBeTruthy();
     expect(root.querySelector('lib-breadcrumb')).toBeNull();
     expect(root.querySelector('lib-left-sidebar')).toBeNull();
     expect(root.querySelector('choh-terminal')).toBeNull();


### PR DESCRIPTION
## Summary

CHIRIMEN バナーは常に表示し、ヘッダー下部のツールバー行（アイコンボタン・メニュー・Disconnect）は Web Serial 接続後にのみ表示する。コンソールシェルでは `lib-header-toolbar` を常にマウントし、breadcrumb とメインコンテンツは従来どおり接続後のみ表示する。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #477

## What changed?

- `header-toolbar`: バナー領域は常時表示。ツールバー行を `connected$` に応じて表示／非表示にし、接続時はメニューを Disconnect のみに整理した。
- `console-shell`: ヘッダーシェルを未接続時もマウントするよう戻し、breadcrumb は接続時のみのままとした。
- 上記に合わせて `libs-console-shell-ui` / `libs-console-shell-feature` のユニットテストを更新した。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. 未接続: バナーのみ表示され、ツールバー行（アイコン・メニュー）が出ないこと。
2. Connect ページから接続成功後: ツールバー行と breadcrumb・メイン UI が表示されること。
3. `pnpm exec nx test libs-console-shell-ui` と `pnpm exec nx test libs-console-shell-feature` が通ること。

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant