### PR TITLE
fix(web-serial-data-access): /terminal 接続直後の初期化タイムアウトを修正

### DIFF
--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
@@ -100,6 +100,7 @@ describe('PiZeroSerialBootstrapService', () => {
       expect.objectContaining({
         prompt: expect.any(RegExp),
         timeout: SERIAL_TIMEOUT.DEFAULT,
+        retry: 1,
       }),
     );
     expect(exec).toHaveBeenNthCalledWith(
@@ -107,7 +108,8 @@ describe('PiZeroSerialBootstrapService', () => {
       PI_ZERO_LOGIN_PASSWORD,
       expect.objectContaining({
         prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-        timeout: SERIAL_TIMEOUT.DEFAULT,
+        timeout: SERIAL_TIMEOUT.LONG,
+        retry: 1,
       }),
     );
     expect(lines.some((l) => l.includes('ログインユーザー'))).toBe(true);

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
@@ -132,6 +132,7 @@ export class PiZeroSerialBootstrapService {
           this.serial.exec$(PI_ZERO_LOGIN_USER, {
             prompt: PI_ZERO_SERIAL_PASSWORD_LINE_PATTERN,
             timeout: SERIAL_TIMEOUT.DEFAULT,
+            retry: 1,
           }),
         ),
         tap(() => {
@@ -140,7 +141,8 @@ export class PiZeroSerialBootstrapService {
         switchMap(() =>
           this.serial.exec$(PI_ZERO_LOGIN_PASSWORD, {
             prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-            timeout: SERIAL_TIMEOUT.DEFAULT,
+            timeout: SERIAL_TIMEOUT.LONG,
+            retry: 1,
           }),
         ),
         tap(() => log('[コンソール] ログインが完了しました。')),


### PR DESCRIPTION
## Summary
- `/terminal` 接続直後のログイン処理で、パスワード送信後のシェル待機が短く `Command execution timeout` になりやすい問題を修正
- ログインユーザー送信・パスワード送信の両方にリトライを追加し、一時的な応答遅延を吸収
- パスワード送信後の待機タイムアウトを `DEFAULT` から `LONG` に延長し、Issue #529 の再現条件を緩和

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #529

## What changed?

- `PiZeroSerialBootstrapService` のログインシーケンスで `exec$` オプションを調整
- ログインユーザー送信に `retry: 1` を追加
- パスワード送信後の待機を `timeout: SERIAL_TIMEOUT.LONG` + `retry: 1` に変更
- `pi-zero-serial-bootstrap.service.spec.ts` の期待値を実装に合わせて更新

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx test libs-web-serial-data-access` を実行する
2. `http://localhost:4200/terminal` にアクセスする
3. ログイン処理後に初期化がタイムアウトせず、待機プロンプト (`$ `) まで到達することを確認する

## Environment (if relevant)

- Browser: Chrome v146.x
- OS: macOS
- Node version: v22.x
- pnpm version: (local env)

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)