### PR TITLE
feat(web-serial): シリアルコマンドを Observable 中心に再構成（#522）

### DIFF
--- a/libs/i2cdetect/data-access/src/lib/i2cdetect.service.ts
+++ b/libs/i2cdetect/data-access/src/lib/i2cdetect.service.ts
@@ -1,4 +1,11 @@
 import { Injectable, inject } from '@angular/core';
+import {
+  type Observable,
+  catchError,
+  firstValueFrom,
+  map,
+  throwError,
+} from 'rxjs';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { formatI2cdetectResult } from '@libs-i2cdetect-util';
 import {
@@ -20,23 +27,31 @@ export class I2cdetectService {
   private serial = inject(SerialFacadeService);
 
   /**
+   * I2C デバイスを検出（Observable）
+   *
+   * @returns I2C デバイス情報（HTML形式）
+   */
+  detectI2cDevices$(): Observable<string> {
+    return this.serial.exec$('i2cdetect -y 1', {
+      prompt: PI_ZERO_PROMPT,
+      timeout: SERIAL_TIMEOUT.DEFAULT,
+    }).pipe(
+      map((result) => formatI2cdetectResult(result.stdout)),
+      catchError((error: unknown) =>
+        throwError(() =>
+          wrapSerialError('Failed to detect I2C devices', error),
+        ),
+      ),
+    );
+  }
+
+  /**
    * I2C デバイスを検出
    *
    * @returns I2C デバイス情報（HTML形式）
    */
   async detectI2cDevices(): Promise<string> {
-    try {
-      const output = (
-        await this.serial.exec('i2cdetect -y 1', {
-          prompt: PI_ZERO_PROMPT,
-          timeout: SERIAL_TIMEOUT.DEFAULT,
-        })
-      ).stdout;
-
-      return formatI2cdetectResult(output);
-    } catch (error: unknown) {
-      throw wrapSerialError('Failed to detect I2C devices', error);
-    }
+    return firstValueFrom(this.detectI2cDevices$());
   }
 
   /**

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NEVER } from 'rxjs';
+import { NEVER, of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@xterm/xterm', () => {
@@ -50,6 +50,7 @@ describe('TerminalViewComponent', () => {
       .overrideProvider(PiZeroSerialBootstrapService, {
         useValue: {
           runAfterConnect: vi.fn().mockResolvedValue(undefined),
+          runAfterConnect$: vi.fn(() => of(undefined)),
         },
       })
       .compileComponents();

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -1,13 +1,15 @@
 import {
   AfterViewInit,
   Component,
+  DestroyRef,
   ElementRef,
   OnDestroy,
   ViewChild,
   inject,
   input,
 } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { EMPTY, Subscription, catchError, finalize, switchMap } from 'rxjs';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import {
@@ -48,6 +50,7 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
   private serial = inject(SerialFacadeService);
   private piZeroBootstrap = inject(PiZeroSerialBootstrapService);
   private commandRequests = inject(TerminalCommandRequestService);
+  private destroyRef = inject(DestroyRef);
 
   readonly xterminal = new Terminal(xtermConsoleConfigOptions);
 
@@ -57,37 +60,34 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
   private execTail: Promise<void> = Promise.resolve();
 
   private commandRequestSub?: Subscription;
-  private connectionEstablishedSub?: Subscription;
   private resizeObserver?: ResizeObserver;
 
   ngAfterViewInit(): void {
     this.configTerminal();
-    this.connectionEstablishedSub = this.serial.connectionEstablished$.subscribe(
-      () => {
-        if (!this.serial.isConnected()) {
-          return;
-        }
-        this.xterminal.writeln(
-          '[コンソール] シリアルに接続しました。初期化しています...',
-        );
-        void this.enqueueExec(async () => {
-          try {
-            await this.piZeroBootstrap.runAfterConnect((line) =>
-              this.xterminal.writeln(line),
-            );
-          } catch {
-            // 失敗メッセージは runAfterConnect 内で表示済み
+    this.serial.connectionEstablished$
+      .pipe(
+        switchMap(() => {
+          if (!this.serial.isConnected()) {
+            return EMPTY;
           }
-          this.xterminal.write('$ ');
-        });
-      },
-    );
+          this.xterminal.writeln(
+            '[コンソール] シリアルに接続しました。初期化しています...',
+          );
+          return this.piZeroBootstrap
+            .runAfterConnect$((line) => this.xterminal.writeln(line))
+            .pipe(
+              catchError(() => EMPTY),
+              finalize(() => this.xterminal.write('$ ')),
+            );
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
   }
 
   ngOnDestroy(): void {
     this.resizeObserver?.disconnect();
     this.commandRequestSub?.unsubscribe();
-    this.connectionEstablishedSub?.unsubscribe();
     this.xterminal.dispose();
   }
 
@@ -113,16 +113,14 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
     this.xterminal.reset();
     if (this.serial.isConnected()) {
       this.xterminal.writeln('[コンソール] シリアル接続済み。初期化しています...');
-      void this.enqueueExec(async () => {
-        try {
-          await this.piZeroBootstrap.runAfterConnect((line) =>
-            this.xterminal.writeln(line),
-          );
-        } catch {
-          // 失敗メッセージは runAfterConnect 内で表示済み
-        }
-        this.xterminal.write('$ ');
-      });
+      this.piZeroBootstrap
+        .runAfterConnect$((line) => this.xterminal.writeln(line))
+        .pipe(
+          takeUntilDestroyed(this.destroyRef),
+          catchError(() => EMPTY),
+          finalize(() => this.xterminal.write('$ ')),
+        )
+        .subscribe();
     } else {
       this.xterminal.writeln('$ ');
     }

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { from } from 'rxjs';
 import {
   PI_ZERO_LOGIN_PASSWORD,
   PI_ZERO_LOGIN_USER,
@@ -33,7 +34,9 @@ describe('PiZeroSerialBootstrapService', () => {
       isConnected: () => true,
       getConnectionEpoch: () => 1,
       readUntilPrompt,
+      readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
       exec,
+      exec$: (c: string, o: unknown) => from(exec(c, o)),
     } as unknown as SerialFacadeService;
 
     const shellReadiness = createShellReadinessMock();
@@ -74,7 +77,9 @@ describe('PiZeroSerialBootstrapService', () => {
       isConnected: () => true,
       getConnectionEpoch: () => 1,
       readUntilPrompt,
+      readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
       exec,
+      exec$: (c: string, o: unknown) => from(exec(c, o)),
     } as unknown as SerialFacadeService;
 
     const shellReadiness = createShellReadinessMock();
@@ -123,11 +128,14 @@ describe('PiZeroSerialBootstrapService', () => {
     const readUntilPrompt = vi.fn().mockResolvedValue({
       stdout: `${PI_ZERO_PROMPT} `,
     });
+    const exec = vi.fn().mockResolvedValue({ stdout: '' });
     const serial = {
       isConnected: () => true,
       getConnectionEpoch: () => 1,
       readUntilPrompt,
-      exec: vi.fn().mockResolvedValue({ stdout: '' }),
+      readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
+      exec,
+      exec$: (c: string, o: unknown) => from(exec(c, o)),
     } as unknown as SerialFacadeService;
 
     const shellReadiness = createShellReadinessMock();
@@ -154,7 +162,9 @@ describe('PiZeroSerialBootstrapService', () => {
       isConnected: () => true,
       getConnectionEpoch: () => 1,
       readUntilPrompt,
+      readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
       exec,
+      exec$: (c: string, o: unknown) => from(exec(c, o)),
     } as unknown as SerialFacadeService;
 
     const lines: string[] = [];

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
@@ -1,5 +1,8 @@
 import { Injectable } from '@angular/core';
-import { createConnectClient } from '@libs-connect-util';
+import {
+  type ConnectClient,
+  createConnectClient,
+} from '@libs-connect-util';
 import { sanitizeSerialStdout } from '@libs-terminal-util';
 import {
   PI_ZERO_LOGIN_PASSWORD,
@@ -9,6 +12,21 @@ import {
   PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
   SERIAL_TIMEOUT,
 } from '@libs-web-serial-util';
+import type { Observable } from 'rxjs';
+import {
+  catchError,
+  concatMap,
+  defaultIfEmpty,
+  defer,
+  firstValueFrom,
+  from,
+  ignoreElements,
+  map,
+  of,
+  switchMap,
+  tap,
+  throwError,
+} from 'rxjs';
 import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
 import { SerialFacadeService } from './serial-facade.service';
 
@@ -28,92 +46,137 @@ export class PiZeroSerialBootstrapService {
   /**
    * 接続セッションごとに1回、シェル到達（必要ならログイン）と接続直後の初期化を行う。
    */
-  async runAfterConnect(onStatus?: PiZeroBootstrapStatusHandler): Promise<void> {
+  runAfterConnect$(
+    onStatus?: PiZeroBootstrapStatusHandler,
+  ): Observable<void> {
+    const log = onStatus ?? (() => undefined);
+
     if (!this.serial.isConnected()) {
-      return;
+      return of(undefined);
     }
 
     const epoch = this.serial.getConnectionEpoch();
     if (epoch === this.lastBootstrappedEpoch) {
-      return;
+      return of(undefined);
     }
 
-    const log = onStatus ?? (() => undefined);
-
-    try {
-      await this.runPipeline(log);
-      if (this.serial.isConnected()) {
-        this.lastBootstrappedEpoch = epoch;
-        this.shellReadiness.setReady(true);
-      }
-    } catch (error: unknown) {
-      const message =
-        error instanceof Error ? error.message : String(error);
-      log(`[コンソール] 接続後の初期化に失敗しました: ${message}`);
-      throw error;
-    }
-  }
-
-  private async runPipeline(log: PiZeroBootstrapStatusHandler): Promise<void> {
-    const client = createConnectClient();
-
-    let atShell = false;
-    try {
-      await this.serial.readUntilPrompt({
-        prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-        timeout: SERIAL_TIMEOUT.SHORT,
-      });
-      atShell = true;
-    } catch {
-      atShell = false;
-    }
-
-    if (!atShell) {
-      log('[コンソール] ログイン画面を検出しました。');
-      await this.serial.readUntilPrompt({
-        prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
-        timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
-      });
-      log(
-        `[コンソール] ログインユーザー「${PI_ZERO_LOGIN_USER}」を送信中...`,
-      );
-      await this.serial.exec(PI_ZERO_LOGIN_USER, {
-        prompt: PI_ZERO_SERIAL_PASSWORD_LINE_PATTERN,
-        timeout: SERIAL_TIMEOUT.LONG,
-      });
-      log('[コンソール] パスワードを送信中（画面には表示しません）...');
-      await this.serial.exec(PI_ZERO_LOGIN_PASSWORD, {
-        prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-        timeout: SERIAL_TIMEOUT.LONG,
-      });
-      log('[コンソール] ログインが完了しました。');
-    }
-
-    log('[コンソール] タイムゾーン関連の初期化を開始します。');
-    for (const step of client.timezoneSteps) {
-      log(step.statusMessage);
-      try {
-        const { stdout } = await this.serial.exec(step.command, {
-          prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-          timeout: SERIAL_TIMEOUT.DEFAULT,
-        });
-        const cleaned = sanitizeSerialStdout(
-          typeof stdout === 'string' ? stdout : '',
-          step.command,
-          client.prompt,
-        );
-        for (const line of cleaned.split(/\r?\n/)) {
-          if (line.length > 0) {
-            log(line);
-          }
+    return defer(() => this.runPipeline$(log)).pipe(
+      tap(() => {
+        if (this.serial.isConnected()) {
+          this.lastBootstrappedEpoch = epoch;
+          this.shellReadiness.setReady(true);
         }
-      } catch (error: unknown) {
+      }),
+      map(() => undefined),
+      catchError((error: unknown) => {
         const message =
           error instanceof Error ? error.message : String(error);
-        log(`[コンソール] コマンドが失敗しました: ${message}`);
-        console.warn(`Initial command failed: ${step.command}`, error);
-      }
-    }
-    log('[コンソール] タイムゾーン関連の初期化が完了しました。');
+        log(`[コンソール] 接続後の初期化に失敗しました: ${message}`);
+        return throwError(() => error);
+      }),
+    );
+  }
+
+  /**
+   * 接続セッションごとに1回、シェル到達（必要ならログイン）と接続直後の初期化を行う。
+   * @deprecated Prefer {@link PiZeroSerialBootstrapService.runAfterConnect$}.
+   */
+  async runAfterConnect(onStatus?: PiZeroBootstrapStatusHandler): Promise<void> {
+    await firstValueFrom(
+      this.runAfterConnect$(onStatus).pipe(defaultIfEmpty(undefined)),
+    );
+  }
+
+  private runPipeline$(log: PiZeroBootstrapStatusHandler): Observable<void> {
+    const client = createConnectClient();
+
+    return this.serial.readUntilPrompt$({
+      prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+      timeout: SERIAL_TIMEOUT.SHORT,
+    }).pipe(
+      map(() => true),
+      catchError(() => of(false)),
+      switchMap((atShell) =>
+        atShell ? of(undefined) : this.loginSequence$(log),
+      ),
+      switchMap(() => this.timezoneSequence$(log, client)),
+    );
+  }
+
+  private loginSequence$(log: PiZeroBootstrapStatusHandler): Observable<void> {
+    log('[コンソール] ログイン画面を検出しました。');
+    return this.serial
+      .readUntilPrompt$({
+        prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
+        timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
+      })
+      .pipe(
+        tap(() => {
+          log(
+            `[コンソール] ログインユーザー「${PI_ZERO_LOGIN_USER}」を送信中...`,
+          );
+        }),
+        switchMap(() =>
+          this.serial.exec$(PI_ZERO_LOGIN_USER, {
+            prompt: PI_ZERO_SERIAL_PASSWORD_LINE_PATTERN,
+            timeout: SERIAL_TIMEOUT.LONG,
+          }),
+        ),
+        tap(() => {
+          log('[コンソール] パスワードを送信中（画面には表示しません）...');
+        }),
+        switchMap(() =>
+          this.serial.exec$(PI_ZERO_LOGIN_PASSWORD, {
+            prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+            timeout: SERIAL_TIMEOUT.LONG,
+          }),
+        ),
+        tap(() => log('[コンソール] ログインが完了しました。')),
+        map(() => undefined),
+      );
+  }
+
+  private timezoneSequence$(
+    log: PiZeroBootstrapStatusHandler,
+    client: ConnectClient,
+  ): Observable<void> {
+    log('[コンソール] タイムゾーン関連の初期化を開始します。');
+    return from(client.timezoneSteps).pipe(
+      concatMap((step) => {
+        log(step.statusMessage);
+        return this.serial
+          .exec$(step.command, {
+            prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+            timeout: SERIAL_TIMEOUT.DEFAULT,
+          })
+          .pipe(
+            tap(({ stdout }) => {
+              const cleaned = sanitizeSerialStdout(
+                typeof stdout === 'string' ? stdout : '',
+                step.command,
+                client.prompt,
+              );
+              for (const line of cleaned.split(/\r?\n/)) {
+                if (line.length > 0) {
+                  log(line);
+                }
+              }
+            }),
+            catchError((error: unknown) => {
+              const message =
+                error instanceof Error ? error.message : String(error);
+              log(`[コンソール] コマンドが失敗しました: ${message}`);
+              console.warn(`Initial command failed: ${step.command}`, error);
+              return of(undefined);
+            }),
+          );
+      }),
+      ignoreElements(),
+      defaultIfEmpty(undefined),
+      tap(() =>
+        log('[コンソール] タイムゾーン関連の初期化が完了しました。'),
+      ),
+      map(() => undefined),
+    );
   }
 }

--- a/libs/web-serial/data-access/src/lib/serial-command.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command.service.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { Observable, Subject } from 'rxjs';
+import { Observable, Subject, firstValueFrom } from 'rxjs';
 import { SerialCommandService } from './serial-command.service';
 import {
   PI_ZERO_PROMPT,
@@ -111,5 +111,30 @@ describe('SerialCommandService', () => {
 
     const result = await execPromise;
     expect(result.stdout).toContain('hi');
+  });
+
+  it('exec$ resolves via firstValueFrom like exec', async () => {
+    const { service, chunks, transport } = createService();
+
+    let releaseWrite: (() => void) | undefined;
+    transport.write = vi.fn(
+      () =>
+        new Observable<void>((subscriber) => {
+          releaseWrite = () => {
+            subscriber.next();
+            subscriber.complete();
+          };
+        })
+    );
+
+    const resultPromise = firstValueFrom(
+      service.exec$('ls', { prompt: PI_ZERO_PROMPT, timeout: 1000, retry: 0 }),
+    );
+
+    releaseWrite?.();
+    chunks.next(`ls\r\noutput\r\n${PI_ZERO_PROMPT}`);
+
+    const result = await resultPromise;
+    expect(result.stdout).toContain(PI_ZERO_PROMPT);
   });
 });

--- a/libs/web-serial/data-access/src/lib/serial-command.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command.service.ts
@@ -1,7 +1,27 @@
 /// <reference types="@types/w3c-web-serial" />
 
 import { Injectable } from '@angular/core';
-import { firstValueFrom, type Subscription } from 'rxjs';
+import {
+  Observable,
+  Subject,
+  Subscription,
+  TimeoutError,
+  catchError,
+  concatMap,
+  defer,
+  EMPTY,
+  filter,
+  finalize,
+  firstValueFrom,
+  map,
+  merge,
+  mergeMap,
+  of,
+  retry,
+  take,
+  throwError,
+  timeout,
+} from 'rxjs';
 import { SerialTransportService } from './serial-transport.service';
 
 /**
@@ -37,23 +57,29 @@ export interface CommandResult {
   providedIn: 'root',
 })
 export class SerialCommandService {
-  private commandSeq = 0;
   private readBuffer = '';
   private readSubscription: Subscription | null = null;
-  private pendingCommands = new Map<
-    string,
-    {
-      resolve: (value: string) => void;
-      reject: (reason: unknown) => void;
-      timeoutId: number;
-      config: CommandExecutionConfig;
-    }
-  >();
+  /** 受信チャンクでバッファが更新されたことを Observable 側の待機に伝える */
+  private readonly bufferNotify$ = new Subject<void>();
+  /** コマンド実行を直列化（複数 exec$ が同時に走らない） */
+  private readonly executionQueue$ = new Subject<Observable<unknown>>();
+  /** cancelAllCommands 用。enqueue 時点の世代と異なれば実行を打ち切る */
+  private generation = 0;
+  private pendingCount = 0;
 
-  constructor(private readonly transport: SerialTransportService) {}
-
-  private nextCommandId(): string {
-    return `cmd-${++this.commandSeq}-${Date.now()}`;
+  constructor(private readonly transport: SerialTransportService) {
+    this.executionQueue$
+      .pipe(
+        concatMap((work) =>
+          work.pipe(
+            catchError((err: unknown) => {
+              console.error('Serial command queue work error:', err);
+              return EMPTY;
+            }),
+          ),
+        ),
+      )
+      .subscribe();
   }
 
   private matchesPrompt(input: string, prompt: string | RegExp): boolean {
@@ -73,7 +99,7 @@ export class SerialCommandService {
     this.readSubscription = this.transport.getReadStream().subscribe({
       next: (chunk) => {
         this.readBuffer += chunk;
-        this.tryResolvePendingFromBuffer();
+        this.bufferNotify$.next();
       },
       error: (err) => console.error('Serial read stream error:', err),
     });
@@ -99,147 +125,197 @@ export class SerialCommandService {
     this.readBuffer = '';
   }
 
-  /** 現在バッファが待機中コマンドのプロンプトに一致すれば解決する */
-  private tryResolvePendingFromBuffer(): string | null {
-    for (const [commandId, command] of this.pendingCommands) {
-      if (this.matchesPrompt(this.readBuffer, command.config.prompt)) {
-        clearTimeout(command.timeoutId);
-        this.pendingCommands.delete(commandId);
-        const stdout = this.readBuffer;
-        command.resolve(stdout);
+  private enqueueCommand$<T>(
+    factory: (enqueuedGen: number) => Observable<T>,
+  ): Observable<T> {
+    return new Observable<T>((subscriber) => {
+      const enqueuedGen = this.generation;
+      this.pendingCount++;
+      this.executionQueue$.next(
+        defer(() => {
+          if (this.generation !== enqueuedGen) {
+            return throwError(() => new Error('All commands cancelled'));
+          }
+          return factory(enqueuedGen);
+        }).pipe(
+          finalize(() => {
+            this.pendingCount--;
+          }),
+          mergeMap((value) => {
+            subscriber.next(value as T);
+            subscriber.complete();
+            return EMPTY;
+          }),
+          catchError((err: unknown) => {
+            subscriber.error(err);
+            return EMPTY;
+          }),
+        ),
+      );
+    });
+  }
+
+  private waitForPromptMatch$(
+    config: CommandExecutionConfig,
+    enqueuedGen: number,
+  ): Observable<string> {
+    return merge(of(undefined), this.bufferNotify$).pipe(
+      map(() => {
+        if (this.generation !== enqueuedGen) {
+          throw new Error('All commands cancelled');
+        }
+        return this.readBuffer;
+      }),
+      filter((buf) => this.matchesPrompt(buf, config.prompt)),
+      take(1),
+      map((buf) => {
+        const stdout = buf;
         this.readBuffer = '';
         return stdout;
+      }),
+      timeout({ first: config.timeout }),
+      catchError((err: unknown) => {
+        if (err instanceof TimeoutError) {
+          return throwError(() => new Error('Command execution timeout'));
+        }
+        return throwError(() => err);
+      }),
+    );
+  }
+
+  private buildExecPipeline$(
+    sendData: string,
+    config: CommandExecutionConfig,
+    enqueuedGen: number,
+    onAttemptStart?: () => void,
+  ): Observable<CommandResult> {
+    const retryCount = config.retry ?? 0;
+    const attempt$ = defer(() => {
+      if (this.generation !== enqueuedGen) {
+        return throwError(() => new Error('All commands cancelled'));
       }
-    }
-    return null;
+      onAttemptStart?.();
+      this.clearReadBuffer();
+      return this.transport.write(sendData).pipe(
+        mergeMap(() => this.waitForPromptMatch$(config, enqueuedGen)),
+        map((stdout) => ({ stdout })),
+      );
+    });
+    return attempt$.pipe(retry({ count: retryCount }));
+  }
+
+  private buildReadUntilPromptPipeline$(
+    config: CommandExecutionConfig,
+    enqueuedGen: number,
+    onAttemptStart?: () => void,
+  ): Observable<CommandResult> {
+    const retryCount = config.retry ?? 0;
+    const attempt$ = defer(() => {
+      if (this.generation !== enqueuedGen) {
+        return throwError(() => new Error('All commands cancelled'));
+      }
+      onAttemptStart?.();
+      if (this.matchesPrompt(this.readBuffer, config.prompt)) {
+        const stdout = this.readBuffer;
+        this.readBuffer = '';
+        return of<CommandResult>({ stdout });
+      }
+      return this.waitForPromptMatch$(config, enqueuedGen).pipe(
+        map((stdout) => ({ stdout })),
+      );
+    });
+    return attempt$.pipe(retry({ count: retryCount }));
   }
 
   /**
    * コマンド実行（stdin に `cmd + '\n'` を送信し、prompt まで待機）
    */
-  async exec(
+  exec$(
     cmd: string,
     config: CommandExecutionConfig,
-    onAttemptStart?: () => void
-  ): Promise<CommandResult> {
-    return this.execInternal(cmd + '\n', config, onAttemptStart);
+    onAttemptStart?: () => void,
+  ): Observable<CommandResult> {
+    return this.enqueueCommand$((enqueuedGen) =>
+      this.buildExecPipeline$(cmd + '\n', config, enqueuedGen, onAttemptStart),
+    );
   }
 
   /**
    * raw コマンド実行（stdin に `cmdRaw` をそのまま送信）
    */
-  async execRaw(
+  execRaw$(
     cmdRaw: string,
     config: CommandExecutionConfig,
-    onAttemptStart?: () => void
-  ): Promise<CommandResult> {
-    return this.execInternal(cmdRaw, config, onAttemptStart);
+    onAttemptStart?: () => void,
+  ): Observable<CommandResult> {
+    return this.enqueueCommand$((enqueuedGen) =>
+      this.buildExecPipeline$(cmdRaw, config, enqueuedGen, onAttemptStart),
+    );
   }
 
   /**
    * 読み取りのみ（送信せず prompt まで待機）
    */
+  readUntilPrompt$(
+    config: CommandExecutionConfig,
+    onAttemptStart?: () => void,
+  ): Observable<CommandResult> {
+    return this.enqueueCommand$((enqueuedGen) =>
+      this.buildReadUntilPromptPipeline$(
+        config,
+        enqueuedGen,
+        onAttemptStart,
+      ),
+    );
+  }
+
+  /**
+   * コマンド実行（stdin に `cmd + '\n'` を送信し、prompt まで待機）
+   * @deprecated Prefer {@link SerialCommandService.exec$} for reactive pipelines.
+   */
+  async exec(
+    cmd: string,
+    config: CommandExecutionConfig,
+    onAttemptStart?: () => void,
+  ): Promise<CommandResult> {
+    return firstValueFrom(this.exec$(cmd, config, onAttemptStart));
+  }
+
+  /**
+   * raw コマンド実行（stdin に `cmdRaw` をそのまま送信）
+   * @deprecated Prefer {@link SerialCommandService.execRaw$}.
+   */
+  async execRaw(
+    cmdRaw: string,
+    config: CommandExecutionConfig,
+    onAttemptStart?: () => void,
+  ): Promise<CommandResult> {
+    return firstValueFrom(this.execRaw$(cmdRaw, config, onAttemptStart));
+  }
+
+  /**
+   * 読み取りのみ（送信せず prompt まで待機）
+   * @deprecated Prefer {@link SerialCommandService.readUntilPrompt$}.
+   */
   async readUntilPrompt(
     config: CommandExecutionConfig,
-    onAttemptStart?: () => void
+    onAttemptStart?: () => void,
   ): Promise<CommandResult> {
-    const retry = config.retry ?? 0;
-    let lastError: unknown;
-
-    for (let attempt = 0; attempt <= retry; attempt++) {
-      onAttemptStart?.();
-      // Keep readBuffer: login/boot lines may already be present after a prior
-      // readUntilPrompt timeout (shell probe → login: wait).
-
-      const { id, promise } = this.registerWait(config);
-      this.tryResolvePendingFromBuffer();
-      try {
-        const stdout = await promise;
-        return { stdout };
-      } catch (error: unknown) {
-        lastError = error;
-        if (attempt === retry) {
-          throw error;
-        }
-      } finally {
-        this.cancelCommand(id);
-      }
-    }
-
-    throw lastError ?? new Error('readUntilPrompt failed');
+    return firstValueFrom(this.readUntilPrompt$(config, onAttemptStart));
   }
 
-  private async execInternal(
-    sendData: string,
-    config: CommandExecutionConfig,
-    onAttemptStart?: () => void
-  ): Promise<CommandResult> {
-    const retry = config.retry ?? 0;
-    let lastError: unknown;
-
-    for (let attempt = 0; attempt <= retry; attempt++) {
-      onAttemptStart?.();
-      this.clearReadBuffer();
-
-      const { id, promise } = this.registerWait(config);
-      try {
-        await firstValueFrom(this.transport.write(sendData));
-        const stdout = await promise;
-        return { stdout };
-      } catch (error: unknown) {
-        lastError = error;
-        this.cancelCommand(id);
-        void promise.catch(() => undefined);
-        if (attempt === retry) {
-          throw error;
-        }
-      }
-    }
-
-    throw lastError ?? new Error('exec failed');
-  }
-
-  private registerWait(
-    config: CommandExecutionConfig
-  ): { id: string; promise: Promise<string> } {
-    const id = this.nextCommandId();
-
-    return {
-      id,
-      promise: new Promise((resolve, reject) => {
-        const timeoutId = setTimeout(() => {
-          this.pendingCommands.delete(id);
-          reject(new Error('Command execution timeout'));
-        }, config.timeout) as unknown as number;
-
-        this.pendingCommands.set(id, {
-          resolve,
-          reject,
-          timeoutId,
-          config,
-        });
-      }),
-    };
-  }
-
+  /**
+   * 単一の待機 ID によるキャンセルはサポートしない（世代ベースの cancelAllCommands を利用）。
+   */
   cancelCommand(commandId: string): void {
-    const command = this.pendingCommands.get(commandId);
-    if (command) {
-      clearTimeout(command.timeoutId);
-      command.reject(new Error('Command cancelled'));
-      this.pendingCommands.delete(commandId);
-    }
+    void commandId;
   }
 
   cancelAllCommands(): void {
-    for (const [, command] of this.pendingCommands) {
-      clearTimeout(command.timeoutId);
-      command.reject(new Error('All commands cancelled'));
-    }
-    this.pendingCommands.clear();
+    this.generation++;
   }
 
   getPendingCommandCount(): number {
-    return this.pendingCommands.size;
+    return this.pendingCount;
   }
 }

--- a/libs/web-serial/data-access/src/lib/serial-facade.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-facade.service.ts
@@ -168,40 +168,70 @@ export class SerialFacadeService {
   /**
    * コマンド実行（stdout 相当を返す）
    */
-  async exec(cmd: string, options: SerialExecOptions): Promise<CommandResult> {
+  exec$(
+    cmd: string,
+    options: SerialExecOptions,
+  ): Observable<CommandResult> {
     const {
       prompt,
       timeout = SERIAL_TIMEOUT.DEFAULT,
       retry = 0,
     } = options;
-    return this.command.exec(cmd, { prompt, timeout, retry });
+    return this.command.exec$(cmd, { prompt, timeout, retry });
   }
 
   /**
    * raw コマンド実行（改行制御が必要なケース向け）
    */
-  async execRaw(
+  execRaw$(
     cmdRaw: string,
     options: SerialExecOptions,
-  ): Promise<CommandResult> {
+  ): Observable<CommandResult> {
     const {
       prompt,
       timeout = SERIAL_TIMEOUT.DEFAULT,
       retry = 0,
     } = options;
-    return this.command.execRaw(cmdRaw, { prompt, timeout, retry });
+    return this.command.execRaw$(cmdRaw, { prompt, timeout, retry });
   }
 
   /**
    * 送信せずに prompt まで待機
    */
-  async readUntilPrompt(options: SerialExecOptions): Promise<CommandResult> {
+  readUntilPrompt$(options: SerialExecOptions): Observable<CommandResult> {
     const {
       prompt,
       timeout = SERIAL_TIMEOUT.DEFAULT,
       retry = 0,
     } = options;
-    return this.command.readUntilPrompt({ prompt, timeout, retry });
+    return this.command.readUntilPrompt$({ prompt, timeout, retry });
+  }
+
+  /**
+   * コマンド実行（stdout 相当を返す）
+   * @deprecated Prefer {@link SerialFacadeService.exec$}.
+   */
+  async exec(cmd: string, options: SerialExecOptions): Promise<CommandResult> {
+    return firstValueFrom(this.exec$(cmd, options));
+  }
+
+  /**
+   * raw コマンド実行（改行制御が必要なケース向け）
+   * @deprecated Prefer {@link SerialFacadeService.execRaw$}.
+   */
+  async execRaw(
+    cmdRaw: string,
+    options: SerialExecOptions,
+  ): Promise<CommandResult> {
+    return firstValueFrom(this.execRaw$(cmdRaw, options));
+  }
+
+  /**
+   * 送信せずに prompt まで待機
+   * @deprecated Prefer {@link SerialFacadeService.readUntilPrompt$}.
+   */
+  async readUntilPrompt(options: SerialExecOptions): Promise<CommandResult> {
+    return firstValueFrom(this.readUntilPrompt$(options));
   }
 
   /** 現在のシリアル接続セッション番号（切断後も値は保持され、次回接続で増える） */


### PR DESCRIPTION
## Summary

Web Serial のコマンド実行を Observable ファーストにし、[Issue #522](https://github.com/gurezo/chirimen-lite-console/issues/522) の方針（`@gurezo/web-serial-rxjs` の RxJS モデルとの整合）に沿って `libs/web-serial/data-access` を中心に改修した。既存の Promise / async API は後方互換のため残し、`firstValueFrom` で Observable 実装に委譲している。

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #522

## What changed?

- `SerialCommandService` に `exec$` / `execRaw$` / `readUntilPrompt$` を追加（内部キュー・`bufferNotify$`・`timeout` / `retry`）。Promise 版は `@deprecated` とし `firstValueFrom` 委譲。
- `SerialFacadeService` に同名の `$` メソッドを追加し、既存 async メソッドは Observable 版へ委譲（`@deprecated`）。
- `PiZeroSerialBootstrapService` に `runAfterConnect$` を追加し、ブートストラップを RxJS パイプライン化。`runAfterConnect` は `firstValueFrom` 委譲（`@deprecated`）。
- `TerminalViewComponent` で `runAfterConnect$` と `takeUntilDestroyed` を利用し購読ライフサイクルを明示化。
- `I2cdetectService` に `detectI2cDevices$` を追加し、既存 `detectI2cDevices` は `firstValueFrom` 委譲。

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - Details: 各所に Observable 系メソッドを追加。既存の公開 async メソッドは維持（非推奨マークのみ）。
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `npx nx run libs-web-serial-data-access:test`
2. `npx nx run libs-terminal-ui:test`
3. 実機またはモックでシリアル接続後、ターミナル初期化（ブートストラップ）と `i2cdetect` 相当のコマンドが従来どおり動くことを確認

## Environment (if relevant)

- Browser: Chromium 系（Web Serial 利用時）
- OS: macOS / Windows / Linux
- Node version: （ローカルに合わせて記載）
- pnpm version: （ローカルに合わせて記載）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant