### PR TITLE
feat(pin-assign-panel): add padding around pin assign image

### DIFF
--- a/libs/pin-assign-panel/ui/src/lib/pin-assign/pin-assign.component.html
+++ b/libs/pin-assign-panel/ui/src/lib/pin-assign/pin-assign.component.html
@@ -1,5 +1,5 @@
 <div
-  class="flex min-h-0 w-full min-w-0 flex-1 flex-col items-stretch overflow-y-auto overflow-x-hidden"
+  class="flex min-h-0 w-full min-w-0 flex-1 flex-col items-stretch overflow-y-auto overflow-x-hidden p-2"
 >
   <img
     ngSrc="wallpaperS.png"


### PR DESCRIPTION
## Summary

Add padding around the pin assign panel content so the `wallpaperS` image has 8px inset on all sides (Tailwind `p-2`), matching the 4–8px spacing requested in #496.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #496

## What changed?

- Added `p-2` to the scroll container in `pin-assign.component.html` so the pin assign image has consistent top/bottom/left/right spacing without conflicting with `mx-auto` on the `img`.

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. Run the console app and open the right panel.
2. Confirm visible padding around the pin assign diagram.
3. Resize the viewport and confirm `max-w-full` / `object-contain` still behave as before.

## Environment (if relevant)

- Browser: (your browser)
- OS: macOS / Windows / Linux
- Node version: (`node -v`)
- pnpm version: (`pnpm -v`)

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [ ] I considered error handling where relevant