### PR TITLE
feat: Pi Zero 接続後にタイムゾーン設定状況をターミナルに表示

### DIFF
--- a/libs/connect/util/src/lib/connect.util.ts
+++ b/libs/connect/util/src/lib/connect.util.ts
@@ -21,7 +21,7 @@ export interface ConnectClient {
   prompt: string;
   /**
    * 接続直後のタイムゾーン初期化（各ステップの説明とコマンド）
-   * sudo がパスワードを要求する場合でも後続へ進めるよう set-timezone は `|| true`
+   * `sudo -n` で対話的パスワード待ちを避け、失敗時も `|| true` で後続へ進める
    */
   timezoneSteps: PostConnectTimezoneStep[];
 }
@@ -33,7 +33,8 @@ export function createConnectClient(): ConnectClient {
       {
         statusMessage:
           '[コンソール] タイムゾーンを Asia/Tokyo に設定しています...',
-        command: 'sudo timedatectl set-timezone Asia/Tokyo || true',
+        command:
+          'sudo -n timedatectl set-timezone Asia/Tokyo 2>/dev/null || true',
       },
       {
         statusMessage: '[コンソール] タイムゾーンの状態を表示します。',

--- a/libs/connect/util/src/lib/connect.util.ts
+++ b/libs/connect/util/src/lib/connect.util.ts
@@ -5,6 +5,14 @@ export function ensureSerialSupport(): boolean {
   return 'serial' in navigator;
 }
 
+export interface PostConnectTimezoneStep {
+  /**
+   * コマンド実行直前にターミナルへ出す説明文（機微情報を含めない）
+   */
+  statusMessage: string;
+  command: string;
+}
+
 export interface ConnectClient {
   /**
    * 期待するシェルプロンプト（Raspberry Pi Zero 前提）
@@ -12,15 +20,26 @@ export interface ConnectClient {
    */
   prompt: string;
   /**
-   * 初期化（TZ 設定など）で実行するコマンド列
+   * 接続直後のタイムゾーン初期化（各ステップの説明とコマンド）
+   * sudo がパスワードを要求する場合でも後続へ進めるよう set-timezone は `|| true`
    */
-  timezoneCommands: string[];
+  timezoneSteps: PostConnectTimezoneStep[];
 }
 
 export function createConnectClient(): ConnectClient {
   return {
     prompt: PI_ZERO_PROMPT,
-    timezoneCommands: ['sudo timedatectl set-timezone Asia/Tokyo'],
+    timezoneSteps: [
+      {
+        statusMessage:
+          '[コンソール] タイムゾーンを Asia/Tokyo に設定しています...',
+        command: 'sudo timedatectl set-timezone Asia/Tokyo || true',
+      },
+      {
+        statusMessage: '[コンソール] タイムゾーンの状態を表示します。',
+        command: 'timedatectl status',
+      },
+    ],
   };
 }
 

--- a/libs/web-serial/data-access/project.json
+++ b/libs/web-serial/data-access/project.json
@@ -4,7 +4,7 @@
   "sourceRoot": "libs/web-serial/data-access/src",
   "projectType": "library",
   "tags": ["type:data-access", "domain:web-serial"],
-  "implicitDependencies": ["libs-web-serial-util"],
+  "implicitDependencies": ["libs-web-serial-util", "libs-terminal-util"],
   "targets": {
     "build": {
       "executor": "nx:run-commands",

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
@@ -7,6 +7,9 @@ import {
 import { PiZeroSerialBootstrapService } from './pi-zero-serial-bootstrap.service';
 import type { SerialFacadeService } from './serial-facade.service';
 
+const TZ_SET_CMD = 'sudo timedatectl set-timezone Asia/Tokyo || true';
+const TZ_STATUS_CMD = 'timedatectl status';
+
 describe('PiZeroSerialBootstrapService', () => {
   it('skips login when shell prompt is already visible', async () => {
     const readUntilPrompt = vi.fn().mockResolvedValue({
@@ -25,8 +28,16 @@ describe('PiZeroSerialBootstrapService', () => {
 
     expect(readUntilPrompt).toHaveBeenCalledTimes(1);
     expect(readUntilPrompt).toHaveBeenCalledWith(PI_ZERO_PROMPT, 5000, 0);
-    expect(exec).toHaveBeenCalledWith(
-      'sudo timedatectl set-timezone Asia/Tokyo',
+    expect(exec).toHaveBeenNthCalledWith(
+      1,
+      TZ_SET_CMD,
+      PI_ZERO_PROMPT,
+      10000,
+      0,
+    );
+    expect(exec).toHaveBeenNthCalledWith(
+      2,
+      TZ_STATUS_CMD,
       PI_ZERO_PROMPT,
       10000,
       0,
@@ -66,8 +77,16 @@ describe('PiZeroSerialBootstrapService', () => {
       0,
     );
     expect(lines.some((l) => l.includes('ログインユーザー'))).toBe(true);
-    expect(exec).toHaveBeenCalledWith(
-      'sudo timedatectl set-timezone Asia/Tokyo',
+    expect(exec).toHaveBeenNthCalledWith(
+      3,
+      TZ_SET_CMD,
+      PI_ZERO_PROMPT,
+      10000,
+      0,
+    );
+    expect(exec).toHaveBeenNthCalledWith(
+      4,
+      TZ_STATUS_CMD,
       PI_ZERO_PROMPT,
       10000,
       0,
@@ -90,5 +109,31 @@ describe('PiZeroSerialBootstrapService', () => {
     await service.runAfterConnect();
 
     expect(readUntilPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs timezone status stdout lines to the status handler', async () => {
+    const readUntilPrompt = vi.fn().mockResolvedValue({
+      stdout: `ready\r\n${PI_ZERO_PROMPT} `,
+    });
+    const exec = vi
+      .fn()
+      .mockResolvedValueOnce({ stdout: '' })
+      .mockResolvedValueOnce({
+        stdout: `${TZ_STATUS_CMD}\r\n       Time zone: Asia/Tokyo (${PI_ZERO_PROMPT} `,
+      });
+    const serial = {
+      isConnected: () => true,
+      getConnectionEpoch: () => 1,
+      readUntilPrompt,
+      exec,
+    } as unknown as SerialFacadeService;
+
+    const lines: string[] = [];
+    const service = new PiZeroSerialBootstrapService(serial);
+    await service.runAfterConnect((line) => lines.push(line));
+
+    expect(
+      lines.some((l) => l.includes('Time zone: Asia/Tokyo')),
+    ).toBe(true);
   });
 });

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
@@ -3,11 +3,13 @@ import {
   PI_ZERO_LOGIN_PASSWORD,
   PI_ZERO_LOGIN_USER,
   PI_ZERO_PROMPT,
+  PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
 } from '@libs-web-serial-util';
 import { PiZeroSerialBootstrapService } from './pi-zero-serial-bootstrap.service';
 import type { SerialFacadeService } from './serial-facade.service';
 
-const TZ_SET_CMD = 'sudo timedatectl set-timezone Asia/Tokyo || true';
+const TZ_SET_CMD =
+  'sudo -n timedatectl set-timezone Asia/Tokyo 2>/dev/null || true';
 const TZ_STATUS_CMD = 'timedatectl status';
 
 describe('PiZeroSerialBootstrapService', () => {
@@ -27,18 +29,22 @@ describe('PiZeroSerialBootstrapService', () => {
     await service.runAfterConnect();
 
     expect(readUntilPrompt).toHaveBeenCalledTimes(1);
-    expect(readUntilPrompt).toHaveBeenCalledWith(PI_ZERO_PROMPT, 5000, 0);
+    expect(readUntilPrompt).toHaveBeenCalledWith(
+      PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+      5000,
+      0,
+    );
     expect(exec).toHaveBeenNthCalledWith(
       1,
       TZ_SET_CMD,
-      PI_ZERO_PROMPT,
+      PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
       10000,
       0,
     );
     expect(exec).toHaveBeenNthCalledWith(
       2,
       TZ_STATUS_CMD,
-      PI_ZERO_PROMPT,
+      PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
       10000,
       0,
     );
@@ -72,7 +78,7 @@ describe('PiZeroSerialBootstrapService', () => {
     expect(exec).toHaveBeenNthCalledWith(
       2,
       PI_ZERO_LOGIN_PASSWORD,
-      PI_ZERO_PROMPT,
+      PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
       30000,
       0,
     );
@@ -80,14 +86,14 @@ describe('PiZeroSerialBootstrapService', () => {
     expect(exec).toHaveBeenNthCalledWith(
       3,
       TZ_SET_CMD,
-      PI_ZERO_PROMPT,
+      PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
       10000,
       0,
     );
     expect(exec).toHaveBeenNthCalledWith(
       4,
       TZ_STATUS_CMD,
-      PI_ZERO_PROMPT,
+      PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
       10000,
       0,
     );

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { createConnectClient } from '@libs-connect-util';
+import { sanitizeSerialStdout } from '@libs-terminal-util';
 import {
   PI_ZERO_LOGIN_PASSWORD,
   PI_ZERO_LOGIN_USER,
@@ -83,12 +84,33 @@ export class PiZeroSerialBootstrapService {
       log('[コンソール] ログインが完了しました。');
     }
 
-    for (const cmd of client.timezoneCommands) {
+    log('[コンソール] タイムゾーン関連の初期化を開始します。');
+    for (const step of client.timezoneSteps) {
+      log(step.statusMessage);
       try {
-        await this.serial.exec(cmd, client.prompt, 10000, 0);
-      } catch (error) {
-        console.warn(`Initial command failed: ${cmd}`, error);
+        const { stdout } = await this.serial.exec(
+          step.command,
+          client.prompt,
+          10000,
+          0,
+        );
+        const cleaned = sanitizeSerialStdout(
+          stdout,
+          step.command,
+          client.prompt,
+        );
+        for (const line of cleaned.split(/\r?\n/)) {
+          if (line.length > 0) {
+            log(line);
+          }
+        }
+      } catch (error: unknown) {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        log(`[コンソール] コマンドが失敗しました: ${message}`);
+        console.warn(`Initial command failed: ${step.command}`, error);
       }
     }
+    log('[コンソール] タイムゾーン関連の初期化が完了しました。');
   }
 }

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
@@ -6,6 +6,7 @@ import {
   PI_ZERO_LOGIN_USER,
   PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
   PI_ZERO_SERIAL_PASSWORD_LINE_PATTERN,
+  PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
 } from '@libs-web-serial-util';
 import { SerialFacadeService } from './serial-facade.service';
 
@@ -52,7 +53,11 @@ export class PiZeroSerialBootstrapService {
 
     let atShell = false;
     try {
-      await this.serial.readUntilPrompt(client.prompt, 5000, 0);
+      await this.serial.readUntilPrompt(
+        PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+        5000,
+        0,
+      );
       atShell = true;
     } catch {
       atShell = false;
@@ -77,7 +82,7 @@ export class PiZeroSerialBootstrapService {
       log('[コンソール] パスワードを送信中（画面には表示しません）...');
       await this.serial.exec(
         PI_ZERO_LOGIN_PASSWORD,
-        client.prompt,
+        PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
         30000,
         0,
       );
@@ -90,12 +95,12 @@ export class PiZeroSerialBootstrapService {
       try {
         const { stdout } = await this.serial.exec(
           step.command,
-          client.prompt,
+          PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
           10000,
           0,
         );
         const cleaned = sanitizeSerialStdout(
-          stdout,
+          typeof stdout === 'string' ? stdout : '',
           step.command,
           client.prompt,
         );

--- a/libs/web-serial/data-access/vitest.config.ts
+++ b/libs/web-serial/data-access/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@libs-connect-util': resolve(__dirname, '../../connect/util/src/index.ts'),
+      '@libs-terminal-util': resolve(__dirname, '../../terminal/util/src/index.ts'),
       '@libs-web-serial-util': resolve(__dirname, '../util/src/index.ts'),
     },
   },

--- a/libs/web-serial/util/src/lib/pi-zero-prompt.const.ts
+++ b/libs/web-serial/util/src/lib/pi-zero-prompt.const.ts
@@ -1,2 +1,8 @@
 export const PI_ZERO_PROMPT = 'pi@raspberrypi:' as const;
 
+/**
+ * シリアルコンソールの pi ユーザーシェルプロンプト先頭（`pi@<hostname>:`）。
+ * 固定文字列 {@link PI_ZERO_PROMPT} だけでは Chirimen 等でホスト名が異なりログイン完了を検出できない。
+ */
+export const PI_ZERO_SHELL_PROMPT_LINE_PATTERN = /pi@[^:\r\n]+:/;
+


### PR DESCRIPTION
## Summary

Web Serial 接続後の Pi Zero ブートストラップで、タイムゾーン設定の各ステップの説明と `timedatectl status` の出力をターミナル（xterm）に表示するようにしました。sudo で set-timezone が失敗しても後続の状態表示へ進めるよう `|| true` を付与しています。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #500

## What changed?

- `ConnectClient` の `timezoneCommands` を、説明文付きの `timezoneSteps` に変更。設定コマンドに `|| true` を追加し、続けて `timedatectl status` を実行。
- `PiZeroSerialBootstrapService` で各ステップの `statusMessage` とコマンド出力（`sanitizeSerialStdout` 適用）を `onStatus` 経由でターミナルへ出力。
- `libs-web-serial-data-access` が `@libs-terminal-util` に依存（implicitDependencies / vitest alias）。

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details: `ConnectClient` のフィールドを `timezoneCommands` から `timezoneSteps` に変更（利用は `createConnectClient` / ブートストラップのみ）。
- [x] This change is backward compatible（外部から `ConnectClient` を直接拡張している利用は想定なし）
- [ ] This change introduces a breaking change

## How to test

1. Pi Zero を Web Serial で接続する。
2. ターミナルパネルで、ログイン後に「タイムゾーン関連の初期化」メッセージ、`timedatectl status` に相当する出力が表示されることを確認する。
3. `pnpm exec vitest run --config libs/web-serial/data-access/vitest.config.ts`

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant
