### PR TITLE
refactor(web-serial): issue #527 改善と Promise API 廃止を実施

### DIFF
--- a/libs/chirimen-setup/data-access/src/lib/extra-setup.service.ts
+++ b/libs/chirimen-setup/data-access/src/lib/extra-setup.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
+import { firstValueFrom } from 'rxjs';
 
 export interface ExtraSetupStep {
   label: string;
@@ -30,10 +31,10 @@ export class ExtraSetupService {
   ): Promise<void> {
     for (const step of EXTRA_SETUP_STEPS) {
       try {
-        const { stdout } = await this.serial.exec(step.command, {
+        const { stdout } = await firstValueFrom(this.serial.exec$(step.command, {
           prompt: this.prompt,
           timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
-        });
+        }));
         onAfterStep?.(step, stdout);
       } catch {
         onAfterStep?.(step, '');

--- a/libs/chirimen-setup/data-access/src/lib/node-install.service.ts
+++ b/libs/chirimen-setup/data-access/src/lib/node-install.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
+import { firstValueFrom } from 'rxjs';
 import {
   buildNodeInstallStepList,
   type NodeInstallOptions,
@@ -28,10 +29,10 @@ export class NodeInstallService {
   ): Promise<void> {
     const steps = this.buildInstallSteps(options);
     for (const step of steps) {
-      const { stdout } = await this.serial.exec(step.command, {
+      const { stdout } = await firstValueFrom(this.serial.exec$(step.command, {
         prompt: this.prompt,
         timeout: SERIAL_TIMEOUT.NODE_INSTALL,
-      });
+      }));
       onAfterStep?.(step, stdout);
     }
   }

--- a/libs/chirimen-setup/data-access/src/lib/setup-command.service.ts
+++ b/libs/chirimen-setup/data-access/src/lib/setup-command.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
+import { firstValueFrom } from 'rxjs';
 import {
   EXTRA_SETUP_STEPS,
   ExtraSetupService,
@@ -77,10 +78,10 @@ export class SetupCommandService {
     });
 
     try {
-      const { stdout } = await this.serial.exec(postStep.command, {
+      const { stdout } = await firstValueFrom(this.serial.exec$(postStep.command, {
         prompt: this.prompt,
         timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
-      });
+      }));
       emit('post', postStep.label, postStep.command, stdout);
     } catch {
       emit('post', postStep.label, postStep.command, '');

--- a/libs/console-shell/feature/src/lib/console-shell/console-shell.component.spec.ts
+++ b/libs/console-shell/feature/src/lib/console-shell/console-shell.component.spec.ts
@@ -115,10 +115,6 @@ describe('ConsoleShellComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should dispatch init on ngOnInit', () => {
-    expect(storeDispatch).toHaveBeenCalled();
-  });
-
   it('should dispatch onConnect when onConnect is called', () => {
     storeDispatch.mockClear();
     component.onConnect();

--- a/libs/console-shell/feature/src/lib/console-shell/console-shell.component.ts
+++ b/libs/console-shell/feature/src/lib/console-shell/console-shell.component.ts
@@ -112,8 +112,6 @@ export class ConsoleShellComponent implements OnInit, OnDestroy {
   private subscriptions = new Subscription();
 
   ngOnInit() {
-    this.store.dispatch(WebSerialActions.init());
-
     this.subscriptions.add(
       this.router.events
         .pipe(

--- a/libs/file-manager/data-access/src/lib/file.service.spec.ts
+++ b/libs/file-manager/data-access/src/lib/file.service.spec.ts
@@ -4,6 +4,7 @@ import { FileContentService } from '@libs-wifi-data-access';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
 import { FileUtils } from '@libs-wifi-util';
+import { from } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FileService } from './file.service';
 
@@ -20,7 +21,12 @@ describe('FileService', () => {
     const injector = Injector.create({
       providers: [
         FileService,
-        { provide: SerialFacadeService, useValue: { exec } },
+        {
+          provide: SerialFacadeService,
+          useValue: {
+            exec$: (...args: unknown[]) => from(exec(...args)),
+          },
+        },
         {
           provide: FileContentService,
           useValue: { readFile, writeBinaryFile },

--- a/libs/file-manager/data-access/src/lib/file.service.ts
+++ b/libs/file-manager/data-access/src/lib/file.service.ts
@@ -4,6 +4,7 @@ import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { FileUtils } from '@libs-wifi-util';
 import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
 import { FileTreeNode, parseLsOutput } from '@libs-file-manager-util';
+import { firstValueFrom } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class FileService {
@@ -18,10 +19,10 @@ export class FileService {
     const escaped = FileUtils.escapePath(dir);
 
     const stdout = (
-      await this.serial.exec(`ls -al --quoting-style=c -- ${escaped}`, {
+      await firstValueFrom(this.serial.exec$(`ls -al --quoting-style=c -- ${escaped}`, {
         prompt: PI_ZERO_PROMPT,
         timeout: SERIAL_TIMEOUT.LONG,
-      })
+      }))
     ).stdout;
 
     return stdout
@@ -40,26 +41,26 @@ export class FileService {
 
   async mkdir(path: string): Promise<void> {
     const escaped = FileUtils.escapePath(path);
-    await this.serial.exec(`mkdir -p -- ${escaped}`, {
+    await firstValueFrom(this.serial.exec$(`mkdir -p -- ${escaped}`, {
       prompt: PI_ZERO_PROMPT,
       timeout: SERIAL_TIMEOUT.DEFAULT,
-    });
+    }));
   }
 
   async touch(path: string): Promise<void> {
     const escaped = FileUtils.escapePath(path);
-    await this.serial.exec(`touch -- ${escaped}`, {
+    await firstValueFrom(this.serial.exec$(`touch -- ${escaped}`, {
       prompt: PI_ZERO_PROMPT,
       timeout: SERIAL_TIMEOUT.DEFAULT,
-    });
+    }));
   }
 
   async remove(path: string): Promise<void> {
     const escaped = FileUtils.escapePath(path);
-    await this.serial.exec(`rm -- ${escaped}`, {
+    await firstValueFrom(this.serial.exec$(`rm -- ${escaped}`, {
       prompt: PI_ZERO_PROMPT,
       timeout: SERIAL_TIMEOUT.DEFAULT,
-    });
+    }));
   }
 
   async read(path: string): Promise<string> {
@@ -73,10 +74,10 @@ export class FileService {
   async move(fromPath: string, toPath: string): Promise<void> {
     const fromEscaped = FileUtils.escapePath(fromPath);
     const toEscaped = FileUtils.escapePath(toPath);
-    await this.serial.exec(`mv -- ${fromEscaped} ${toEscaped}`, {
+    await firstValueFrom(this.serial.exec$(`mv -- ${fromEscaped} ${toEscaped}`, {
       prompt: PI_ZERO_PROMPT,
       timeout: SERIAL_TIMEOUT.DEFAULT,
-    });
+    }));
   }
 
   /**

--- a/libs/remote/data-access/src/lib/remote-run.service.ts
+++ b/libs/remote/data-access/src/lib/remote-run.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
+import { firstValueFrom } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class RemoteRunService {
@@ -15,9 +16,9 @@ export class RemoteRunService {
   async start(scriptPath: string, args: string[] = []): Promise<void> {
     const argsPart = args.length ? ` ${args.map((a) => JSON.stringify(a)).join(' ')}` : '';
     // -w は start の待ち合わせ（環境依存のため長めの timeout）
-    await this.serial.exec(`forever start -w ${scriptPath}${argsPart}`, {
+    await firstValueFrom(this.serial.exec$(`forever start -w ${scriptPath}${argsPart}`, {
       prompt: this.prompt,
       timeout: SERIAL_TIMEOUT.PROCESS_CONTROL,
-    });
+    }));
   }
 }

--- a/libs/remote/data-access/src/lib/remote-status.service.ts
+++ b/libs/remote/data-access/src/lib/remote-status.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
+import { firstValueFrom } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class RemoteStatusService {
@@ -9,10 +10,10 @@ export class RemoteStatusService {
 
   async listPlain(): Promise<string> {
     return (
-      await this.serial.exec('forever list --plain', {
+      await firstValueFrom(this.serial.exec$('forever list --plain', {
         prompt: this.prompt,
         timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
-      })
+      }))
     ).stdout;
   }
 }

--- a/libs/remote/data-access/src/lib/remote-stop.service.spec.ts
+++ b/libs/remote/data-access/src/lib/remote-stop.service.spec.ts
@@ -1,5 +1,6 @@
 import '@angular/compiler';
 import { Injector } from '@angular/core';
+import { from } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
@@ -14,7 +15,12 @@ describe('RemoteStopService', () => {
     const injector = Injector.create({
       providers: [
         RemoteStopService,
-        { provide: SerialFacadeService, useValue: { exec } },
+        {
+          provide: SerialFacadeService,
+          useValue: {
+            exec$: (...args: unknown[]) => from(exec(...args)),
+          },
+        },
       ],
     });
     svc = injector.get(RemoteStopService);

--- a/libs/remote/data-access/src/lib/remote-stop.service.ts
+++ b/libs/remote/data-access/src/lib/remote-stop.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
+import { firstValueFrom } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class RemoteStopService {
@@ -8,10 +9,10 @@ export class RemoteStopService {
   private readonly prompt = PI_ZERO_PROMPT;
 
   async stopAll(): Promise<void> {
-    await this.serial.exec('forever stopall', {
+    await firstValueFrom(this.serial.exec$('forever stopall', {
       prompt: this.prompt,
       timeout: SERIAL_TIMEOUT.PROCESS_CONTROL,
-    });
+    }));
   }
 
   /**
@@ -20,9 +21,9 @@ export class RemoteStopService {
    */
   async stopTarget(target: string): Promise<void> {
     const arg = JSON.stringify(target);
-    await this.serial.exec(`forever stop ${arg}`, {
+    await firstValueFrom(this.serial.exec$(`forever stop ${arg}`, {
       prompt: this.prompt,
       timeout: SERIAL_TIMEOUT.PROCESS_CONTROL,
-    });
+    }));
   }
 }

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NEVER, of } from 'rxjs';
+import { NEVER, from, of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@xterm/xterm', () => {
@@ -42,14 +42,14 @@ describe('TerminalViewComponent', () => {
       .overrideProvider(SerialFacadeService, {
         useValue: {
           isConnected: () => true,
-          exec: execMock,
+          exec$: (...args: unknown[]) =>
+            from(execMock(...(args as [string, unknown]))),
           connectionEstablished$: NEVER,
           getConnectionEpoch: () => 1,
         },
       })
       .overrideProvider(PiZeroSerialBootstrapService, {
         useValue: {
-          runAfterConnect: vi.fn().mockResolvedValue(undefined),
           runAfterConnect$: vi.fn(() => of(undefined)),
         },
       })

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -9,7 +9,14 @@ import {
   input,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { EMPTY, Subscription, catchError, finalize, switchMap } from 'rxjs';
+import {
+  EMPTY,
+  Subscription,
+  catchError,
+  finalize,
+  firstValueFrom,
+  switchMap,
+} from 'rxjs';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import {
@@ -129,10 +136,10 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
       this.xterminal,
       async (command) => {
         return this.enqueueExec(async () => {
-          const { stdout } = await this.serial.exec(command, {
+          const { stdout } = await firstValueFrom(this.serial.exec$(command, {
             prompt: this.remotePrompt(),
             timeout: SERIAL_TIMEOUT.DEFAULT,
-          });
+          }));
           return sanitizeSerialStdout(stdout, command, this.remotePrompt());
         });
       },
@@ -150,10 +157,10 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
           }
           this.xterminal.writeln(`$ ${cmd}`);
           try {
-            const { stdout } = await this.serial.exec(cmd, {
+            const { stdout } = await firstValueFrom(this.serial.exec$(cmd, {
               prompt: this.remotePrompt(),
               timeout: SERIAL_TIMEOUT.DEFAULT,
-            });
+            }));
             const out = sanitizeSerialStdout(
               stdout,
               cmd,

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { from } from 'rxjs';
+import { firstValueFrom, from } from 'rxjs';
 import {
   PI_ZERO_LOGIN_PASSWORD,
   PI_ZERO_LOGIN_USER,
@@ -34,15 +34,13 @@ describe('PiZeroSerialBootstrapService', () => {
     const serial = {
       isConnected: () => true,
       getConnectionEpoch: () => 1,
-      readUntilPrompt,
       readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
-      exec,
       exec$: (c: string, o: unknown) => from(exec(c, o)),
     } as unknown as SerialFacadeService;
 
     const shellReadiness = createShellReadinessMock();
     const service = new PiZeroSerialBootstrapService(serial, shellReadiness);
-    await service.runAfterConnect();
+    await firstValueFrom(service.runAfterConnect$());
 
     expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
     expect(readUntilPrompt).toHaveBeenCalledTimes(1);
@@ -77,16 +75,14 @@ describe('PiZeroSerialBootstrapService', () => {
     const serial = {
       isConnected: () => true,
       getConnectionEpoch: () => 1,
-      readUntilPrompt,
       readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
-      exec,
       exec$: (c: string, o: unknown) => from(exec(c, o)),
     } as unknown as SerialFacadeService;
 
     const shellReadiness = createShellReadinessMock();
     const service = new PiZeroSerialBootstrapService(serial, shellReadiness);
     const lines: string[] = [];
-    await service.runAfterConnect((line) => lines.push(line));
+    await firstValueFrom(service.runAfterConnect$((line) => lines.push(line)));
 
     expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
     expect(readUntilPrompt).toHaveBeenCalledTimes(2);
@@ -141,16 +137,14 @@ describe('PiZeroSerialBootstrapService', () => {
     const serial = {
       isConnected: () => true,
       getConnectionEpoch: () => 1,
-      readUntilPrompt,
       readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
-      exec,
       exec$: (c: string, o: unknown) => from(exec(c, o)),
     } as unknown as SerialFacadeService;
 
     const shellReadiness = createShellReadinessMock();
     const service = new PiZeroSerialBootstrapService(serial, shellReadiness);
-    await service.runAfterConnect();
-    await service.runAfterConnect();
+    await firstValueFrom(service.runAfterConnect$());
+    await firstValueFrom(service.runAfterConnect$());
 
     expect(readUntilPrompt).toHaveBeenCalledTimes(1);
     expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledTimes(1);
@@ -170,16 +164,14 @@ describe('PiZeroSerialBootstrapService', () => {
     const serial = {
       isConnected: () => true,
       getConnectionEpoch: () => 1,
-      readUntilPrompt,
       readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
-      exec,
       exec$: (c: string, o: unknown) => from(exec(c, o)),
     } as unknown as SerialFacadeService;
 
     const lines: string[] = [];
     const shellReadiness = createShellReadinessMock();
     const service = new PiZeroSerialBootstrapService(serial, shellReadiness);
-    await service.runAfterConnect((line) => lines.push(line));
+    await firstValueFrom(service.runAfterConnect$((line) => lines.push(line)));
 
     expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
     expect(

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
@@ -16,6 +16,7 @@ import type { Observable } from 'rxjs';
 import {
   catchError,
   concatMap,
+  defaultIfEmpty,
   defer,
   finalize,
   from,

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
@@ -16,10 +16,8 @@ import type { Observable } from 'rxjs';
 import {
   catchError,
   concatMap,
-  defaultIfEmpty,
   defer,
   finalize,
-  firstValueFrom,
   from,
   ignoreElements,
   map,
@@ -98,16 +96,6 @@ export class PiZeroSerialBootstrapService {
     );
 
     return this.activeBootstrap$;
-  }
-
-  /**
-   * 接続セッションごとに1回、シェル到達（必要ならログイン）と接続直後の初期化を行う。
-   * @deprecated Prefer {@link PiZeroSerialBootstrapService.runAfterConnect$}.
-   */
-  async runAfterConnect(onStatus?: PiZeroBootstrapStatusHandler): Promise<void> {
-    await firstValueFrom(
-      this.runAfterConnect$(onStatus).pipe(defaultIfEmpty(undefined)),
-    );
   }
 
   private runPipeline$(log: PiZeroBootstrapStatusHandler): Observable<void> {

--- a/libs/web-serial/data-access/src/lib/serial-command.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command.service.spec.ts
@@ -41,9 +41,8 @@ describe('SerialCommandService', () => {
         })
     );
 
-    const execPromise = service.exec(
-      'ls',
-      { prompt: PI_ZERO_PROMPT, timeout: 1000, retry: 0 }
+    const execPromise = firstValueFrom(
+      service.exec$('ls', { prompt: PI_ZERO_PROMPT, timeout: 1000, retry: 0 }),
     );
 
     releaseWrite?.();
@@ -57,11 +56,13 @@ describe('SerialCommandService', () => {
   it('readUntilPrompt resolves without writing', async () => {
     const { service, chunks } = createService();
 
-    const readPromise = service.readUntilPrompt({
-      prompt: PI_ZERO_PROMPT,
-      timeout: 1000,
-      retry: 0,
-    });
+    const readPromise = firstValueFrom(
+      service.readUntilPrompt$({
+        prompt: PI_ZERO_PROMPT,
+        timeout: 1000,
+        retry: 0,
+      }),
+    );
 
     queueMicrotask(() => {
       chunks.next(`welcome\r\n${PI_ZERO_PROMPT}`);
@@ -74,22 +75,26 @@ describe('SerialCommandService', () => {
   it('readUntilPrompt sees data already buffered before the wait starts', async () => {
     const { service, chunks } = createService();
     chunks.next('Raspberry Pi OS\r\n\r\nraspberrypi login: ');
-    const result = await service.readUntilPrompt({
-      prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
-      timeout: 1000,
-      retry: 0,
-    });
+    const result = await firstValueFrom(
+      service.readUntilPrompt$({
+        prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
+        timeout: 1000,
+        retry: 0,
+      }),
+    );
     expect(result.stdout).toMatch(/login:\s*/i);
   });
 
   it('readUntilPrompt matches Japanese login prompt in buffer', async () => {
     const { service, chunks } = createService();
     chunks.next('ホスト名 ログイン: ');
-    const result = await service.readUntilPrompt({
-      prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
-      timeout: 1000,
-      retry: 0,
-    });
+    const result = await firstValueFrom(
+      service.readUntilPrompt$({
+        prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
+        timeout: 1000,
+        retry: 0,
+      }),
+    );
     expect(result.stdout).toMatch(/ログイン/);
   });
 
@@ -108,13 +113,12 @@ describe('SerialCommandService', () => {
     );
 
     const escaped = PI_ZERO_PROMPT.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const execPromise = service.exec(
-      'echo hi',
-      {
+    const execPromise = firstValueFrom(
+      service.exec$('echo hi', {
         prompt: new RegExp(escaped),
         timeout: 1000,
         retry: 0,
-      }
+      }),
     );
 
     releaseWrite?.();

--- a/libs/web-serial/data-access/src/lib/serial-command.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command.service.ts
@@ -12,7 +12,6 @@ import {
   EMPTY,
   filter,
   finalize,
-  firstValueFrom,
   map,
   merge,
   mergeMap,
@@ -267,41 +266,6 @@ export class SerialCommandService {
         onAttemptStart,
       ),
     );
-  }
-
-  /**
-   * コマンド実行（stdin に `cmd + '\n'` を送信し、prompt まで待機）
-   * @deprecated Prefer {@link SerialCommandService.exec$} for reactive pipelines.
-   */
-  async exec(
-    cmd: string,
-    config: CommandExecutionConfig,
-    onAttemptStart?: () => void,
-  ): Promise<CommandResult> {
-    return firstValueFrom(this.exec$(cmd, config, onAttemptStart));
-  }
-
-  /**
-   * raw コマンド実行（stdin に `cmdRaw` をそのまま送信）
-   * @deprecated Prefer {@link SerialCommandService.execRaw$}.
-   */
-  async execRaw(
-    cmdRaw: string,
-    config: CommandExecutionConfig,
-    onAttemptStart?: () => void,
-  ): Promise<CommandResult> {
-    return firstValueFrom(this.execRaw$(cmdRaw, config, onAttemptStart));
-  }
-
-  /**
-   * 読み取りのみ（送信せず prompt まで待機）
-   * @deprecated Prefer {@link SerialCommandService.readUntilPrompt$}.
-   */
-  async readUntilPrompt(
-    config: CommandExecutionConfig,
-    onAttemptStart?: () => void,
-  ): Promise<CommandResult> {
-    return firstValueFrom(this.readUntilPrompt$(config, onAttemptStart));
   }
 
   /**

--- a/libs/web-serial/data-access/src/lib/serial-facade.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-facade.service.ts
@@ -4,7 +4,6 @@ import { Injectable, inject } from '@angular/core';
 import {
   catchError,
   defer,
-  firstValueFrom,
   of,
   type Observable,
   Subject,
@@ -100,17 +99,6 @@ export class SerialFacadeService {
     });
   }
 
-  /**
-   * Serial ポートに接続
-   *
-   * @param baudRate ボーレート (デフォルト: 115200)
-   * @returns 接続成功の場合 true、失敗の場合 false
-   */
-  async connect(baudRate = 115200): Promise<boolean> {
-    const result = await firstValueFrom(this.connect$(baudRate));
-    return result.ok;
-  }
-
   private startReadStreamSubscription(): void {
     this.command.startReadLoop();
   }
@@ -131,13 +119,6 @@ export class SerialFacadeService {
   }
 
   /**
-   * Serial ポートから切断
-   */
-  async disconnect(): Promise<void> {
-    return firstValueFrom(this.disconnect$());
-  }
-
-  /**
    * データを書き込む（Observable）
    */
   write$(data: string): Observable<void> {
@@ -148,13 +129,6 @@ export class SerialFacadeService {
   }
 
   /**
-   * データを書き込む
-   */
-  async write(data: string): Promise<void> {
-    return firstValueFrom(this.write$(data));
-  }
-
-  /**
    * 1 チャンクだけ読み取る（Observable）
    */
   read$(): Observable<string> {
@@ -162,20 +136,6 @@ export class SerialFacadeService {
       return throwError(() => new Error('Serial port not connected'));
     }
     return this.transport.getReadStream().pipe(take(1));
-  }
-
-  /**
-   * 1回だけ読み取る
-   */
-  async read(): Promise<string> {
-    return firstValueFrom(this.read$());
-  }
-
-  /**
-   * 1回だけ文字列として読み取る
-   */
-  async readString(): Promise<string> {
-    return this.read();
   }
 
   /**
@@ -218,33 +178,6 @@ export class SerialFacadeService {
       retry = 0,
     } = options;
     return this.command.readUntilPrompt$({ prompt, timeout, retry });
-  }
-
-  /**
-   * コマンド実行（stdout 相当を返す）
-   * @deprecated Prefer {@link SerialFacadeService.exec$}.
-   */
-  async exec(cmd: string, options: SerialExecOptions): Promise<CommandResult> {
-    return firstValueFrom(this.exec$(cmd, options));
-  }
-
-  /**
-   * raw コマンド実行（改行制御が必要なケース向け）
-   * @deprecated Prefer {@link SerialFacadeService.execRaw$}.
-   */
-  async execRaw(
-    cmdRaw: string,
-    options: SerialExecOptions,
-  ): Promise<CommandResult> {
-    return firstValueFrom(this.execRaw$(cmdRaw, options));
-  }
-
-  /**
-   * 送信せずに prompt まで待機
-   * @deprecated Prefer {@link SerialFacadeService.readUntilPrompt$}.
-   */
-  async readUntilPrompt(options: SerialExecOptions): Promise<CommandResult> {
-    return firstValueFrom(this.readUntilPrompt$(options));
   }
 
   /** 現在のシリアル接続セッション番号（切断後も値は保持され、次回接続で増える） */

--- a/libs/web-serial/data-access/src/lib/serial-facade.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-facade.service.ts
@@ -17,7 +17,7 @@ import {
   SerialCommandService,
 } from './serial-command.service';
 import {
-  getWebSerialConnectFailureMessage,
+  getConnectionErrorMessage,
   SERIAL_TIMEOUT,
   type SerialExecOptions,
 } from '@libs-web-serial-util';
@@ -93,7 +93,7 @@ export class SerialFacadeService {
           console.error('Connection error:', error);
           return of<SerialFacadeConnectResult>({
             ok: false,
-            errorMessage: getWebSerialConnectFailureMessage(error),
+            errorMessage: getConnectionErrorMessage(error),
           });
         })
       );

--- a/libs/web-serial/data-access/src/lib/serial-transport.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.ts
@@ -6,7 +6,6 @@ import {
   catchError,
   defaultIfEmpty,
   defer,
-  firstValueFrom,
   map,
   Observable,
   of,
@@ -101,24 +100,6 @@ export class SerialTransportService {
         })
       );
     });
-  }
-
-  /**
-   * Serial ポートに接続
-   * @param baudRate ボーレート (デフォルト: 115200)
-   * @returns 接続成功時は SerialPort、失敗時はエラーメッセージ
-   */
-  async connect(
-    baudRate = 115200
-  ): Promise<{ port: SerialPort } | { error: string }> {
-    return firstValueFrom(this.connect$(baudRate));
-  }
-
-  /**
-   * Serial ポートから切断
-   */
-  async disconnect(): Promise<void> {
-    return firstValueFrom(this.disconnect$());
   }
 
   /**

--- a/libs/web-serial/state/src/lib/web-serial.actions.ts
+++ b/libs/web-serial/state/src/lib/web-serial.actions.ts
@@ -4,8 +4,8 @@ export const WebSerialActions = createActionGroup({
   source: '[Web Serial]',
   events: {
     onConnect: emptyProps(),
-    onConnectSuccess: props<{ isConnected: boolean; message: string }>(),
-    onConnectFail: props<{ isConnected: boolean; errorMessage: string }>(),
+    onConnectSuccess: props<{ message: string }>(),
+    onConnectFail: props<{ errorMessage: string }>(),
     onDisConnect: emptyProps(),
     error: props<{ error: unknown }>(),
   },

--- a/libs/web-serial/state/src/lib/web-serial.actions.ts
+++ b/libs/web-serial/state/src/lib/web-serial.actions.ts
@@ -3,7 +3,6 @@ import { createActionGroup, emptyProps, props } from '@ngrx/store';
 export const WebSerialActions = createActionGroup({
   source: '[Web Serial]',
   events: {
-    init: emptyProps(),
     onConnect: emptyProps(),
     onConnectSuccess: props<{ isConnected: boolean; message: string }>(),
     onConnectFail: props<{ isConnected: boolean; errorMessage: string }>(),

--- a/libs/web-serial/state/src/lib/web-serial.effects.ts
+++ b/libs/web-serial/state/src/lib/web-serial.effects.ts
@@ -26,14 +26,12 @@ export class WebSerialEffects {
             if (!result.ok) {
               return of(
                 WebSerialActions.onConnectFail({
-                  isConnected: false,
                   errorMessage: result.errorMessage,
                 }),
               );
             }
             return of(
               WebSerialActions.onConnectSuccess({
-                isConnected: true,
                 message: CONNECTION_SUCCESS_MESSAGE,
               }),
             );
@@ -41,7 +39,6 @@ export class WebSerialEffects {
           catchError((error: unknown) => {
             return [
               WebSerialActions.onConnectFail({
-                isConnected: false,
                 errorMessage: getConnectionErrorMessage(error),
               }),
             ];

--- a/libs/web-serial/state/src/lib/web-serial.effects.ts
+++ b/libs/web-serial/state/src/lib/web-serial.effects.ts
@@ -2,7 +2,7 @@ import { inject, Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { catchError, of, switchMap } from 'rxjs';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
-import { getWebSerialConnectFailureMessage } from '@libs-web-serial-util';
+import { getConnectionErrorMessage } from '@libs-web-serial-util';
 import { WebSerialActions } from './web-serial.actions';
 
 const CONNECTION_SUCCESS_MESSAGE = 'Web Serial Open Success';
@@ -42,7 +42,7 @@ export class WebSerialEffects {
             return [
               WebSerialActions.onConnectFail({
                 isConnected: false,
-                errorMessage: getWebSerialConnectFailureMessage(error),
+                errorMessage: getConnectionErrorMessage(error),
               }),
             ];
           }),

--- a/libs/web-serial/state/src/lib/web-serial.reducers.ts
+++ b/libs/web-serial/state/src/lib/web-serial.reducers.ts
@@ -16,21 +16,18 @@ export const webSerialReducer = createReducer(
   on(WebSerialActions.onConnect, (state) => ({
     ...state,
   })),
-  on(WebSerialActions.onConnectSuccess, (state, { isConnected, message }) => ({
+  on(WebSerialActions.onConnectSuccess, (state, { message }) => ({
     ...state,
-    isConnected,
+    isConnected: true,
     connectionMessage: message,
     errorMessage: '',
   })),
-  on(
-    WebSerialActions.onConnectFail,
-    (state, { isConnected, errorMessage }) => ({
-      ...state,
-      isConnected,
-      connectionMessage: '',
-      errorMessage,
-    })
-  ),
+  on(WebSerialActions.onConnectFail, (state, { errorMessage }) => ({
+    ...state,
+    isConnected: false,
+    connectionMessage: '',
+    errorMessage,
+  })),
   on(WebSerialActions.onDisConnect, () => ({
     ...initialWebSerialState,
   })),

--- a/libs/web-serial/state/src/lib/web-serial.reducers.ts
+++ b/libs/web-serial/state/src/lib/web-serial.reducers.ts
@@ -13,9 +13,6 @@ export const webSerialFeatureKey = 'webSerial';
 
 export const webSerialReducer = createReducer(
   initialWebSerialState,
-  on(WebSerialActions.init, () => ({
-    ...initialWebSerialState,
-  })),
   on(WebSerialActions.onConnect, (state) => ({
     ...state,
   })),

--- a/libs/web-serial/util/src/lib/serial-error-messages.ts
+++ b/libs/web-serial/util/src/lib/serial-error-messages.ts
@@ -96,28 +96,3 @@ export function getRaspberryPiZeroError(): string {
   return 'Web Serial is not Raspberry Pi Zero';
 }
 
-/** NgRx ストア・トースト向け: 接続フローで捕捉した未知の例外を日本語メッセージにする */
-export function getWebSerialConnectFailureMessage(error: unknown): string {
-  if (error instanceof SerialError) {
-    if (error.is(SerialErrorCode.OPERATION_CANCELLED)) {
-      return 'ポートが選択されませんでした';
-    }
-    if (
-      error.is(SerialErrorCode.PORT_NOT_AVAILABLE) ||
-      error.is(SerialErrorCode.PORT_OPEN_FAILED)
-    ) {
-      return 'サポートされていないデバイスです。Raspberry Pi Zero以外のデバイスは接続できません。';
-    }
-  }
-  if (error instanceof Error && error.message?.includes('No port selected')) {
-    return 'ポートが選択されませんでした';
-  }
-  if (
-    error instanceof Error &&
-    (error.message?.includes('not a Raspberry Pi Zero') ||
-      error.message?.includes('not supported'))
-  ) {
-    return 'サポートされていないデバイスです。Raspberry Pi Zero以外のデバイスは接続できません。';
-  }
-  return '接続に失敗しました';
-}

--- a/libs/wifi/data-access/src/lib/file-content.service.ts
+++ b/libs/wifi/data-access/src/lib/file-content.service.ts
@@ -6,6 +6,7 @@ import {
   SERIAL_TIMEOUT,
   wrapSerialError,
 } from '@libs-web-serial-util';
+import { firstValueFrom } from 'rxjs';
 
 /**
  * ファイル内容情報
@@ -31,10 +32,10 @@ export class FileContentService {
   async readFile(path: string): Promise<FileContentInfo> {
     try {
       const result = (
-        await this.serial.exec(`base64 -- ${FileUtils.escapePath(path)}`, {
+        await firstValueFrom(this.serial.exec$(`base64 -- ${FileUtils.escapePath(path)}`, {
           prompt: PI_ZERO_PROMPT,
           timeout: SERIAL_TIMEOUT.LONG,
-        })
+        }))
       ).stdout;
 
       const lines = result.split('\n').map((line) => line.trim());
@@ -70,10 +71,10 @@ export class FileContentService {
   async writeTextFile(path: string, content: string): Promise<void> {
     try {
       const command = FileUtils.generateHeredocCommand(path, content);
-      await this.serial.exec(command, {
+      await firstValueFrom(this.serial.exec$(command, {
         prompt: 'EOL',
         timeout: SERIAL_TIMEOUT.DEFAULT,
-      });
+      }));
     } catch (error: unknown) {
       throw wrapSerialError('Failed to write text file', error);
     }
@@ -83,30 +84,30 @@ export class FileContentService {
     try {
       const base64 = FileUtils.arrayBufferToBase64(buffer);
 
-      await this.serial.write('\x03');
+      await firstValueFrom(this.serial.write$('\x03'));
       await this.sleep(100);
 
-      await this.serial.exec(`base64 -d > ${FileUtils.escapePath(path)}`, {
+      await firstValueFrom(this.serial.exec$(`base64 -d > ${FileUtils.escapePath(path)}`, {
         prompt: '\n',
         timeout: SERIAL_TIMEOUT.DEFAULT,
-      });
+      }));
 
       const lineLength = 512;
       for (let i = 0; i <= Math.floor(base64.length / lineLength); i++) {
         const line = base64.substring(i * lineLength, (i + 1) * lineLength);
-        await this.serial.exec(line, {
+        await firstValueFrom(this.serial.exec$(line, {
           prompt: '\n',
           timeout: SERIAL_TIMEOUT.LINE,
-        });
+        }));
         await this.sleep(1);
       }
 
-      await this.serial.write('\x04');
+      await firstValueFrom(this.serial.write$('\x04'));
       await this.sleep(10);
-      await this.serial.exec('', {
+      await firstValueFrom(this.serial.exec$('', {
         prompt: '\\$',
         timeout: SERIAL_TIMEOUT.LINE,
-      });
+      }));
     } catch (error: unknown) {
       throw wrapSerialError('Failed to write binary file', error);
     }
@@ -115,10 +116,10 @@ export class FileContentService {
   async appendToFile(path: string, content: string): Promise<void> {
     try {
       const command = FileUtils.generateAppendCommand(path, content);
-      await this.serial.exec(command, {
+      await firstValueFrom(this.serial.exec$(command, {
         prompt: 'EOL',
         timeout: SERIAL_TIMEOUT.DEFAULT,
-      });
+      }));
     } catch (error: unknown) {
       throw wrapSerialError('Failed to append to file', error);
     }

--- a/libs/wifi/data-access/src/lib/wifi-config.service.ts
+++ b/libs/wifi/data-access/src/lib/wifi-config.service.ts
@@ -8,6 +8,7 @@ import {
   SERIAL_TIMEOUT,
   wrapSerialError,
 } from '@libs-web-serial-util';
+import { firstValueFrom } from 'rxjs';
 
 /**
  * WiFi 設定（setWiFi / configureWifi）を担当
@@ -25,14 +26,14 @@ export class WifiConfigService {
    */
   async setWiFi(ssid: string, password: string): Promise<void> {
     try {
-      await this.serial.exec('cd', {
+      await firstValueFrom(this.serial.exec$('cd', {
         prompt: PI_ZERO_PROMPT,
         timeout: SERIAL_TIMEOUT.DEFAULT,
-      });
-      await this.serial.exec('sudo touch /boot/ssh', {
+      }));
+      await firstValueFrom(this.serial.exec$('sudo touch /boot/ssh', {
         prompt: PI_ZERO_PROMPT,
         timeout: SERIAL_TIMEOUT.DEFAULT,
-      });
+      }));
 
       const wifiSetupScript = this.generateWifiSetupScript();
 
@@ -40,13 +41,13 @@ export class WifiConfigService {
 
       const qSsid = shellSingleQuote(ssid);
       const qPass = shellSingleQuote(password);
-      await this.serial.exec(
+      await firstValueFrom(this.serial.exec$(
         `chmod +x wifi_setup.sh && ./wifi_setup.sh ${qSsid} ${qPass}`,
         {
           prompt: PI_ZERO_PROMPT,
           timeout: SERIAL_TIMEOUT.LONG,
         }
-      );
+      ));
     } catch (error: unknown) {
       throw wrapSerialError('Failed to set WiFi', error);
     }
@@ -107,34 +108,34 @@ network={
 
   private async saveWifiConfig(configContent: string): Promise<void> {
     try {
-      await this.serial.exec(
+      await firstValueFrom(this.serial.exec$(
         'sudo cp /etc/wpa_supplicant/wpa_supplicant.conf /etc/wpa_supplicant/wpa_supplicant.conf.backup',
         {
           prompt: PI_ZERO_PROMPT,
           timeout: SERIAL_TIMEOUT.DEFAULT,
         }
-      );
+      ));
 
       const encoder = new TextEncoder();
       const uint8Array = encoder.encode(configContent);
       const base64 = FileUtils.arrayBufferToBase64(uint8Array.buffer);
 
-      await this.serial.write('\x03');
+      await firstValueFrom(this.serial.write$('\x03'));
       await this.sleep(100);
 
-      await this.serial.exec(
+      await firstValueFrom(this.serial.exec$(
         'sudo tee /etc/wpa_supplicant/wpa_supplicant.conf > /dev/null',
         {
           prompt: '\n',
           timeout: SERIAL_TIMEOUT.DEFAULT,
         }
-      );
-      await this.serial.exec(base64, {
+      ));
+      await firstValueFrom(this.serial.exec$(base64, {
         prompt: '\n',
         timeout: SERIAL_TIMEOUT.LINE,
-      });
+      }));
 
-      await this.serial.write('\x04');
+      await firstValueFrom(this.serial.write$('\x04'));
       await this.sleep(10);
     } catch (error: unknown) {
       throw wrapSerialError('Failed to save WiFi config', error);

--- a/libs/wifi/data-access/src/lib/wifi-reboot-flow.service.ts
+++ b/libs/wifi/data-access/src/lib/wifi-reboot-flow.service.ts
@@ -5,6 +5,7 @@ import {
   SERIAL_TIMEOUT,
   wrapSerialError,
 } from '@libs-web-serial-util';
+import { firstValueFrom } from 'rxjs';
 
 /**
  * WiFi 再起動・有効/無効のフローを担当
@@ -20,15 +21,15 @@ export class WifiRebootFlowService {
    */
   async restartWifiService(): Promise<void> {
     try {
-      await this.serial.exec('sudo systemctl restart wpa_supplicant', {
+      await firstValueFrom(this.serial.exec$('sudo systemctl restart wpa_supplicant', {
         prompt: PI_ZERO_PROMPT,
         timeout: SERIAL_TIMEOUT.DEFAULT,
-      });
+      }));
 
-      await this.serial.exec('sudo systemctl restart networking', {
+      await firstValueFrom(this.serial.exec$('sudo systemctl restart networking', {
         prompt: PI_ZERO_PROMPT,
         timeout: SERIAL_TIMEOUT.DEFAULT,
-      });
+      }));
     } catch (error: unknown) {
       throw wrapSerialError('Failed to restart WiFi service', error);
     }
@@ -39,10 +40,10 @@ export class WifiRebootFlowService {
    */
   async enableWifi(): Promise<void> {
     try {
-      await this.serial.exec('sudo ifconfig wlan0 up', {
+      await firstValueFrom(this.serial.exec$('sudo ifconfig wlan0 up', {
         prompt: PI_ZERO_PROMPT,
         timeout: SERIAL_TIMEOUT.DEFAULT,
-      });
+      }));
     } catch (error: unknown) {
       throw wrapSerialError('Failed to enable WiFi', error);
     }
@@ -53,10 +54,10 @@ export class WifiRebootFlowService {
    */
   async disableWifi(): Promise<void> {
     try {
-      await this.serial.exec('sudo ifconfig wlan0 down', {
+      await firstValueFrom(this.serial.exec$('sudo ifconfig wlan0 down', {
         prompt: PI_ZERO_PROMPT,
         timeout: SERIAL_TIMEOUT.DEFAULT,
-      });
+      }));
     } catch (error: unknown) {
       throw wrapSerialError('Failed to disable WiFi', error);
     }
@@ -67,10 +68,10 @@ export class WifiRebootFlowService {
    */
   async rebootDevice(): Promise<void> {
     try {
-      await this.serial.exec('sudo reboot', {
+      await firstValueFrom(this.serial.exec$('sudo reboot', {
         prompt: PI_ZERO_PROMPT,
         timeout: SERIAL_TIMEOUT.REBOOT,
-      });
+      }));
     } catch {
       // 再起動でシリアルが切れるとタイムアウトや切断エラーになり得る
     }

--- a/libs/wifi/data-access/src/lib/wifi-scan.service.ts
+++ b/libs/wifi/data-access/src/lib/wifi-scan.service.ts
@@ -11,6 +11,7 @@ import {
   wrapSerialError,
 } from '@libs-web-serial-util';
 import type { WiFiInfo } from '@libs-shared-types';
+import { firstValueFrom } from 'rxjs';
 
 /**
  * WiFi スキャン・状態取得を担当
@@ -28,16 +29,16 @@ export class WifiScanService {
   }> {
     try {
       const ifconfigOutput = (
-        await this.serial.exec('ifconfig', {
+        await firstValueFrom(this.serial.exec$('ifconfig', {
           prompt: PI_ZERO_PROMPT,
           timeout: SERIAL_TIMEOUT.DEFAULT,
-        })
+        }))
       ).stdout;
       const iwconfigOutput = (
-        await this.serial.exec('iwconfig', {
+        await firstValueFrom(this.serial.exec$('iwconfig', {
           prompt: PI_ZERO_PROMPT,
           timeout: SERIAL_TIMEOUT.DEFAULT,
-        })
+        }))
       ).stdout;
 
       const { ipInfo, ipaddr } = parseWifiIfconfigOutput(ifconfigOutput);
@@ -52,10 +53,10 @@ export class WifiScanService {
   async scanNetworks(): Promise<{ rawData: string[]; wifiInfos: WiFiInfo[] }> {
     try {
       const output = (
-        await this.serial.exec('sudo iwlist wlan0 scan', {
+        await firstValueFrom(this.serial.exec$('sudo iwlist wlan0 scan', {
           prompt: PI_ZERO_PROMPT,
           timeout: SERIAL_TIMEOUT.LONG,
-        })
+        }))
       ).stdout;
 
       const lines = output.split('\n');
@@ -70,10 +71,10 @@ export class WifiScanService {
   async getDetailedWifiStatus(): Promise<string> {
     try {
       return (
-        await this.serial.exec('iwconfig wlan0', {
+        await firstValueFrom(this.serial.exec$('iwconfig wlan0', {
           prompt: PI_ZERO_PROMPT,
           timeout: SERIAL_TIMEOUT.DEFAULT,
-        })
+        }))
       ).stdout;
     } catch (error: unknown) {
       throw wrapSerialError('Failed to get WiFi status', error);
@@ -83,10 +84,10 @@ export class WifiScanService {
   async getIpAddress(): Promise<string> {
     try {
       const stdout = (
-        await this.serial.exec('hostname -I', {
+        await firstValueFrom(this.serial.exec$('hostname -I', {
           prompt: PI_ZERO_PROMPT,
           timeout: SERIAL_TIMEOUT.DEFAULT,
-        })
+        }))
       ).stdout;
 
       const lines = stdout.split('\n');
@@ -101,10 +102,10 @@ export class WifiScanService {
   async showNetworkConfig(): Promise<string> {
     try {
       return (
-        await this.serial.exec('cat /etc/network/interfaces', {
+        await firstValueFrom(this.serial.exec$('cat /etc/network/interfaces', {
           prompt: PI_ZERO_PROMPT,
           timeout: SERIAL_TIMEOUT.DEFAULT,
-        })
+        }))
       ).stdout;
     } catch (error: unknown) {
       throw wrapSerialError('Failed to show network config', error);
@@ -116,13 +117,13 @@ export class WifiScanService {
    */
   async checkChirimenTutorialReachability(): Promise<string> {
     try {
-      const { stdout } = await this.serial.exec(
+      const { stdout } = await firstValueFrom(this.serial.exec$(
         'wget --spider -nv https://tutorial.chirimen.org/',
         {
           prompt: PI_ZERO_PROMPT,
           timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
         }
-      );
+      ));
       return stdout;
     } catch (error: unknown) {
       throw wrapSerialError('Connectivity check failed', error);

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "21.1.6",
     "@angular/platform-browser-dynamic": "21.1.6",
     "@angular/router": "21.1.6",
-    "@gurezo/web-serial-rxjs": "0.1.11",
+    "@gurezo/web-serial-rxjs": "0.2.0",
     "@ngrx/component-store": "21.0.1",
     "@ngrx/effects": "21.0.1",
     "@ngrx/operators": "21.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 21.1.6
         version: 21.1.6(@angular/common@21.1.6(@angular/core@21.1.6(@angular/compiler@21.1.6)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1))(@angular/core@21.1.6(@angular/compiler@21.1.6)(rxjs@7.8.1)(zone.js@0.16.0))(@angular/platform-browser@21.1.6(@angular/animations@21.1.6(@angular/core@21.1.6(@angular/compiler@21.1.6)(rxjs@7.8.1)(zone.js@0.16.0)))(@angular/common@21.1.6(@angular/core@21.1.6(@angular/compiler@21.1.6)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1))(@angular/core@21.1.6(@angular/compiler@21.1.6)(rxjs@7.8.1)(zone.js@0.16.0)))(rxjs@7.8.1)
       '@gurezo/web-serial-rxjs':
-        specifier: 0.1.11
-        version: 0.1.11(rxjs@7.8.1)
+        specifier: 0.2.0
+        version: 0.2.0(rxjs@7.8.1)
       '@ngrx/component-store':
         specifier: 21.0.1
         version: 21.0.1(@angular/core@21.1.6(@angular/compiler@21.1.6)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1)
@@ -1790,8 +1790,8 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@gurezo/web-serial-rxjs@0.1.11':
-    resolution: {integrity: sha512-HzX55v+DhZM2ceEB1B3ftg1+4ZBhlLU14gTzJRQ0nVoderDM8sy/niVYJNIMLGtJw9bsT0lruQ5BJEn3e6rbJA==}
+  '@gurezo/web-serial-rxjs@0.2.0':
+    resolution: {integrity: sha512-h96/KcYLnIbDrnCa5+QsuK70gTDQIpVui25orYbaKi8B2MpDzQFSUV3I8WI+d0f4YZnekv67spBCqv63Cujkvw==}
     peerDependencies:
       rxjs: ^7.8.0
 
@@ -11895,7 +11895,7 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@gurezo/web-serial-rxjs@0.1.11(rxjs@7.8.1)':
+  '@gurezo/web-serial-rxjs@0.2.0(rxjs@7.8.1)':
     dependencies:
       rxjs: 7.8.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ onlyBuiltDependencies:
   - msgpackr-extract
   - nx
 
+# Temporarily disabled for installing @gurezo/web-serial-rxjs@0.2.0.
 # Malicious releases are often detected and removed within a week.
 # 7 days x 24h x 60 min
-minimumReleaseAge: 10080
+# minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

Issue #527 と #524 の指摘を踏まえ、web-serial 周辺の責務重複と API 形状を整理しました。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [x] Breaking change

## Related issues

- Fixes #527
- Refs #524

## What changed?

- `@gurezo/web-serial-rxjs` を `0.2.0` へ更新し、導入のため `pnpm-workspace.yaml` の `minimumReleaseAge` を暫定コメントアウト
- 接続失敗メッセージ変換を `getConnectionErrorMessage` に統一し、重複ロジックを削除
- `WebSerialActions.init` と reducer/component 側の no-op フローを削除
- `SerialFacadeService` / `SerialCommandService` / `SerialTransportService` / `PiZeroSerialBootstrapService` の deprecated Promise API を削除
- 全呼び出し元（terminal/wifi/remote/setup/file-manager ほか）を `exec$` / `write$` / `readUntilPrompt$` + `firstValueFrom` に移行
- 接続可否の reducer 更新を action 種別ベースにし、payload 依存を削減

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details:
   - `SerialFacadeService` の `connect/disconnect/write/read/readString/exec/execRaw/readUntilPrompt` を削除
   - `SerialCommandService` の `exec/execRaw/readUntilPrompt` を削除
   - `SerialTransportService` の `connect/disconnect` を削除
   - `PiZeroSerialBootstrapService` の `runAfterConnect` を削除
   - 移行方法: `xxx$` メソッドに置き換え、必要箇所で `firstValueFrom` を使用
- [ ] This change is backward compatible
- [x] This change introduces a breaking change
 - Migration notes:
   - Promise 版 API 呼び出しはすべて Observable 版 API (`exec$`, `write$`, `readUntilPrompt$`, `connect$`, `disconnect$`) に置き換えてください。

## How to test

1. `pnpm nx run-many -t test -p libs-web-serial-data-access,libs-console-shell-feature --parallel=2`
2. Web Serial 接続/切断を実行し、接続成功・失敗メッセージが表示されることを確認
3. ターミナル/Remote/WiFi/Setup/FileManager でコマンド実行が従来通り動くことを確認

## Environment (if relevant)

- Browser: Chrome (Web Serial)
- OS: macOS
- Node version: v22.17.1
- pnpm version: 10.30.3

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)