### PR TITLE
feat(terminal): ターミナルページの黒背景と余白の調整

### DIFF
--- a/libs/terminal/feature/src/lib/terminal-page/terminal-page.component.ts
+++ b/libs/terminal/feature/src/lib/terminal-page/terminal-page.component.ts
@@ -6,7 +6,9 @@ import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
   selector: 'choh-terminal',
   imports: [TerminalViewComponent],
   template: `
-    <div class="h-full min-h-0 min-w-0">
+    <div
+      class="box-border h-full min-h-0 min-w-0 bg-black pt-1 pr-1 pb-1 pl-1"
+    >
       <choh-terminal-view [remotePrompt]="remotePrompt" />
     </div>
   `,


### PR DESCRIPTION
## Summary

`/terminal` のレイアウトを整理し、ターミナル周りに黒い背景と四辺それぞれの余白（Tailwind `pt-1` / `pr-1` / `pb-1` / `pl-1`）を付与する。余白は `terminal-page` のラッパーで持ち、`choh-terminal-view` ホスト側の padding は削除して二重にならないようにした。

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #513

## What changed?

- `TerminalPageComponent` のラッパーに `bg-black`、`box-border`、四辺個別の `pt-1 pr-1 pb-1 pl-1` を追加した。
- `TerminalViewComponent` のホストから `pt-1 pl-1` を外し、余白はページ側に集約した。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. 開発サーバを起動し `http://localhost:4200/terminal` を開く。
2. ターミナル領域の外周に黒背景と約 4px の余白が付いていることを確認する。
3. シリアル接続・コマンド入力など、ターミナルの既存動作に問題がないことを確認する。

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [ ] I considered error handling where relevant