### PR TITLE
feat(file-manager): ファイルツリーのアイコンを Material シンボルに変更

### DIFF
--- a/libs/file-manager/ui/src/lib/file-tree/file-tree.component.ts
+++ b/libs/file-manager/ui/src/lib/file-tree/file-tree.component.ts
@@ -19,7 +19,7 @@ import { FileTreeNode } from '@libs-file-manager-util';
                 (click)="onSelect(node)"
               >
                 @if (node.isDirectory) {
-                  <mat-icon aria-hidden="true" class="shrink-0">folder</mat-icon>
+                  <mat-icon aria-hidden="true" class="shrink-0 text-amber-500">folder</mat-icon>
                   <span>{{ node.name }}</span>
                 } @else {
                   <mat-icon aria-hidden="true" class="shrink-0">article</mat-icon>


### PR DESCRIPTION
## Summary

ファイルツリーで表示していたフォルダ・ファイルの絵文字を、Material Symbols Outlined の `folder` と `article` に差し替えました。フォルダアイコンには視認性のためアンバー系（`text-amber-500`）の色を適用しています。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #515

## What changed?

- `libs/file-manager/ui/src/lib/file-tree/file-tree.component.ts` に `MatIcon` を取り込み、テンプレートで `folder` / `article` を表示
- ボタン内を `inline-flex items-center gap-1` で整列
- フォルダ用 `mat-icon` に `text-amber-500` を付与
- アプリ全体の `MAT_ICON_DEFAULT_OPTIONS`（`material-symbols-outlined`）をそのまま利用

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. コンソールアプリを起動し、デバイスにシリアル接続する
2. 左サイドバーのファイルツリーを表示する
3. ディレクトリ行に `folder` アイコン（アンバー色）が、ファイル行に `article` アイコンが表示されることを確認する

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)