### PR TITLE
feat(terminal): 同一接続セッションでターミナル再訪時の初期化をスキップ

### DIFF
--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
@@ -31,11 +31,15 @@ import { TerminalViewComponent } from './terminal-view.component';
 describe('TerminalViewComponent', () => {
   let fixture: ComponentFixture<TerminalViewComponent>;
   let execMock: ReturnType<typeof vi.fn>;
+  let shouldRunAfterConnectMock: ReturnType<typeof vi.fn>;
+  let runAfterConnectMock: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     execMock = vi.fn().mockResolvedValue({
       stdout: `i2cdetect -y 1\n     0  1\n${PI_ZERO_PROMPT} `,
     });
+    shouldRunAfterConnectMock = vi.fn(() => true);
+    runAfterConnectMock = vi.fn(() => of(undefined));
     await TestBed.configureTestingModule({
       imports: [TerminalViewComponent],
     })
@@ -50,7 +54,8 @@ describe('TerminalViewComponent', () => {
       })
       .overrideProvider(PiZeroSerialBootstrapService, {
         useValue: {
-          runAfterConnect$: vi.fn(() => of(undefined)),
+          shouldRunAfterConnect: shouldRunAfterConnectMock,
+          runAfterConnect$: runAfterConnectMock,
         },
       })
       .compileComponents();
@@ -78,5 +83,19 @@ describe('TerminalViewComponent', () => {
         timeout: SERIAL_TIMEOUT.DEFAULT,
       });
     });
+  });
+
+  it('skips bootstrap execution when already initialized', async () => {
+    runAfterConnectMock.mockClear();
+    shouldRunAfterConnectMock.mockReturnValue(false);
+
+    fixture.destroy();
+    fixture = TestBed.createComponent(TerminalViewComponent);
+    fixture.detectChanges();
+
+    await vi.waitFor(() => {
+      expect(shouldRunAfterConnectMock).toHaveBeenCalled();
+    });
+    expect(runAfterConnectMock).not.toHaveBeenCalled();
   });
 });

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -77,15 +77,9 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
           if (!this.serial.isConnected()) {
             return EMPTY;
           }
-          this.xterminal.writeln(
-            '[コンソール] シリアルに接続しました。初期化しています...',
+          return this.bootstrapAfterConnect$(
+            '[コンソール] シリアルに接続しました。',
           );
-          return this.piZeroBootstrap
-            .runAfterConnect$((line) => this.xterminal.writeln(line))
-            .pipe(
-              catchError(() => EMPTY),
-              finalize(() => this.xterminal.write('$ ')),
-            );
         }),
         takeUntilDestroyed(this.destroyRef),
       )
@@ -119,14 +113,8 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
 
     this.xterminal.reset();
     if (this.serial.isConnected()) {
-      this.xterminal.writeln('[コンソール] シリアル接続済み。初期化しています...');
-      this.piZeroBootstrap
-        .runAfterConnect$((line) => this.xterminal.writeln(line))
-        .pipe(
-          takeUntilDestroyed(this.destroyRef),
-          catchError(() => EMPTY),
-          finalize(() => this.xterminal.write('$ ')),
-        )
+      this.bootstrapAfterConnect$('[コンソール] シリアル接続済み。')
+        .pipe(takeUntilDestroyed(this.destroyRef))
         .subscribe();
     } else {
       this.xterminal.writeln('$ ');
@@ -187,5 +175,20 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
     } catch {
       // Dimensions may be zero before layout stabilizes
     }
+  }
+
+  private bootstrapAfterConnect$(prefixMessage: string) {
+    if (!this.piZeroBootstrap.shouldRunAfterConnect()) {
+      this.xterminal.writeln(`${prefixMessage} 初期化済みのためスキップします。`);
+      this.xterminal.write('$ ');
+      return EMPTY;
+    }
+    this.xterminal.writeln(`${prefixMessage} 初期化しています...`);
+    return this.piZeroBootstrap.runAfterConnect$((line) =>
+      this.xterminal.writeln(line),
+    ).pipe(
+      catchError(() => EMPTY),
+      finalize(() => this.xterminal.write('$ ')),
+    );
   }
 }

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
@@ -153,6 +153,30 @@ describe('PiZeroSerialBootstrapService', () => {
     expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
   });
 
+  it('re-runs bootstrap when connection epoch changes', async () => {
+    let epoch = 1;
+    const readUntilPrompt = vi.fn().mockResolvedValue({
+      stdout: `${PI_ZERO_PROMPT} `,
+    });
+    const exec = vi.fn().mockResolvedValue({ stdout: '' });
+    const serial = {
+      isConnected: () => true,
+      getConnectionEpoch: () => epoch,
+      readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
+      exec$: (c: string, o: unknown) => from(exec(c, o)),
+    } as unknown as SerialFacadeService;
+
+    const shellReadiness = createShellReadinessMock();
+    const service = new PiZeroSerialBootstrapService(serial, shellReadiness);
+
+    await firstValueFrom(service.runAfterConnect$());
+    epoch = 2;
+    await firstValueFrom(service.runAfterConnect$());
+
+    expect(readUntilPrompt).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledTimes(2);
+  });
+
   it('logs timezone status stdout lines to the status handler', async () => {
     const readUntilPrompt = vi.fn().mockResolvedValue({
       stdout: `ready\r\n${PI_ZERO_PROMPT} `,

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
@@ -50,19 +50,29 @@ export class PiZeroSerialBootstrapService {
   /**
    * 接続セッションごとに1回、シェル到達（必要ならログイン）と接続直後の初期化を行う。
    */
+  shouldRunAfterConnect(): boolean {
+    if (!this.serial.isConnected()) {
+      return false;
+    }
+    const epoch = this.serial.getConnectionEpoch();
+    if (epoch === this.lastBootstrappedEpoch) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * 接続セッション内で未初期化の場合のみ初期化パイプラインを実行する。
+   */
   runAfterConnect$(
     onStatus?: PiZeroBootstrapStatusHandler,
   ): Observable<void> {
     const log = onStatus ?? (() => undefined);
 
-    if (!this.serial.isConnected()) {
+    if (!this.shouldRunAfterConnect()) {
       return of(undefined);
     }
-
     const epoch = this.serial.getConnectionEpoch();
-    if (epoch === this.lastBootstrappedEpoch) {
-      return of(undefined);
-    }
 
     if (
       this.activeBootstrap$ !== null &&


### PR DESCRIPTION
## Summary

Issue #517 の対応として、ターミナル画面へ再遷移した際に同一接続セッション内で初期化処理を再実行しないようにしました。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #517

## What changed?

- `PiZeroSerialBootstrapService` に `shouldRunAfterConnect()` を追加し、同一 `connectionEpoch` での再初期化判定を明示化
- `TerminalViewComponent` の接続時処理を `bootstrapAfterConnect$` に集約し、初期化済みの場合は初期化処理をスキップ
- テストを追加し、同一セッションでのスキップ動作と `connectionEpoch` 変更時の再初期化動作を検証

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx run libs-web-serial-data-access:test`
2. `pnpm nx run libs-terminal-ui:test`
3. `pnpm nx run libs-web-serial-data-access:lint && pnpm nx run libs-terminal-ui:lint`

## Environment (if relevant)

- Browser: N/A
- OS: macOS
- Node version: (local environment)
- pnpm version: (local environment)

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)