### PR TITLE
refactor(web-serial): シリアル通信の実装改善（#520）

### DIFF
--- a/libs/chirimen-setup/data-access/src/lib/extra-setup.service.ts
+++ b/libs/chirimen-setup/data-access/src/lib/extra-setup.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
 
 export interface ExtraSetupStep {
   label: string;
@@ -30,12 +30,10 @@ export class ExtraSetupService {
   ): Promise<void> {
     for (const step of EXTRA_SETUP_STEPS) {
       try {
-        const { stdout } = await this.serial.exec(
-          step.command,
-          this.prompt,
-          60000,
-          0,
-        );
+        const { stdout } = await this.serial.exec(step.command, {
+          prompt: this.prompt,
+          timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
+        });
         onAfterStep?.(step, stdout);
       } catch {
         onAfterStep?.(step, '');

--- a/libs/chirimen-setup/data-access/src/lib/node-install.service.ts
+++ b/libs/chirimen-setup/data-access/src/lib/node-install.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
 import {
   buildNodeInstallStepList,
   type NodeInstallOptions,
@@ -28,12 +28,10 @@ export class NodeInstallService {
   ): Promise<void> {
     const steps = this.buildInstallSteps(options);
     for (const step of steps) {
-      const { stdout } = await this.serial.exec(
-        step.command,
-        this.prompt,
-        300000,
-        0,
-      );
+      const { stdout } = await this.serial.exec(step.command, {
+        prompt: this.prompt,
+        timeout: SERIAL_TIMEOUT.NODE_INSTALL,
+      });
       onAfterStep?.(step, stdout);
     }
   }

--- a/libs/chirimen-setup/data-access/src/lib/setup-command.service.ts
+++ b/libs/chirimen-setup/data-access/src/lib/setup-command.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
 import {
   EXTRA_SETUP_STEPS,
   ExtraSetupService,
@@ -77,12 +77,10 @@ export class SetupCommandService {
     });
 
     try {
-      const { stdout } = await this.serial.exec(
-        postStep.command,
-        this.prompt,
-        60000,
-        0,
-      );
+      const { stdout } = await this.serial.exec(postStep.command, {
+        prompt: this.prompt,
+        timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
+      });
       emit('post', postStep.label, postStep.command, stdout);
     } catch {
       emit('post', postStep.label, postStep.command, '');

--- a/libs/file-manager/data-access/src/lib/file.service.spec.ts
+++ b/libs/file-manager/data-access/src/lib/file.service.spec.ts
@@ -2,7 +2,7 @@ import '@angular/compiler';
 import { Injector } from '@angular/core';
 import { FileContentService } from '@libs-wifi-data-access';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
 import { FileUtils } from '@libs-wifi-util';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FileService } from './file.service';
@@ -45,8 +45,10 @@ describe('FileService', () => {
       await svc.listLines('');
       expect(exec).toHaveBeenCalledWith(
         `ls -al --quoting-style=c -- ${FileUtils.escapePath('.')}`,
-        PI_ZERO_PROMPT,
-        30000,
+        {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.LONG,
+        },
       );
     });
 
@@ -55,8 +57,10 @@ describe('FileService', () => {
       await svc.listLines('./my dir');
       expect(exec).toHaveBeenCalledWith(
         `ls -al --quoting-style=c -- ${FileUtils.escapePath('./my dir')}`,
-        PI_ZERO_PROMPT,
-        30000,
+        {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.LONG,
+        },
       );
     });
   });
@@ -82,8 +86,10 @@ describe('FileService', () => {
       await svc.mkdir('/tmp/a');
       expect(exec).toHaveBeenCalledWith(
         `mkdir -p -- ${FileUtils.escapePath('/tmp/a')}`,
-        PI_ZERO_PROMPT,
-        10000,
+        {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.DEFAULT,
+        },
       );
     });
   });
@@ -93,8 +99,10 @@ describe('FileService', () => {
       await svc.touch('./file.txt');
       expect(exec).toHaveBeenCalledWith(
         `touch -- ${FileUtils.escapePath('./file.txt')}`,
-        PI_ZERO_PROMPT,
-        10000,
+        {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.DEFAULT,
+        },
       );
     });
   });
@@ -104,8 +112,10 @@ describe('FileService', () => {
       await svc.remove('./old.txt');
       expect(exec).toHaveBeenCalledWith(
         `rm -- ${FileUtils.escapePath('./old.txt')}`,
-        PI_ZERO_PROMPT,
-        10000,
+        {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.DEFAULT,
+        },
       );
     });
   });
@@ -152,8 +162,10 @@ describe('FileService', () => {
       await svc.move('./a', './b');
       expect(exec).toHaveBeenCalledWith(
         `mv -- ${FileUtils.escapePath('./a')} ${FileUtils.escapePath('./b')}`,
-        PI_ZERO_PROMPT,
-        10000,
+        {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.DEFAULT,
+        },
       );
     });
   });

--- a/libs/file-manager/data-access/src/lib/file.service.ts
+++ b/libs/file-manager/data-access/src/lib/file.service.ts
@@ -2,7 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { FileContentService } from '@libs-wifi-data-access';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { FileUtils } from '@libs-wifi-util';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
 import { FileTreeNode, parseLsOutput } from '@libs-file-manager-util';
 
 @Injectable({ providedIn: 'root' })
@@ -18,11 +18,10 @@ export class FileService {
     const escaped = FileUtils.escapePath(dir);
 
     const stdout = (
-      await this.serial.exec(
-        `ls -al --quoting-style=c -- ${escaped}`,
-        PI_ZERO_PROMPT,
-        30000,
-      )
+      await this.serial.exec(`ls -al --quoting-style=c -- ${escaped}`, {
+        prompt: PI_ZERO_PROMPT,
+        timeout: SERIAL_TIMEOUT.LONG,
+      })
     ).stdout;
 
     return stdout
@@ -41,17 +40,26 @@ export class FileService {
 
   async mkdir(path: string): Promise<void> {
     const escaped = FileUtils.escapePath(path);
-    await this.serial.exec(`mkdir -p -- ${escaped}`, PI_ZERO_PROMPT, 10000);
+    await this.serial.exec(`mkdir -p -- ${escaped}`, {
+      prompt: PI_ZERO_PROMPT,
+      timeout: SERIAL_TIMEOUT.DEFAULT,
+    });
   }
 
   async touch(path: string): Promise<void> {
     const escaped = FileUtils.escapePath(path);
-    await this.serial.exec(`touch -- ${escaped}`, PI_ZERO_PROMPT, 10000);
+    await this.serial.exec(`touch -- ${escaped}`, {
+      prompt: PI_ZERO_PROMPT,
+      timeout: SERIAL_TIMEOUT.DEFAULT,
+    });
   }
 
   async remove(path: string): Promise<void> {
     const escaped = FileUtils.escapePath(path);
-    await this.serial.exec(`rm -- ${escaped}`, PI_ZERO_PROMPT, 10000);
+    await this.serial.exec(`rm -- ${escaped}`, {
+      prompt: PI_ZERO_PROMPT,
+      timeout: SERIAL_TIMEOUT.DEFAULT,
+    });
   }
 
   async read(path: string): Promise<string> {
@@ -65,11 +73,10 @@ export class FileService {
   async move(fromPath: string, toPath: string): Promise<void> {
     const fromEscaped = FileUtils.escapePath(fromPath);
     const toEscaped = FileUtils.escapePath(toPath);
-    await this.serial.exec(
-      `mv -- ${fromEscaped} ${toEscaped}`,
-      PI_ZERO_PROMPT,
-      10000,
-    );
+    await this.serial.exec(`mv -- ${fromEscaped} ${toEscaped}`, {
+      prompt: PI_ZERO_PROMPT,
+      timeout: SERIAL_TIMEOUT.DEFAULT,
+    });
   }
 
   /**

--- a/libs/i2cdetect/data-access/src/lib/i2cdetect.service.ts
+++ b/libs/i2cdetect/data-access/src/lib/i2cdetect.service.ts
@@ -1,7 +1,11 @@
 import { Injectable, inject } from '@angular/core';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { formatI2cdetectResult } from '@libs-i2cdetect-util';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import {
+  PI_ZERO_PROMPT,
+  SERIAL_TIMEOUT,
+  wrapSerialError,
+} from '@libs-web-serial-util';
 
 /**
  * I2C デバイス検出サービス
@@ -23,14 +27,15 @@ export class I2cdetectService {
   async detectI2cDevices(): Promise<string> {
     try {
       const output = (
-        await this.serial.exec('i2cdetect -y 1', PI_ZERO_PROMPT, 10000)
+        await this.serial.exec('i2cdetect -y 1', {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.DEFAULT,
+        })
       ).stdout;
 
       return formatI2cdetectResult(output);
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Failed to detect I2C devices: ${errorMessage}`);
+      throw wrapSerialError('Failed to detect I2C devices', error);
     }
   }
 

--- a/libs/remote/data-access/src/lib/remote-run.service.ts
+++ b/libs/remote/data-access/src/lib/remote-run.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
 
 @Injectable({ providedIn: 'root' })
 export class RemoteRunService {
@@ -15,12 +15,9 @@ export class RemoteRunService {
   async start(scriptPath: string, args: string[] = []): Promise<void> {
     const argsPart = args.length ? ` ${args.map((a) => JSON.stringify(a)).join(' ')}` : '';
     // -w は start の待ち合わせ（環境依存のため長めの timeout）
-    await this.serial.exec(
-      `forever start -w ${scriptPath}${argsPart}`,
-      this.prompt,
-      120000,
-      0
-    );
+    await this.serial.exec(`forever start -w ${scriptPath}${argsPart}`, {
+      prompt: this.prompt,
+      timeout: SERIAL_TIMEOUT.PROCESS_CONTROL,
+    });
   }
 }
-

--- a/libs/remote/data-access/src/lib/remote-status.service.ts
+++ b/libs/remote/data-access/src/lib/remote-status.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
 
 @Injectable({ providedIn: 'root' })
 export class RemoteStatusService {
@@ -9,8 +9,10 @@ export class RemoteStatusService {
 
   async listPlain(): Promise<string> {
     return (
-      await this.serial.exec('forever list --plain', this.prompt, 60000, 0)
+      await this.serial.exec('forever list --plain', {
+        prompt: this.prompt,
+        timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
+      })
     ).stdout;
   }
 }
-

--- a/libs/remote/data-access/src/lib/remote-stop.service.spec.ts
+++ b/libs/remote/data-access/src/lib/remote-stop.service.spec.ts
@@ -2,7 +2,7 @@ import '@angular/compiler';
 import { Injector } from '@angular/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
 import { RemoteStopService } from './remote-stop.service';
 
 describe('RemoteStopService', () => {
@@ -22,21 +22,17 @@ describe('RemoteStopService', () => {
 
   it('stopAll calls forever stopall', async () => {
     await svc.stopAll();
-    expect(exec).toHaveBeenCalledWith(
-      'forever stopall',
-      PI_ZERO_PROMPT,
-      120000,
-      0,
-    );
+    expect(exec).toHaveBeenCalledWith('forever stopall', {
+      prompt: PI_ZERO_PROMPT,
+      timeout: SERIAL_TIMEOUT.PROCESS_CONTROL,
+    });
   });
 
   it('stopTarget calls forever stop with JSON-quoted target', async () => {
     await svc.stopTarget(`app'x`);
-    expect(exec).toHaveBeenCalledWith(
-      `forever stop ${JSON.stringify(`app'x`)}`,
-      PI_ZERO_PROMPT,
-      120000,
-      0,
-    );
+    expect(exec).toHaveBeenCalledWith(`forever stop ${JSON.stringify(`app'x`)}`, {
+      prompt: PI_ZERO_PROMPT,
+      timeout: SERIAL_TIMEOUT.PROCESS_CONTROL,
+    });
   });
 });

--- a/libs/remote/data-access/src/lib/remote-stop.service.ts
+++ b/libs/remote/data-access/src/lib/remote-stop.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
 
 @Injectable({ providedIn: 'root' })
 export class RemoteStopService {
@@ -8,7 +8,10 @@ export class RemoteStopService {
   private readonly prompt = PI_ZERO_PROMPT;
 
   async stopAll(): Promise<void> {
-    await this.serial.exec('forever stopall', this.prompt, 120000, 0);
+    await this.serial.exec('forever stopall', {
+      prompt: this.prompt,
+      timeout: SERIAL_TIMEOUT.PROCESS_CONTROL,
+    });
   }
 
   /**
@@ -17,7 +20,9 @@ export class RemoteStopService {
    */
   async stopTarget(target: string): Promise<void> {
     const arg = JSON.stringify(target);
-    await this.serial.exec(`forever stop ${arg}`, this.prompt, 120000, 0);
+    await this.serial.exec(`forever stop ${arg}`, {
+      prompt: this.prompt,
+      timeout: SERIAL_TIMEOUT.PROCESS_CONTROL,
+    });
   }
 }
-

--- a/libs/shared/guards/src/lib/browser-check.service.ts
+++ b/libs/shared/guards/src/lib/browser-check.service.ts
@@ -1,9 +1,17 @@
 import { Injectable } from '@angular/core';
-import { isBrowserSupported } from '@gurezo/web-serial-rxjs';
+import { checkBrowserSupport } from '@gurezo/web-serial-rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class BrowserCheckService {
+  /**
+   * Web Serial 利用可否（Chromium 系・API 有無を @gurezo/web-serial-rxjs で検証）
+   */
   isSupported(): boolean {
-    return isBrowserSupported();
+    try {
+      checkBrowserSupport();
+      return true;
+    } catch {
+      return false;
+    }
   }
 }

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
@@ -1,11 +1,30 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NEVER } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@xterm/xterm', () => {
+  class MockTerminal {
+    loadAddon = vi.fn();
+    open = vi.fn();
+    dispose = vi.fn();
+    writeln = vi.fn();
+    write = vi.fn();
+    reset = vi.fn();
+    onKey = vi.fn();
+  }
+  return { Terminal: MockTerminal };
+});
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: class {
+    fit = vi.fn();
+  },
+}));
 import {
   PiZeroSerialBootstrapService,
   SerialFacadeService,
 } from '@libs-web-serial-data-access';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
 import { TerminalCommandRequestService } from '@libs-terminal-util';
 import { TerminalViewComponent } from './terminal-view.component';
 
@@ -53,12 +72,10 @@ describe('TerminalViewComponent', () => {
     requests.requestCommand('i2cdetect -y 1');
 
     await vi.waitFor(() => {
-      expect(execMock).toHaveBeenCalledWith(
-        'i2cdetect -y 1',
-        PI_ZERO_PROMPT,
-        10000,
-        0,
-      );
+      expect(execMock).toHaveBeenCalledWith('i2cdetect -y 1', {
+        prompt: PI_ZERO_PROMPT,
+        timeout: SERIAL_TIMEOUT.DEFAULT,
+      });
     });
   });
 });

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -20,7 +20,7 @@ import {
   PiZeroSerialBootstrapService,
   SerialFacadeService,
 } from '@libs-web-serial-data-access';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
 
 @Component({
   selector: 'choh-terminal-view',
@@ -131,12 +131,10 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
       this.xterminal,
       async (command) => {
         return this.enqueueExec(async () => {
-          const { stdout } = await this.serial.exec(
-            command,
-            this.remotePrompt(),
-            10000,
-            0,
-          );
+          const { stdout } = await this.serial.exec(command, {
+            prompt: this.remotePrompt(),
+            timeout: SERIAL_TIMEOUT.DEFAULT,
+          });
           return sanitizeSerialStdout(stdout, command, this.remotePrompt());
         });
       },
@@ -154,12 +152,10 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
           }
           this.xterminal.writeln(`$ ${cmd}`);
           try {
-            const { stdout } = await this.serial.exec(
-              cmd,
-              this.remotePrompt(),
-              10000,
-              0,
-            );
+            const { stdout } = await this.serial.exec(cmd, {
+              prompt: this.remotePrompt(),
+              timeout: SERIAL_TIMEOUT.DEFAULT,
+            });
             const out = sanitizeSerialStdout(
               stdout,
               cmd,

--- a/libs/web-serial/data-access/src/index.ts
+++ b/libs/web-serial/data-access/src/index.ts
@@ -1,3 +1,4 @@
+export type { SerialExecOptions } from '@libs-web-serial-util';
 export * from './lib/pi-zero-serial-bootstrap.service';
 export * from './lib/pi-zero-shell-readiness.service';
 export * from './lib/serial-command.service';

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
@@ -4,6 +4,7 @@ import {
   PI_ZERO_LOGIN_USER,
   PI_ZERO_PROMPT,
   PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+  SERIAL_TIMEOUT,
 } from '@libs-web-serial-util';
 import { PiZeroSerialBootstrapService } from './pi-zero-serial-bootstrap.service';
 import type { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
@@ -41,24 +42,25 @@ describe('PiZeroSerialBootstrapService', () => {
 
     expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
     expect(readUntilPrompt).toHaveBeenCalledTimes(1);
-    expect(readUntilPrompt).toHaveBeenCalledWith(
-      PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-      5000,
-      0,
-    );
+    expect(readUntilPrompt).toHaveBeenCalledWith({
+      prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+      timeout: SERIAL_TIMEOUT.SHORT,
+    });
     expect(exec).toHaveBeenNthCalledWith(
       1,
       TZ_SET_CMD,
-      PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-      10000,
-      0,
+      expect.objectContaining({
+        prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+        timeout: SERIAL_TIMEOUT.DEFAULT,
+      }),
     );
     expect(exec).toHaveBeenNthCalledWith(
       2,
       TZ_STATUS_CMD,
-      PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-      10000,
-      0,
+      expect.objectContaining({
+        prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+        timeout: SERIAL_TIMEOUT.DEFAULT,
+      }),
     );
   });
 
@@ -85,31 +87,35 @@ describe('PiZeroSerialBootstrapService', () => {
     expect(exec).toHaveBeenNthCalledWith(
       1,
       PI_ZERO_LOGIN_USER,
-      expect.any(RegExp),
-      30000,
-      0,
+      expect.objectContaining({
+        prompt: expect.any(RegExp),
+        timeout: SERIAL_TIMEOUT.LONG,
+      }),
     );
     expect(exec).toHaveBeenNthCalledWith(
       2,
       PI_ZERO_LOGIN_PASSWORD,
-      PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-      30000,
-      0,
+      expect.objectContaining({
+        prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+        timeout: SERIAL_TIMEOUT.LONG,
+      }),
     );
     expect(lines.some((l) => l.includes('ログインユーザー'))).toBe(true);
     expect(exec).toHaveBeenNthCalledWith(
       3,
       TZ_SET_CMD,
-      PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-      10000,
-      0,
+      expect.objectContaining({
+        prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+        timeout: SERIAL_TIMEOUT.DEFAULT,
+      }),
     );
     expect(exec).toHaveBeenNthCalledWith(
       4,
       TZ_STATUS_CMD,
-      PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-      10000,
-      0,
+      expect.objectContaining({
+        prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+        timeout: SERIAL_TIMEOUT.DEFAULT,
+      }),
     );
   });
 

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
@@ -7,6 +7,7 @@ import {
   PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
   PI_ZERO_SERIAL_PASSWORD_LINE_PATTERN,
   PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+  SERIAL_TIMEOUT,
 } from '@libs-web-serial-util';
 import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
 import { SerialFacadeService } from './serial-facade.service';
@@ -58,11 +59,10 @@ export class PiZeroSerialBootstrapService {
 
     let atShell = false;
     try {
-      await this.serial.readUntilPrompt(
-        PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-        5000,
-        0,
-      );
+      await this.serial.readUntilPrompt({
+        prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+        timeout: SERIAL_TIMEOUT.SHORT,
+      });
       atShell = true;
     } catch {
       atShell = false;
@@ -70,27 +70,22 @@ export class PiZeroSerialBootstrapService {
 
     if (!atShell) {
       log('[コンソール] ログイン画面を検出しました。');
-      await this.serial.readUntilPrompt(
-        PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
-        60000,
-        0,
-      );
+      await this.serial.readUntilPrompt({
+        prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
+        timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
+      });
       log(
         `[コンソール] ログインユーザー「${PI_ZERO_LOGIN_USER}」を送信中...`,
       );
-      await this.serial.exec(
-        PI_ZERO_LOGIN_USER,
-        PI_ZERO_SERIAL_PASSWORD_LINE_PATTERN,
-        30000,
-        0,
-      );
+      await this.serial.exec(PI_ZERO_LOGIN_USER, {
+        prompt: PI_ZERO_SERIAL_PASSWORD_LINE_PATTERN,
+        timeout: SERIAL_TIMEOUT.LONG,
+      });
       log('[コンソール] パスワードを送信中（画面には表示しません）...');
-      await this.serial.exec(
-        PI_ZERO_LOGIN_PASSWORD,
-        PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-        30000,
-        0,
-      );
+      await this.serial.exec(PI_ZERO_LOGIN_PASSWORD, {
+        prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+        timeout: SERIAL_TIMEOUT.LONG,
+      });
       log('[コンソール] ログインが完了しました。');
     }
 
@@ -98,12 +93,10 @@ export class PiZeroSerialBootstrapService {
     for (const step of client.timezoneSteps) {
       log(step.statusMessage);
       try {
-        const { stdout } = await this.serial.exec(
-          step.command,
-          PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-          10000,
-          0,
-        );
+        const { stdout } = await this.serial.exec(step.command, {
+          prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+          timeout: SERIAL_TIMEOUT.DEFAULT,
+        });
         const cleaned = sanitizeSerialStdout(
           typeof stdout === 'string' ? stdout : '',
           step.command,

--- a/libs/web-serial/data-access/src/lib/serial-command.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command.service.spec.ts
@@ -1,35 +1,58 @@
 import { describe, expect, it, vi } from 'vitest';
+import { Observable, Subject } from 'rxjs';
 import { SerialCommandService } from './serial-command.service';
 import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import type { SerialTransportService } from './serial-transport.service';
+
+function createService() {
+  const chunks = new Subject<string>();
+  const transport = {
+    getReadStream: () => chunks.asObservable(),
+    write: vi.fn(
+      () =>
+        new Observable<void>((subscriber) => {
+          subscriber.next();
+          subscriber.complete();
+        })
+    ),
+  };
+  const service = new SerialCommandService(
+    transport as unknown as SerialTransportService
+  );
+  service.startReadLoop();
+  return { service, chunks, transport };
+}
 
 describe('SerialCommandService', () => {
   it('exec resolves when prompt matches', async () => {
-    const service = new SerialCommandService();
+    const { service, chunks, transport } = createService();
 
-    let resolveWrite: (() => void) | undefined;
-    const writeFn = vi.fn(async () => {
-      await new Promise<void>((resolve) => {
-        resolveWrite = resolve;
-      });
-    });
+    let releaseWrite: (() => void) | undefined;
+    transport.write = vi.fn(
+      () =>
+        new Observable<void>((subscriber) => {
+          releaseWrite = () => {
+            subscriber.next();
+            subscriber.complete();
+          };
+        })
+    );
 
     const execPromise = service.exec(
       'ls',
-      { prompt: PI_ZERO_PROMPT, timeout: 1000, retry: 0 },
-      writeFn,
-      undefined
+      { prompt: PI_ZERO_PROMPT, timeout: 1000, retry: 0 }
     );
 
-    service.processInput(`ls\r\noutput\r\n${PI_ZERO_PROMPT}`);
-    resolveWrite?.();
+    releaseWrite?.();
+    chunks.next(`ls\r\noutput\r\n${PI_ZERO_PROMPT}`);
 
     const result = await execPromise;
     expect(result.stdout).toContain(PI_ZERO_PROMPT);
-    expect(writeFn).toHaveBeenCalled();
+    expect(transport.write).toHaveBeenCalled();
   });
 
   it('readUntilPrompt resolves without writing', async () => {
-    const service = new SerialCommandService();
+    const { service, chunks } = createService();
 
     const readPromise = service.readUntilPrompt({
       prompt: PI_ZERO_PROMPT,
@@ -37,40 +60,42 @@ describe('SerialCommandService', () => {
       retry: 0,
     });
 
-    service.processInput(`welcome\r\n${PI_ZERO_PROMPT}`);
+    queueMicrotask(() => {
+      chunks.next(`welcome\r\n${PI_ZERO_PROMPT}`);
+    });
 
     const result = await readPromise;
     expect(result.stdout).toContain(PI_ZERO_PROMPT);
   });
 
   it('supports RegExp prompt', async () => {
-    const service = new SerialCommandService();
+    const { service, chunks, transport } = createService();
 
-    let resolveWrite: (() => void) | undefined;
-    const writeFn = vi.fn(async () => {
-      await new Promise<void>((resolve) => {
-        resolveWrite = resolve;
-      });
-    });
+    let releaseWrite: (() => void) | undefined;
+    transport.write = vi.fn(
+      () =>
+        new Observable<void>((subscriber) => {
+          releaseWrite = () => {
+            subscriber.next();
+            subscriber.complete();
+          };
+        })
+    );
 
+    const escaped = PI_ZERO_PROMPT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const execPromise = service.exec(
       'echo hi',
       {
-        prompt: new RegExp(
-          PI_ZERO_PROMPT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-        ),
+        prompt: new RegExp(escaped),
         timeout: 1000,
         retry: 0,
-      },
-      writeFn,
-      undefined
+      }
     );
 
-    service.processInput(`echo hi\r\nhi\r\n${PI_ZERO_PROMPT}`);
-    resolveWrite?.();
+    releaseWrite?.();
+    chunks.next(`echo hi\r\nhi\r\n${PI_ZERO_PROMPT}`);
 
     const result = await execPromise;
     expect(result.stdout).toContain('hi');
   });
 });
-

--- a/libs/web-serial/data-access/src/lib/serial-command.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command.service.spec.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Observable, Subject } from 'rxjs';
 import { SerialCommandService } from './serial-command.service';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import {
+  PI_ZERO_PROMPT,
+  PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
+} from '@libs-web-serial-util';
 import type { SerialTransportService } from './serial-transport.service';
 
 function createService() {
@@ -66,6 +69,17 @@ describe('SerialCommandService', () => {
 
     const result = await readPromise;
     expect(result.stdout).toContain(PI_ZERO_PROMPT);
+  });
+
+  it('readUntilPrompt sees data already buffered before the wait starts', async () => {
+    const { service, chunks } = createService();
+    chunks.next('Raspberry Pi OS\r\n\r\nraspberrypi login: ');
+    const result = await service.readUntilPrompt({
+      prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
+      timeout: 1000,
+      retry: 0,
+    });
+    expect(result.stdout).toMatch(/login:\s*$/m);
   });
 
   it('supports RegExp prompt', async () => {

--- a/libs/web-serial/data-access/src/lib/serial-command.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command.service.ts
@@ -148,7 +148,8 @@ export class SerialCommandService {
 
     for (let attempt = 0; attempt <= retry; attempt++) {
       onAttemptStart?.();
-      this.clearReadBuffer();
+      // Keep readBuffer: login/boot lines may already be present after a prior
+      // readUntilPrompt timeout (shell probe → login: wait).
 
       const { id, promise } = this.registerWait(config);
       this.tryResolvePendingFromBuffer();

--- a/libs/web-serial/data-access/src/lib/serial-command.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command.service.ts
@@ -1,6 +1,8 @@
 /// <reference types="@types/w3c-web-serial" />
 
 import { Injectable } from '@angular/core';
+import { firstValueFrom, type Subscription } from 'rxjs';
+import { SerialTransportService } from './serial-transport.service';
 
 /**
  * コマンド実行設定
@@ -29,16 +31,15 @@ export interface CommandResult {
 /**
  * Serial コマンド実行サービス
  *
- * コマンドの実行、プロンプト待機、タイムアウト管理を担当
- *
- * porting/services/command-executor.service.ts から移行
- * + serial.service.ts の execute() メソッドを統合
+ * 読み取りバッファ・ストリーム購読・プロンプト待ち・書き込みを担当
  */
 @Injectable({
   providedIn: 'root',
 })
 export class SerialCommandService {
   private commandSeq = 0;
+  private readBuffer = '';
+  private readSubscription: Subscription | null = null;
   private pendingCommands = new Map<
     string,
     {
@@ -49,6 +50,8 @@ export class SerialCommandService {
     }
   >();
 
+  constructor(private readonly transport: SerialTransportService) {}
+
   private nextCommandId(): string {
     return `cmd-${++this.commandSeq}-${Date.now()}`;
   }
@@ -57,26 +60,58 @@ export class SerialCommandService {
     if (typeof prompt === 'string') {
       return input.includes(prompt);
     }
-    // RegExp#test は lastIndex があると壊れるため都度 lastIndex をリセット
     prompt.lastIndex = 0;
     return prompt.test(input);
   }
 
   /**
-   * コマンド実行を開始し、指定されたプロンプトが返されるまで待機
-   *
-   * @param commandId コマンドID（通常はコマンド文字列自体）
-   * @param config 実行設定
-   * @param writeFunction データ書き込み関数
-   * @returns コマンド実行結果
+   * 接続後に呼び出し、シリアル読み取りを購読してバッファに蓄積する
    */
-  async executeCommand(
-    commandId: string,
-    config: CommandExecutionConfig,
-    writeFunction: (data: string) => Promise<void>
-  ): Promise<string> {
-    const result = await this.exec(commandId, config, writeFunction);
-    return result.stdout;
+  startReadLoop(): void {
+    this.readBuffer = '';
+    this.readSubscription?.unsubscribe();
+    this.readSubscription = this.transport.getReadStream().subscribe({
+      next: (chunk) => {
+        this.readBuffer += chunk;
+        this.tryResolvePendingFromBuffer();
+      },
+      error: (err) => console.error('Serial read stream error:', err),
+    });
+  }
+
+  /**
+   * 読み取り購読を停止しバッファを空にする
+   */
+  stopReadLoop(): void {
+    this.readSubscription?.unsubscribe();
+    this.readSubscription = null;
+    this.readBuffer = '';
+  }
+
+  /**
+   * 読み取りストリームを購読中か
+   */
+  isReading(): boolean {
+    return this.readSubscription != null && !this.readSubscription.closed;
+  }
+
+  private clearReadBuffer(): void {
+    this.readBuffer = '';
+  }
+
+  /** 現在バッファが待機中コマンドのプロンプトに一致すれば解決する */
+  private tryResolvePendingFromBuffer(): string | null {
+    for (const [commandId, command] of this.pendingCommands) {
+      if (this.matchesPrompt(this.readBuffer, command.config.prompt)) {
+        clearTimeout(command.timeoutId);
+        this.pendingCommands.delete(commandId);
+        const stdout = this.readBuffer;
+        command.resolve(stdout);
+        this.readBuffer = '';
+        return stdout;
+      }
+    }
+    return null;
   }
 
   /**
@@ -85,24 +120,20 @@ export class SerialCommandService {
   async exec(
     cmd: string,
     config: CommandExecutionConfig,
-    writeFunction: (data: string) => Promise<void>,
     onAttemptStart?: () => void
   ): Promise<CommandResult> {
-    return this.execInternal(cmd + '\n', config, writeFunction, onAttemptStart);
+    return this.execInternal(cmd + '\n', config, onAttemptStart);
   }
 
   /**
    * raw コマンド実行（stdin に `cmdRaw` をそのまま送信）
-   *
-   * base64 送信など、改行制御が必要なケースを想定しています。
    */
   async execRaw(
     cmdRaw: string,
     config: CommandExecutionConfig,
-    writeFunction: (data: string) => Promise<void>,
     onAttemptStart?: () => void
   ): Promise<CommandResult> {
-    return this.execInternal(cmdRaw, config, writeFunction, onAttemptStart);
+    return this.execInternal(cmdRaw, config, onAttemptStart);
   }
 
   /**
@@ -110,17 +141,17 @@ export class SerialCommandService {
    */
   async readUntilPrompt(
     config: CommandExecutionConfig,
-    onAttemptStart?: () => void,
-    afterRegisterWait?: () => void
+    onAttemptStart?: () => void
   ): Promise<CommandResult> {
     const retry = config.retry ?? 0;
     let lastError: unknown;
 
     for (let attempt = 0; attempt <= retry; attempt++) {
       onAttemptStart?.();
+      this.clearReadBuffer();
 
       const { id, promise } = this.registerWait(config);
-      afterRegisterWait?.();
+      this.tryResolvePendingFromBuffer();
       try {
         const stdout = await promise;
         return { stdout };
@@ -140,7 +171,6 @@ export class SerialCommandService {
   private async execInternal(
     sendData: string,
     config: CommandExecutionConfig,
-    writeFunction: (data: string) => Promise<void>,
     onAttemptStart?: () => void
   ): Promise<CommandResult> {
     const retry = config.retry ?? 0;
@@ -148,19 +178,16 @@ export class SerialCommandService {
 
     for (let attempt = 0; attempt <= retry; attempt++) {
       onAttemptStart?.();
+      this.clearReadBuffer();
 
       const { id, promise } = this.registerWait(config);
       try {
-        // コマンドを送信
-        await writeFunction(sendData);
+        await firstValueFrom(this.transport.write(sendData));
         const stdout = await promise;
         return { stdout };
       } catch (error: unknown) {
         lastError = error;
-        // pending が残らないようにクリア
         this.cancelCommand(id);
-        // cancelCommand() により promise が reject されるが、ここでは待機しないため
-        // unhandled rejection を防ぐ
         void promise.catch(() => undefined);
         if (attempt === retry) {
           throw error;
@@ -194,30 +221,6 @@ export class SerialCommandService {
     };
   }
 
-  /**
-   * 入力データを処理し、待機中のコマンドのプロンプトとマッチするかチェック
-   *
-   * @param input 受信したデータ
-   * @returns マッチした場合は入力データ、マッチしない場合は null
-   */
-  processInput(input: string): string | null {
-    for (const [commandId, command] of this.pendingCommands) {
-      if (this.matchesPrompt(input, command.config.prompt)) {
-        // コマンド完了
-        clearTimeout(command.timeoutId);
-        this.pendingCommands.delete(commandId);
-        command.resolve(input);
-        return input;
-      }
-    }
-    return null;
-  }
-
-  /**
-   * 特定のコマンドをキャンセル
-   *
-   * @param commandId キャンセルするコマンドID
-   */
   cancelCommand(commandId: string): void {
     const command = this.pendingCommands.get(commandId);
     if (command) {
@@ -227,9 +230,6 @@ export class SerialCommandService {
     }
   }
 
-  /**
-   * すべての待機中のコマンドをキャンセル
-   */
   cancelAllCommands(): void {
     for (const [, command] of this.pendingCommands) {
       clearTimeout(command.timeoutId);
@@ -238,11 +238,6 @@ export class SerialCommandService {
     this.pendingCommands.clear();
   }
 
-  /**
-   * 待機中のコマンド数を取得
-   *
-   * @returns 待機中のコマンド数
-   */
   getPendingCommandCount(): number {
     return this.pendingCommands.size;
   }

--- a/libs/web-serial/data-access/src/lib/serial-facade.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-facade.service.ts
@@ -5,8 +5,6 @@ import {
   catchError,
   defer,
   firstValueFrom,
-  from,
-  map,
   of,
   type Observable,
   Subject,
@@ -78,26 +76,11 @@ export class SerialFacadeService {
             console.error('Connection failed:', result.error);
             return of(false);
           }
-          const { port } = result;
-          return from(this.validator.isSupportedDevice(port)).pipe(
-            switchMap((isValid) => {
-              if (!isValid) {
-                return this.transport.disconnect$().pipe(
-                  tap(() =>
-                    console.warn(
-                      'Unsupported device detected - not a Raspberry Pi Zero. Connection cancelled.',
-                    )
-                  ),
-                  map(() => false)
-                );
-              }
-              this.startReadStreamSubscription();
-              this.connectionEpoch += 1;
-              this.shellReadiness.reset();
-              this.connectionEstablished.next();
-              return of(true);
-            })
-          );
+          this.startReadStreamSubscription();
+          this.connectionEpoch += 1;
+          this.shellReadiness.reset();
+          this.connectionEstablished.next();
+          return of(true);
         }),
         catchError((error) => {
           console.error('Connection error:', error);

--- a/libs/web-serial/data-access/src/lib/serial-facade.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-facade.service.ts
@@ -13,10 +13,13 @@ import {
   throwError,
 } from 'rxjs';
 import {
-  CommandExecutionConfig,
   type CommandResult,
   SerialCommandService,
 } from './serial-command.service';
+import {
+  SERIAL_TIMEOUT,
+  type SerialExecOptions,
+} from '@libs-web-serial-util';
 import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
 import { SerialTransportService } from './serial-transport.service';
 import { SerialValidatorService } from './serial-validator.service';
@@ -24,7 +27,7 @@ import { SerialValidatorService } from './serial-validator.service';
 /**
  * Serial Facade サービス
  *
- * Transport / Validator / Command を統合し、シンプルなインターフェースを提供
+ * Transport / Validator（ポート情報） / Command を統合し、シンプルな API を提供
  */
 @Injectable({
   providedIn: 'root',
@@ -163,29 +166,15 @@ export class SerialFacadeService {
   }
 
   /**
-   * @deprecated Use `exec()` / `execRaw()` / `readUntilPrompt()` instead.
-   * コマンドを実行し、指定されたプロンプトまで待機（後方互換）
-   */
-  async executeCommand(
-    cmd: string,
-    prompt: string | RegExp,
-    timeout = 10000,
-  ): Promise<string> {
-    const result = await this.exec(cmd, prompt, timeout);
-    return result.stdout;
-  }
-
-  /**
    * コマンド実行（stdout 相当を返す）
    */
-  async exec(
-    cmd: string,
-    prompt: string | RegExp,
-    timeout = 10000,
-    retry = 0
-  ): Promise<CommandResult> {
-    const config: CommandExecutionConfig = { prompt, timeout, retry };
-    return this.command.exec(cmd, config);
+  async exec(cmd: string, options: SerialExecOptions): Promise<CommandResult> {
+    const {
+      prompt,
+      timeout = SERIAL_TIMEOUT.DEFAULT,
+      retry = 0,
+    } = options;
+    return this.command.exec(cmd, { prompt, timeout, retry });
   }
 
   /**
@@ -193,24 +182,26 @@ export class SerialFacadeService {
    */
   async execRaw(
     cmdRaw: string,
-    prompt: string | RegExp,
-    timeout = 10000,
-    retry = 0
+    options: SerialExecOptions,
   ): Promise<CommandResult> {
-    const config: CommandExecutionConfig = { prompt, timeout, retry };
-    return this.command.execRaw(cmdRaw, config);
+    const {
+      prompt,
+      timeout = SERIAL_TIMEOUT.DEFAULT,
+      retry = 0,
+    } = options;
+    return this.command.execRaw(cmdRaw, { prompt, timeout, retry });
   }
 
   /**
    * 送信せずに prompt まで待機
    */
-  async readUntilPrompt(
-    prompt: string | RegExp,
-    timeout = 10000,
-    retry = 0
-  ): Promise<CommandResult> {
-    const config: CommandExecutionConfig = { prompt, timeout, retry };
-    return this.command.readUntilPrompt(config);
+  async readUntilPrompt(options: SerialExecOptions): Promise<CommandResult> {
+    const {
+      prompt,
+      timeout = SERIAL_TIMEOUT.DEFAULT,
+      retry = 0,
+    } = options;
+    return this.command.readUntilPrompt({ prompt, timeout, retry });
   }
 
   /** 現在のシリアル接続セッション番号（切断後も値は保持され、次回接続で増える） */
@@ -247,51 +238,5 @@ export class SerialFacadeService {
 
   getPort(): SerialPort | null {
     return this.transport.getPort() ?? null;
-  }
-
-  // ============================================
-  // Legacy methods (後方互換性のため)
-  // ============================================
-
-  /**
-   * @deprecated Use connect() instead
-   */
-  async startConnection(baudRate?: number): Promise<void> {
-    const success = await this.connect(baudRate);
-    if (!success) {
-      throw new Error('Failed to start connection');
-    }
-  }
-
-  /**
-   * @deprecated Use disconnect() instead
-   */
-  async terminateConnection(): Promise<void> {
-    return this.disconnect();
-  }
-
-  /**
-   * @deprecated Use write() instead
-   */
-  async portWrite(data: string): Promise<void> {
-    return this.write(data);
-  }
-
-  /**
-   * @deprecated Use executeCommand() instead
-   */
-  async portWritelnWaitfor(
-    cmd: string,
-    prompt: string | RegExp,
-    timeout = 10000,
-  ): Promise<string> {
-    return this.executeCommand(cmd, prompt, timeout);
-  }
-
-  /**
-   * @deprecated Use isConnected() instead
-   */
-  getConnectionStatus(): boolean {
-    return this.isConnected();
   }
 }

--- a/libs/web-serial/data-access/src/lib/serial-facade.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-facade.service.ts
@@ -10,9 +10,7 @@ import {
   Subject,
   switchMap,
   take,
-  tap,
   throwError,
-  type Subscription,
 } from 'rxjs';
 import {
   CommandExecutionConfig,
@@ -36,9 +34,6 @@ export class SerialFacadeService {
   private command = inject(SerialCommandService);
   private validator = inject(SerialValidatorService);
   private shellReadiness = inject(PiZeroShellReadinessService);
-
-  private readBuffer = '';
-  private readSubscription: Subscription | null = null;
 
   /** 接続成功のたびに増加（同一接続の post-connect 処理を1回に制限するため） */
   private connectionEpoch = 0;
@@ -101,18 +96,7 @@ export class SerialFacadeService {
   }
 
   private startReadStreamSubscription(): void {
-    this.readBuffer = '';
-    this.readSubscription?.unsubscribe();
-    this.readSubscription = this.transport.getReadStream().subscribe({
-      next: (chunk) => {
-        this.readBuffer += chunk;
-        const matched = this.command.processInput(this.readBuffer);
-        if (matched) {
-          this.readBuffer = '';
-        }
-      },
-      error: (err) => console.error('Serial read stream error:', err),
-    });
+    this.command.startReadLoop();
   }
 
   /**
@@ -121,9 +105,7 @@ export class SerialFacadeService {
   disconnect$(): Observable<void> {
     this.shellReadiness.reset();
     this.command.cancelAllCommands();
-    this.readSubscription?.unsubscribe();
-    this.readSubscription = null;
-    this.readBuffer = '';
+    this.command.stopReadLoop();
     return this.transport.disconnect$().pipe(
       catchError((error) => {
         console.error('Disconnect error:', error);
@@ -203,10 +185,7 @@ export class SerialFacadeService {
     retry = 0
   ): Promise<CommandResult> {
     const config: CommandExecutionConfig = { prompt, timeout, retry };
-    const clearReadBuffer = () => {
-      this.readBuffer = '';
-    };
-    return this.command.exec(cmd, config, (data) => this.write(data), clearReadBuffer);
+    return this.command.exec(cmd, config);
   }
 
   /**
@@ -219,15 +198,7 @@ export class SerialFacadeService {
     retry = 0
   ): Promise<CommandResult> {
     const config: CommandExecutionConfig = { prompt, timeout, retry };
-    const clearReadBuffer = () => {
-      this.readBuffer = '';
-    };
-    return this.command.execRaw(
-      cmdRaw,
-      config,
-      (data) => this.write(data),
-      clearReadBuffer
-    );
+    return this.command.execRaw(cmdRaw, config);
   }
 
   /**
@@ -239,16 +210,7 @@ export class SerialFacadeService {
     retry = 0
   ): Promise<CommandResult> {
     const config: CommandExecutionConfig = { prompt, timeout, retry };
-    return this.command.readUntilPrompt(
-      config,
-      undefined,
-      () => {
-        const matched = this.command.processInput(this.readBuffer);
-        if (matched) {
-          this.readBuffer = '';
-        }
-      },
-    );
+    return this.command.readUntilPrompt(config);
   }
 
   /** 現在のシリアル接続セッション番号（切断後も値は保持され、次回接続で増える） */
@@ -264,7 +226,7 @@ export class SerialFacadeService {
    * 読み取り中かどうか（ストリーム購読中は true）
    */
   isReading(): boolean {
-    return this.readSubscription != null && !this.readSubscription.closed;
+    return this.command.isReading();
   }
 
   isWriteReady(): boolean {

--- a/libs/web-serial/data-access/src/lib/serial-transport.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.ts
@@ -18,6 +18,7 @@ import {
   getConnectionErrorMessage,
   getReadErrorMessage,
   getWriteErrorMessage,
+  RASPBERRY_PI_ZERO_INFO,
 } from '@libs-web-serial-util';
 
 /**
@@ -47,7 +48,15 @@ export class SerialTransportService {
     baudRate = 115200
   ): Observable<{ port: SerialPort } | { error: string }> {
     return defer(() => {
-      const client = createSerialClient({ baudRate });
+      const client = createSerialClient({
+        baudRate,
+        filters: [
+          {
+            usbVendorId: RASPBERRY_PI_ZERO_INFO.usbVendorId,
+            usbProductId: RASPBERRY_PI_ZERO_INFO.usbProductId,
+          },
+        ],
+      });
       this.client = client;
       this.readShared$ = null;
       return client.connect().pipe(

--- a/libs/web-serial/state/src/lib/web-serial.actions.ts
+++ b/libs/web-serial/state/src/lib/web-serial.actions.ts
@@ -8,10 +8,6 @@ export const WebSerialActions = createActionGroup({
     onConnectSuccess: props<{ isConnected: boolean; message: string }>(),
     onConnectFail: props<{ isConnected: boolean; errorMessage: string }>(),
     onDisConnect: emptyProps(),
-    sendData: props<{ sendData: string }>(),
-    onSendSuccess: emptyProps(),
-    onSendFail: emptyProps(),
-    receiveData: props<{ receiveData: string }>(),
     error: props<{ error: unknown }>(),
   },
 });

--- a/libs/web-serial/state/src/lib/web-serial.effects.ts
+++ b/libs/web-serial/state/src/lib/web-serial.effects.ts
@@ -1,5 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { SerialError, SerialErrorCode } from '@gurezo/web-serial-rxjs';
 import { catchError, map, of, switchMap } from 'rxjs';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { WebSerialActions } from './web-serial.actions';
@@ -12,6 +13,31 @@ const ERROR_MESSAGES = {
   UNSUPPORTED_DEVICE:
     'サポートされていないデバイスです。Raspberry Pi Zero以外のデバイスは接続できません。',
 } as const;
+
+function connectFailureMessage(error: unknown): string {
+  if (error instanceof SerialError) {
+    if (error.is(SerialErrorCode.OPERATION_CANCELLED)) {
+      return ERROR_MESSAGES.NO_PORT_SELECTED;
+    }
+    if (
+      error.is(SerialErrorCode.PORT_NOT_AVAILABLE) ||
+      error.is(SerialErrorCode.PORT_OPEN_FAILED)
+    ) {
+      return ERROR_MESSAGES.UNSUPPORTED_DEVICE;
+    }
+  }
+  if (error instanceof Error && error.message?.includes('No port selected')) {
+    return ERROR_MESSAGES.NO_PORT_SELECTED;
+  }
+  if (
+    error instanceof Error &&
+    (error.message?.includes('not a Raspberry Pi Zero') ||
+      error.message?.includes('not supported'))
+  ) {
+    return ERROR_MESSAGES.UNSUPPORTED_DEVICE;
+  }
+  return ERROR_MESSAGES.CONNECTION_FAILED;
+}
 
 /**
  * WebSerialEffects
@@ -38,7 +64,7 @@ export class WebSerialEffects {
               return of(
                 WebSerialActions.onConnectFail({
                   isConnected: false,
-                  errorMessage: ERROR_MESSAGES.UNSUPPORTED_DEVICE,
+                  errorMessage: ERROR_MESSAGES.CONNECTION_FAILED,
                 })
               );
             }
@@ -49,20 +75,11 @@ export class WebSerialEffects {
               })
             );
           }),
-          catchError((error) => {
-            let errorMessage: string = ERROR_MESSAGES.CONNECTION_FAILED;
-            if (error.message?.includes('No port selected')) {
-              errorMessage = ERROR_MESSAGES.NO_PORT_SELECTED;
-            } else if (
-              error.message?.includes('not a Raspberry Pi Zero') ||
-              error.message?.includes('not supported')
-            ) {
-              errorMessage = ERROR_MESSAGES.UNSUPPORTED_DEVICE;
-            }
+          catchError((error: unknown) => {
             return [
               WebSerialActions.onConnectFail({
                 isConnected: false,
-                errorMessage: errorMessage,
+                errorMessage: connectFailureMessage(error),
               }),
             ];
           })

--- a/libs/web-serial/state/src/lib/web-serial.effects.ts
+++ b/libs/web-serial/state/src/lib/web-serial.effects.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { SerialError, SerialErrorCode } from '@gurezo/web-serial-rxjs';
-import { catchError, map, of, switchMap } from 'rxjs';
+import { catchError, of, switchMap } from 'rxjs';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { WebSerialActions } from './web-serial.actions';
 
@@ -95,29 +95,5 @@ export class WebSerialEffects {
         switchMap(() => this.service.disconnect$())
       ),
     { dispatch: false }
-  );
-
-  sendData$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType(WebSerialActions.sendData),
-      switchMap((action) =>
-        this.service.write$(action.sendData).pipe(
-          map(() => WebSerialActions.onSendSuccess()),
-          catchError(async (error) => WebSerialActions.error(error))
-        )
-      )
-    )
-  );
-
-  receiveData$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType(WebSerialActions.receiveData),
-      switchMap(() =>
-        this.service.read$().pipe(
-          map((receiveData) => WebSerialActions.receiveData({ receiveData })),
-          catchError(async (error) => WebSerialActions.error(error))
-        )
-      )
-    )
   );
 }

--- a/libs/web-serial/state/src/lib/web-serial.model.ts
+++ b/libs/web-serial/state/src/lib/web-serial.model.ts
@@ -1,7 +1,5 @@
 export interface WebSerialState {
   isConnected: boolean;
-  sendData: string;
-  receiveData: string;
   error: unknown;
   connectionMessage: string; // 接続成功メッセージ
   errorMessage: string; // エラーメッセージ

--- a/libs/web-serial/state/src/lib/web-serial.reducers.ts
+++ b/libs/web-serial/state/src/lib/web-serial.reducers.ts
@@ -4,8 +4,6 @@ import { WebSerialState } from './web-serial.model';
 
 export const initialWebSerialState: WebSerialState = {
   isConnected: false,
-  sendData: '',
-  receiveData: '',
   error: null,
   connectionMessage: '',
   errorMessage: '',
@@ -38,14 +36,6 @@ export const webSerialReducer = createReducer(
   ),
   on(WebSerialActions.onDisConnect, () => ({
     ...initialWebSerialState,
-  })),
-  on(WebSerialActions.sendData, (state, { sendData }) => ({
-    ...state,
-    sendData,
-  })),
-  on(WebSerialActions.receiveData, (state, { receiveData }) => ({
-    ...state,
-    receiveData,
   })),
   on(WebSerialActions.error, (state, { error }) => ({
     ...state,

--- a/libs/web-serial/state/src/lib/web-serial.selectors.ts
+++ b/libs/web-serial/state/src/lib/web-serial.selectors.ts
@@ -9,16 +9,6 @@ export const isConnected = createSelector(
   (state: WebSerialState) => state.isConnected
 );
 
-export const selectSendData = createSelector(
-  selectWebSerialFeature,
-  (state: WebSerialState) => state.sendData
-);
-
-export const selectReciveData = createSelector(
-  selectWebSerialFeature,
-  (state: WebSerialState) => state.receiveData
-);
-
 export const selectConnectionMessage = createSelector(
   selectWebSerialFeature,
   (state: WebSerialState) => state.connectionMessage

--- a/libs/web-serial/util/src/index.ts
+++ b/libs/web-serial/util/src/index.ts
@@ -1,2 +1,5 @@
 export * from './lib/serial-error-messages';
 export * from './lib/pi-zero.const';
+export * from './lib/serial-timeout';
+export * from './lib/serial-exec-options';
+export * from './lib/serial-error-wrap';

--- a/libs/web-serial/util/src/lib/serial-error-wrap.ts
+++ b/libs/web-serial/util/src/lib/serial-error-wrap.ts
@@ -1,0 +1,7 @@
+/**
+ * シリアル／ファイル操作などで catch した unknown を文脈付き Error に包む
+ */
+export function wrapSerialError(context: string, error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  return new Error(`${context}: ${message}`);
+}

--- a/libs/web-serial/util/src/lib/serial-exec-options.ts
+++ b/libs/web-serial/util/src/lib/serial-exec-options.ts
@@ -1,0 +1,8 @@
+/**
+ * {@link SerialFacadeService#exec} / execRaw / readUntilPrompt 向けオプション
+ */
+export interface SerialExecOptions {
+  prompt: string | RegExp;
+  timeout?: number;
+  retry?: number;
+}

--- a/libs/web-serial/util/src/lib/serial-timeout.ts
+++ b/libs/web-serial/util/src/lib/serial-timeout.ts
@@ -1,0 +1,21 @@
+/**
+ * シリアル exec / readUntilPrompt で使うタイムアウト（ミリ秒）の推奨値
+ */
+export const SERIAL_TIMEOUT = {
+  /** 1s — 短い行待ち */
+  LINE: 1_000,
+  /** 5s — ブートストラップ・短いプローブ */
+  SHORT: 5_000,
+  /** 8s — 再起動（プロンプトが返らない場合がある） */
+  REBOOT: 8_000,
+  /** 10s — 通常のシェルコマンド */
+  DEFAULT: 10_000,
+  /** 30s — ファイル読み取り・やや長い処理 */
+  LONG: 30_000,
+  /** 60s — セットアップ・大きめの転送 */
+  FILE_TRANSFER: 60_000,
+  /** 120s — forever 等の長時間プロセス */
+  PROCESS_CONTROL: 120_000,
+  /** 300s — Node.js / chirimen 大規模インストール */
+  NODE_INSTALL: 300_000,
+} as const;

--- a/libs/wifi/data-access/src/lib/file-content.service.ts
+++ b/libs/wifi/data-access/src/lib/file-content.service.ts
@@ -1,7 +1,11 @@
 import { Injectable, inject } from '@angular/core';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { FileUtils } from '@libs-wifi-util';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import {
+  PI_ZERO_PROMPT,
+  SERIAL_TIMEOUT,
+  wrapSerialError,
+} from '@libs-web-serial-util';
 
 /**
  * ファイル内容情報
@@ -27,11 +31,10 @@ export class FileContentService {
   async readFile(path: string): Promise<FileContentInfo> {
     try {
       const result = (
-        await this.serial.exec(
-          `base64 -- ${FileUtils.escapePath(path)}`,
-          PI_ZERO_PROMPT,
-          30000
-        )
+        await this.serial.exec(`base64 -- ${FileUtils.escapePath(path)}`, {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.LONG,
+        })
       ).stdout;
 
       const lines = result.split('\n').map((line) => line.trim());
@@ -60,20 +63,19 @@ export class FileContentService {
         };
       }
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Failed to read file: ${errorMessage}`);
+      throw wrapSerialError('Failed to read file', error);
     }
   }
 
   async writeTextFile(path: string, content: string): Promise<void> {
     try {
       const command = FileUtils.generateHeredocCommand(path, content);
-      await this.serial.exec(command, 'EOL', 10000);
+      await this.serial.exec(command, {
+        prompt: 'EOL',
+        timeout: SERIAL_TIMEOUT.DEFAULT,
+      });
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Failed to write text file: ${errorMessage}`);
+      throw wrapSerialError('Failed to write text file', error);
     }
   }
 
@@ -84,37 +86,41 @@ export class FileContentService {
       await this.serial.write('\x03');
       await this.sleep(100);
 
-      await this.serial.exec(
-        `base64 -d > ${FileUtils.escapePath(path)}`,
-        '\n',
-        10000
-      );
+      await this.serial.exec(`base64 -d > ${FileUtils.escapePath(path)}`, {
+        prompt: '\n',
+        timeout: SERIAL_TIMEOUT.DEFAULT,
+      });
 
       const lineLength = 512;
       for (let i = 0; i <= Math.floor(base64.length / lineLength); i++) {
         const line = base64.substring(i * lineLength, (i + 1) * lineLength);
-        await this.serial.exec(line, '\n', 1000);
+        await this.serial.exec(line, {
+          prompt: '\n',
+          timeout: SERIAL_TIMEOUT.LINE,
+        });
         await this.sleep(1);
       }
 
       await this.serial.write('\x04');
       await this.sleep(10);
-      await this.serial.exec('', '\\$', 1000);
+      await this.serial.exec('', {
+        prompt: '\\$',
+        timeout: SERIAL_TIMEOUT.LINE,
+      });
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Failed to write binary file: ${errorMessage}`);
+      throw wrapSerialError('Failed to write binary file', error);
     }
   }
 
   async appendToFile(path: string, content: string): Promise<void> {
     try {
       const command = FileUtils.generateAppendCommand(path, content);
-      await this.serial.exec(command, 'EOL', 10000);
+      await this.serial.exec(command, {
+        prompt: 'EOL',
+        timeout: SERIAL_TIMEOUT.DEFAULT,
+      });
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Failed to append to file: ${errorMessage}`);
+      throw wrapSerialError('Failed to append to file', error);
     }
   }
 

--- a/libs/wifi/data-access/src/lib/wifi-config.service.ts
+++ b/libs/wifi/data-access/src/lib/wifi-config.service.ts
@@ -3,7 +3,11 @@ import { FileContentService } from './file-content.service';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { FileUtils, shellSingleQuote } from '@libs-wifi-util';
 import { WifiRebootFlowService } from './wifi-reboot-flow.service';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import {
+  PI_ZERO_PROMPT,
+  SERIAL_TIMEOUT,
+  wrapSerialError,
+} from '@libs-web-serial-util';
 
 /**
  * WiFi 設定（setWiFi / configureWifi）を担当
@@ -21,12 +25,14 @@ export class WifiConfigService {
    */
   async setWiFi(ssid: string, password: string): Promise<void> {
     try {
-      await this.serial.exec('cd', PI_ZERO_PROMPT, 10000);
-      await this.serial.exec(
-        'sudo touch /boot/ssh',
-        PI_ZERO_PROMPT,
-        10000
-      );
+      await this.serial.exec('cd', {
+        prompt: PI_ZERO_PROMPT,
+        timeout: SERIAL_TIMEOUT.DEFAULT,
+      });
+      await this.serial.exec('sudo touch /boot/ssh', {
+        prompt: PI_ZERO_PROMPT,
+        timeout: SERIAL_TIMEOUT.DEFAULT,
+      });
 
       const wifiSetupScript = this.generateWifiSetupScript();
 
@@ -36,13 +42,13 @@ export class WifiConfigService {
       const qPass = shellSingleQuote(password);
       await this.serial.exec(
         `chmod +x wifi_setup.sh && ./wifi_setup.sh ${qSsid} ${qPass}`,
-        PI_ZERO_PROMPT,
-        30000
+        {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.LONG,
+        }
       );
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Failed to set WiFi: ${errorMessage}`);
+      throw wrapSerialError('Failed to set WiFi', error);
     }
   }
 
@@ -57,9 +63,7 @@ export class WifiConfigService {
 
       await this.rebootFlow.restartWifiService();
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`WiFi configuration failed: ${errorMessage}`);
+      throw wrapSerialError('WiFi configuration failed', error);
     }
   }
 
@@ -105,8 +109,10 @@ network={
     try {
       await this.serial.exec(
         'sudo cp /etc/wpa_supplicant/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf.backup',
-        PI_ZERO_PROMPT,
-        10000
+        {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.DEFAULT,
+        }
       );
 
       const encoder = new TextEncoder();
@@ -118,17 +124,20 @@ network={
 
       await this.serial.exec(
         'sudo tee /etc/wpa_supplicant/wpa_supplicant.conf > /dev/null',
-        '\n',
-        10000
+        {
+          prompt: '\n',
+          timeout: SERIAL_TIMEOUT.DEFAULT,
+        }
       );
-      await this.serial.exec(base64, '\n', 1000);
+      await this.serial.exec(base64, {
+        prompt: '\n',
+        timeout: SERIAL_TIMEOUT.LINE,
+      });
 
       await this.serial.write('\x04');
       await this.sleep(10);
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Failed to save WiFi config: ${errorMessage}`);
+      throw wrapSerialError('Failed to save WiFi config', error);
     }
   }
 

--- a/libs/wifi/data-access/src/lib/wifi-reboot-flow.service.ts
+++ b/libs/wifi/data-access/src/lib/wifi-reboot-flow.service.ts
@@ -1,6 +1,10 @@
 import { Injectable, inject } from '@angular/core';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import {
+  PI_ZERO_PROMPT,
+  SERIAL_TIMEOUT,
+  wrapSerialError,
+} from '@libs-web-serial-util';
 
 /**
  * WiFi 再起動・有効/無効のフローを担当
@@ -16,21 +20,17 @@ export class WifiRebootFlowService {
    */
   async restartWifiService(): Promise<void> {
     try {
-      await this.serial.exec(
-        'sudo systemctl restart wpa_supplicant',
-        PI_ZERO_PROMPT,
-        10000
-      );
+      await this.serial.exec('sudo systemctl restart wpa_supplicant', {
+        prompt: PI_ZERO_PROMPT,
+        timeout: SERIAL_TIMEOUT.DEFAULT,
+      });
 
-      await this.serial.exec(
-        'sudo systemctl restart networking',
-        PI_ZERO_PROMPT,
-        10000
-      );
+      await this.serial.exec('sudo systemctl restart networking', {
+        prompt: PI_ZERO_PROMPT,
+        timeout: SERIAL_TIMEOUT.DEFAULT,
+      });
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Failed to restart WiFi service: ${errorMessage}`);
+      throw wrapSerialError('Failed to restart WiFi service', error);
     }
   }
 
@@ -39,15 +39,12 @@ export class WifiRebootFlowService {
    */
   async enableWifi(): Promise<void> {
     try {
-      await this.serial.exec(
-        'sudo ifconfig wlan0 up',
-        PI_ZERO_PROMPT,
-        10000
-      );
+      await this.serial.exec('sudo ifconfig wlan0 up', {
+        prompt: PI_ZERO_PROMPT,
+        timeout: SERIAL_TIMEOUT.DEFAULT,
+      });
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Failed to enable WiFi: ${errorMessage}`);
+      throw wrapSerialError('Failed to enable WiFi', error);
     }
   }
 
@@ -56,15 +53,12 @@ export class WifiRebootFlowService {
    */
   async disableWifi(): Promise<void> {
     try {
-      await this.serial.exec(
-        'sudo ifconfig wlan0 down',
-        PI_ZERO_PROMPT,
-        10000
-      );
+      await this.serial.exec('sudo ifconfig wlan0 down', {
+        prompt: PI_ZERO_PROMPT,
+        timeout: SERIAL_TIMEOUT.DEFAULT,
+      });
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Failed to disable WiFi: ${errorMessage}`);
+      throw wrapSerialError('Failed to disable WiFi', error);
     }
   }
 
@@ -73,7 +67,10 @@ export class WifiRebootFlowService {
    */
   async rebootDevice(): Promise<void> {
     try {
-      await this.serial.exec('sudo reboot', PI_ZERO_PROMPT, 8000);
+      await this.serial.exec('sudo reboot', {
+        prompt: PI_ZERO_PROMPT,
+        timeout: SERIAL_TIMEOUT.REBOOT,
+      });
     } catch {
       // 再起動でシリアルが切れるとタイムアウトや切断エラーになり得る
     }

--- a/libs/wifi/data-access/src/lib/wifi-scan.service.ts
+++ b/libs/wifi/data-access/src/lib/wifi-scan.service.ts
@@ -5,7 +5,11 @@ import {
   parseWifiIwconfigOutput,
   parseWifiIwlistOutput,
 } from '@libs-wifi-util';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import {
+  PI_ZERO_PROMPT,
+  SERIAL_TIMEOUT,
+  wrapSerialError,
+} from '@libs-web-serial-util';
 import type { WiFiInfo } from '@libs-shared-types';
 
 /**
@@ -24,10 +28,16 @@ export class WifiScanService {
   }> {
     try {
       const ifconfigOutput = (
-        await this.serial.exec('ifconfig', PI_ZERO_PROMPT, 10000)
+        await this.serial.exec('ifconfig', {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.DEFAULT,
+        })
       ).stdout;
       const iwconfigOutput = (
-        await this.serial.exec('iwconfig', PI_ZERO_PROMPT, 10000)
+        await this.serial.exec('iwconfig', {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.DEFAULT,
+        })
       ).stdout;
 
       const { ipInfo, ipaddr } = parseWifiIfconfigOutput(ifconfigOutput);
@@ -35,20 +45,17 @@ export class WifiScanService {
 
       return { ipInfo, wlInfo, ipaddr };
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Failed to get WiFi status: ${errorMessage}`);
+      throw wrapSerialError('Failed to get WiFi status', error);
     }
   }
 
   async scanNetworks(): Promise<{ rawData: string[]; wifiInfos: WiFiInfo[] }> {
     try {
       const output = (
-        await this.serial.exec(
-          'sudo iwlist wlan0 scan',
-          PI_ZERO_PROMPT,
-          30000
-        )
+        await this.serial.exec('sudo iwlist wlan0 scan', {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.LONG,
+        })
       ).stdout;
 
       const lines = output.split('\n');
@@ -56,28 +63,30 @@ export class WifiScanService {
 
       return { rawData: lines, wifiInfos };
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Failed to scan networks: ${errorMessage}`);
+      throw wrapSerialError('Failed to scan networks', error);
     }
   }
 
   async getDetailedWifiStatus(): Promise<string> {
     try {
       return (
-        await this.serial.exec('iwconfig wlan0', PI_ZERO_PROMPT, 10000)
+        await this.serial.exec('iwconfig wlan0', {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.DEFAULT,
+        })
       ).stdout;
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Failed to get WiFi status: ${errorMessage}`);
+      throw wrapSerialError('Failed to get WiFi status', error);
     }
   }
 
   async getIpAddress(): Promise<string> {
     try {
       const stdout = (
-        await this.serial.exec('hostname -I', PI_ZERO_PROMPT, 10000)
+        await this.serial.exec('hostname -I', {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.DEFAULT,
+        })
       ).stdout;
 
       const lines = stdout.split('\n');
@@ -85,25 +94,20 @@ export class WifiScanService {
       const ipAddresses = firstLine.split(/\s+/);
       return ipAddresses[0] || '';
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Failed to get IP address: ${errorMessage}`);
+      throw wrapSerialError('Failed to get IP address', error);
     }
   }
 
   async showNetworkConfig(): Promise<string> {
     try {
       return (
-        await this.serial.exec(
-          'cat /etc/network/interfaces',
-          PI_ZERO_PROMPT,
-          10000
-        )
+        await this.serial.exec('cat /etc/network/interfaces', {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.DEFAULT,
+        })
       ).stdout;
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Failed to show network config: ${errorMessage}`);
+      throw wrapSerialError('Failed to show network config', error);
     }
   }
 
@@ -114,14 +118,14 @@ export class WifiScanService {
     try {
       const { stdout } = await this.serial.exec(
         'wget --spider -nv https://tutorial.chirimen.org/',
-        PI_ZERO_PROMPT,
-        60000
+        {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
+        }
       );
       return stdout;
     } catch (error: unknown) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Connectivity check failed: ${errorMessage}`);
+      throw wrapSerialError('Connectivity check failed', error);
     }
   }
 


### PR DESCRIPTION
## Summary

Issue #520 に基づき、シリアル送受信のデータフローを整理し、タイムアウト定数化・exec API のオプション化・エラー共通化・未使用 NgRx 状態の削除を行いました。

## Type of change

- [ ] Bug fix
- [x] Refactor
- [ ] New feature
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [x] Breaking change

## Related issues

- Fixes #520

## What changed?

- 読み取りバッファと読み取りストリーム購読を SerialCommandService に集約し、Facade から processInput 連携用コールバックを削除
- SERIAL_TIMEOUT 定数の導入と各所のタイムアウト値の置換
- exec / execRaw / readUntilPrompt の第2引数以降をオプションオブジェクトに変更（呼び出し側をすべて更新）
- wrapSerialError によるシリアル関連 catch の共通化
- Web Serial の sendData / receiveData 系アクション・State・Effect の削除（未使用）
- Facade の非推奨メソッドの削除
- （Phase 0（任意・@gurezo/web-serial-rxjs 最大活用）を実施した場合）USB フィルタによるポート絞り込み、接続後検証の整理、Effects の SerialError ベース分岐、必要なら Guard の checkBrowserSupport 化

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - Details: SerialFacadeService / SerialCommandService の exec 系シグネチャ変更（オプションオブジェクト化）。@libs-web-serial-state の一部アクション・セレクタ削除。
- [ ] This change is backward compatible
- [x] This change introduces a breaking change
  - Migration notes: `serial.exec(cmd, prompt, timeout, retry)` を `serial.exec(cmd, { prompt, timeout, retry })` に置き換える。State から `sendData` / `receiveData` を参照していたコードがあれば削除。

## How to test

1. Chromium 系ブラウザでアプリを起動し、Pi Zero に Web Serial 接続する
2. ターミナルからシェルコマンドを実行し、プロンプト復帰と出力が従来どおりであることを確認する
3. 接続後ブートストラップ（ログイン・タイムゾーン）が問題なく完了することを確認する
4. 必要に応じて WiFi 設定・ファイル操作・CHIRIMEN セットアップなど serial.exec を使う機能を smoke する

## Environment (if relevant)

- Browser: Chrome / Edge（Web Serial 対応）
- OS: macOS / Windows / Linux
- Node version: （ローカルに合わせて記載）
- pnpm version: （ローカルに合わせて記載）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant