### PR TITLE
feat: inline template を component.html に分離

### DIFF
--- a/libs/chirimen-setup/feature/src/lib/setup-step-list/setup-step-list.component.html
+++ b/libs/chirimen-setup/feature/src/lib/setup-step-list/setup-step-list.component.html
@@ -1,0 +1,5 @@
+<ul>
+  @for (step of steps(); track step) {
+    <li>{{ step }}</li>
+  }
+</ul>

--- a/libs/chirimen-setup/feature/src/lib/setup-step-list/setup-step-list.component.ts
+++ b/libs/chirimen-setup/feature/src/lib/setup-step-list/setup-step-list.component.ts
@@ -2,13 +2,7 @@ import { Component, input } from '@angular/core';
 
 @Component({
   selector: 'lib-setup-step-list',
-  template: `
-    <ul>
-      @for (step of steps(); track step) {
-        <li>{{ step }}</li>
-      }
-    </ul>
-  `,
+  templateUrl: './setup-step-list.component.html',
 })
 export class SetupStepListComponent {
   readonly steps = input<string[]>([]);

--- a/libs/chirimen-setup/ui/src/lib/setup-execute-button/setup-execute-button.component.html
+++ b/libs/chirimen-setup/ui/src/lib/setup-execute-button/setup-execute-button.component.html
@@ -1,0 +1,6 @@
+<choh-button
+  [label]="loading() ? loadingLabel() : label()"
+  type="button"
+  [disabled]="disabled() || loading()"
+  (clickEvent)="handleClick()"
+/>

--- a/libs/chirimen-setup/ui/src/lib/setup-execute-button/setup-execute-button.component.ts
+++ b/libs/chirimen-setup/ui/src/lib/setup-execute-button/setup-execute-button.component.ts
@@ -4,14 +4,7 @@ import { ButtonComponent } from '@libs-shared-ui';
 @Component({
   selector: 'lib-setup-execute-button',
   imports: [ButtonComponent],
-  template: `
-    <choh-button
-      [label]="loading() ? loadingLabel() : label()"
-      type="button"
-      [disabled]="disabled() || loading()"
-      (clickEvent)="handleClick()"
-    />
-  `,
+  templateUrl: './setup-execute-button.component.html',
 })
 export class SetupExecuteButtonComponent {
   readonly label = input('セットアップを実行');

--- a/libs/connect/feature/src/lib/connect-page/connect-page.component.html
+++ b/libs/connect/feature/src/lib/connect-page/connect-page.component.html
@@ -1,0 +1,18 @@
+<section
+  class="flex h-full min-h-0 flex-col items-center justify-center gap-4 text-center"
+>
+  @if (connectionStatus$ | async; as status) {
+    <lib-connection-status
+      [status]="status"
+      [message]="disconnectedMessage"
+      [imageSrc]="imageSrc"
+      [imageAlt]="imageAlt"
+    />
+    @if (status === 'disconnected') {
+      <lib-connect-button
+        [label]="connectButtonLabel"
+        (connect)="onConnect()"
+      />
+    }
+  }
+</section>

--- a/libs/connect/feature/src/lib/connect-page/connect-page.component.ts
+++ b/libs/connect/feature/src/lib/connect-page/connect-page.component.ts
@@ -13,26 +13,7 @@ import { map } from 'rxjs';
   selector: 'lib-connect-page',
   host: { class: 'flex min-h-0 flex-1 flex-col' },
   imports: [AsyncPipe, ConnectButtonComponent, ConnectionStatusComponent],
-  template: `
-    <section
-      class="flex h-full min-h-0 flex-col items-center justify-center gap-4 text-center"
-    >
-      @if (connectionStatus$ | async; as status) {
-        <lib-connection-status
-          [status]="status"
-          [message]="disconnectedMessage"
-          [imageSrc]="imageSrc"
-          [imageAlt]="imageAlt"
-        />
-        @if (status === 'disconnected') {
-          <lib-connect-button
-            [label]="connectButtonLabel"
-            (connect)="onConnect()"
-          />
-        }
-      }
-    </section>
-  `,
+  templateUrl: './connect-page.component.html',
 })
 export class ConnectPageComponent {
   private store = inject(Store);

--- a/libs/connect/ui/src/lib/connect-button/connect-button.component.html
+++ b/libs/connect/ui/src/lib/connect-button/connect-button.component.html
@@ -1,0 +1,7 @@
+<button
+  type="button"
+  class="px-5 py-2 text-base font-medium text-white bg-blue-600 border-0 rounded shadow cursor-pointer hover:bg-blue-700 active:bg-blue-800"
+  (click)="connect.emit()"
+>
+  {{ label() }}
+</button>

--- a/libs/connect/ui/src/lib/connect-button/connect-button.component.ts
+++ b/libs/connect/ui/src/lib/connect-button/connect-button.component.ts
@@ -2,15 +2,7 @@ import { Component, input, output } from '@angular/core';
 
 @Component({
   selector: 'lib-connect-button',
-  template: `
-    <button
-      type="button"
-      class="px-5 py-2 text-base font-medium text-white bg-blue-600 border-0 rounded shadow cursor-pointer hover:bg-blue-700 active:bg-blue-800"
-      (click)="connect.emit()"
-    >
-      {{ label() }}
-    </button>
-  `,
+  templateUrl: './connect-button.component.html',
 })
 export class ConnectButtonComponent {
   readonly label = input<string>('Connect');

--- a/libs/connect/ui/src/lib/connection-status/connection-status.component.html
+++ b/libs/connect/ui/src/lib/connection-status/connection-status.component.html
@@ -1,0 +1,16 @@
+@if (status() === 'disconnected') {
+  <div class="flex flex-col justify-center items-center gap-4">
+    @if (message()) {
+      <h2 class="text-center">{{ message() }}</h2>
+    }
+    @if (imageSrc()) {
+      <img
+        [src]="imageSrc()"
+        [alt]="imageAlt()"
+        class="max-w-full h-auto"
+      />
+    }
+  </div>
+} @else {
+  <p>Connection status: {{ status() }}</p>
+}

--- a/libs/connect/ui/src/lib/connection-status/connection-status.component.ts
+++ b/libs/connect/ui/src/lib/connection-status/connection-status.component.ts
@@ -4,24 +4,7 @@ export type ConnectStatus = 'disconnected' | 'connecting' | 'connected';
 
 @Component({
   selector: 'lib-connection-status',
-  template: `
-    @if (status() === 'disconnected') {
-      <div class="flex flex-col justify-center items-center gap-4">
-        @if (message()) {
-          <h2 class="text-center">{{ message() }}</h2>
-        }
-        @if (imageSrc()) {
-          <img
-            [src]="imageSrc()"
-            [alt]="imageAlt()"
-            class="max-w-full h-auto"
-          />
-        }
-      </div>
-    } @else {
-      <p>Connection status: {{ status() }}</p>
-    }
-  `,
+  templateUrl: './connection-status.component.html',
 })
 export class ConnectionStatusComponent {
   readonly status = input<ConnectStatus>('disconnected');

--- a/libs/console-shell/ui/src/lib/main-layout/main-layout.component.html
+++ b/libs/console-shell/ui/src/lib/main-layout/main-layout.component.html
@@ -1,0 +1,3 @@
+<div class="main-layout">
+  <p>Main layout (stub)</p>
+</div>

--- a/libs/console-shell/ui/src/lib/main-layout/main-layout.component.ts
+++ b/libs/console-shell/ui/src/lib/main-layout/main-layout.component.ts
@@ -2,10 +2,6 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'lib-main-layout',
-  template: `
-    <div class="main-layout">
-      <p>Main layout (stub)</p>
-    </div>
-  `,
+  templateUrl: './main-layout.component.html',
 })
 export class MainLayoutComponent {}

--- a/libs/dialogs/ui/src/lib/confirm-dialog/confirm-dialog.component.html
+++ b/libs/dialogs/ui/src/lib/confirm-dialog/confirm-dialog.component.html
@@ -1,0 +1,14 @@
+<div class="dialog-content">
+  @if (viewTitle) {
+    <h2>{{ viewTitle }}</h2>
+  }
+  @if (viewMessage) {
+    <p>{{ viewMessage }}</p>
+  }
+  <div class="dialog-actions">
+    @if (!viewHideCancel) {
+      <button type="button" (click)="cancel()">{{ viewCancelLabel }}</button>
+    }
+    <button type="button" (click)="confirm()">{{ viewConfirmLabel }}</button>
+  </div>
+</div>

--- a/libs/dialogs/ui/src/lib/confirm-dialog/confirm-dialog.component.ts
+++ b/libs/dialogs/ui/src/lib/confirm-dialog/confirm-dialog.component.ts
@@ -12,22 +12,7 @@ export interface ConfirmDialogData {
 
 @Component({
   selector: 'lib-confirm-dialog',
-  template: `
-    <div class="dialog-content">
-      @if (viewTitle) {
-        <h2>{{ viewTitle }}</h2>
-      }
-      @if (viewMessage) {
-        <p>{{ viewMessage }}</p>
-      }
-      <div class="dialog-actions">
-        @if (!viewHideCancel) {
-          <button type="button" (click)="cancel()">{{ viewCancelLabel }}</button>
-        }
-        <button type="button" (click)="confirm()">{{ viewConfirmLabel }}</button>
-      </div>
-    </div>
-  `,
+  templateUrl: './confirm-dialog.component.html',
   styles: [
     `
       .dialog-content {

--- a/libs/dialogs/ui/src/lib/progress-dialog/progress-dialog.component.html
+++ b/libs/dialogs/ui/src/lib/progress-dialog/progress-dialog.component.html
@@ -1,0 +1,9 @@
+<div class="dialog-content">
+  @if (message()) {
+    <p>{{ message() }}</p>
+  }
+  <p>Progress: {{ progress() }}%</p>
+  <div class="progress-bar">
+    <div class="progress-fill" [style.width.%]="progress()"></div>
+  </div>
+</div>

--- a/libs/dialogs/ui/src/lib/progress-dialog/progress-dialog.component.ts
+++ b/libs/dialogs/ui/src/lib/progress-dialog/progress-dialog.component.ts
@@ -2,17 +2,7 @@ import { Component, input } from '@angular/core';
 
 @Component({
   selector: 'lib-progress-dialog',
-  template: `
-    <div class="dialog-content">
-      @if (message()) {
-        <p>{{ message() }}</p>
-      }
-      <p>Progress: {{ progress() }}%</p>
-      <div class="progress-bar">
-        <div class="progress-fill" [style.width.%]="progress()"></div>
-      </div>
-    </div>
-  `,
+  templateUrl: './progress-dialog.component.html',
   styles: [
     `
       .dialog-content {

--- a/libs/dialogs/ui/src/lib/wait-dialog/wait-dialog.component.html
+++ b/libs/dialogs/ui/src/lib/wait-dialog/wait-dialog.component.html
@@ -1,0 +1,6 @@
+<div class="dialog-content">
+  @if (message()) {
+    <p>{{ message() }}</p>
+  }
+  <div class="spinner" aria-busy="true"></div>
+</div>

--- a/libs/dialogs/ui/src/lib/wait-dialog/wait-dialog.component.ts
+++ b/libs/dialogs/ui/src/lib/wait-dialog/wait-dialog.component.ts
@@ -2,14 +2,7 @@ import { Component, input } from '@angular/core';
 
 @Component({
   selector: 'lib-wait-dialog',
-  template: `
-    <div class="dialog-content">
-      @if (message()) {
-        <p>{{ message() }}</p>
-      }
-      <div class="spinner" aria-busy="true"></div>
-    </div>
-  `,
+  templateUrl: './wait-dialog.component.html',
   styles: [
     `
       .dialog-content {

--- a/libs/editor/feature/src/lib/editor-page/editor-page.component.html
+++ b/libs/editor/feature/src/lib/editor-page/editor-page.component.html
@@ -1,0 +1,21 @@
+<div
+  class="editor-page flex h-full min-h-0 min-w-0 flex-col"
+>
+  <choh-editor-toolbar
+    class="shrink-0"
+    [saveDisabled]="!isDirty() || isSaving()"
+    (saveRequested)="saveCurrentFile()"
+  />
+  <choh-file-name-display
+    class="shrink-0"
+    [fileName]="currentFileName()"
+    [isDirty]="isDirty()"
+  />
+  <choh-monaco-editor
+    class="min-h-0 min-w-0 flex-1"
+    [code]="code()"
+    (codeChange)="code.set($event)"
+    (editorInitialized)="onEditorInitialized($event)"
+    (contentEdited)="isDirty.set(true)"
+  />
+</div>

--- a/libs/editor/feature/src/lib/editor-page/editor-page.component.ts
+++ b/libs/editor/feature/src/lib/editor-page/editor-page.component.ts
@@ -39,29 +39,7 @@ const DEFAULT_CODE = `
     EditorToolbarComponent,
     FileNameDisplayComponent,
   ],
-  template: `
-    <div
-      class="editor-page flex h-full min-h-0 min-w-0 flex-col"
-    >
-      <choh-editor-toolbar
-        class="shrink-0"
-        [saveDisabled]="!isDirty() || isSaving()"
-        (saveRequested)="saveCurrentFile()"
-      />
-      <choh-file-name-display
-        class="shrink-0"
-        [fileName]="currentFileName()"
-        [isDirty]="isDirty()"
-      />
-      <choh-monaco-editor
-        class="min-h-0 min-w-0 flex-1"
-        [code]="code()"
-        (codeChange)="code.set($event)"
-        (editorInitialized)="onEditorInitialized($event)"
-        (contentEdited)="isDirty.set(true)"
-      />
-    </div>
-  `,
+  templateUrl: './editor-page.component.html',
 })
 export class EditorPageComponent implements OnInit {
   code = signal(DEFAULT_CODE.trim());

--- a/libs/editor/ui/src/lib/editor-toolbar/editor-toolbar.component.html
+++ b/libs/editor/ui/src/lib/editor-toolbar/editor-toolbar.component.html
@@ -1,0 +1,5 @@
+<div class="editor-toolbar">
+  <button type="button" [disabled]="saveDisabled()" (click)="saveRequested.emit()">
+    Save
+  </button>
+</div>

--- a/libs/editor/ui/src/lib/editor-toolbar/editor-toolbar.component.ts
+++ b/libs/editor/ui/src/lib/editor-toolbar/editor-toolbar.component.ts
@@ -2,13 +2,7 @@ import { Component, input, output } from '@angular/core';
 
 @Component({
   selector: 'choh-editor-toolbar',
-  template: `
-    <div class="editor-toolbar">
-      <button type="button" [disabled]="saveDisabled()" (click)="saveRequested.emit()">
-        Save
-      </button>
-    </div>
-  `,
+  templateUrl: './editor-toolbar.component.html',
 })
 export class EditorToolbarComponent {
   saveDisabled = input(false);

--- a/libs/editor/ui/src/lib/file-name-display/file-name-display.component.html
+++ b/libs/editor/ui/src/lib/file-name-display/file-name-display.component.html
@@ -1,0 +1,10 @@
+<div class="file-name-display">
+  @if (fileName()) {
+    <span>{{ fileName() }}</span>
+    @if (isDirty()) {
+      <span> *</span>
+    }
+  } @else {
+    <span>—</span>
+  }
+</div>

--- a/libs/editor/ui/src/lib/file-name-display/file-name-display.component.ts
+++ b/libs/editor/ui/src/lib/file-name-display/file-name-display.component.ts
@@ -2,18 +2,7 @@ import { Component, input } from '@angular/core';
 
 @Component({
   selector: 'choh-file-name-display',
-  template: `
-    <div class="file-name-display">
-      @if (fileName()) {
-        <span>{{ fileName() }}</span>
-        @if (isDirty()) {
-          <span> *</span>
-        }
-      } @else {
-        <span>—</span>
-      }
-    </div>
-  `,
+  templateUrl: './file-name-display.component.html',
 })
 export class FileNameDisplayComponent {
   fileName = input<string | null>(null);

--- a/libs/editor/ui/src/lib/monaco-editor/monaco-editor.component.html
+++ b/libs/editor/ui/src/lib/monaco-editor/monaco-editor.component.html
@@ -1,0 +1,9 @@
+<div class="flex h-full min-h-0 min-w-0 flex-col">
+  <ngx-monaco-editor
+    class="block min-h-0 min-w-0 flex-1"
+    [options]="editorOptions()"
+    [ngModel]="code()"
+    (ngModelChange)="code.set($event)"
+    (onInit)="onEditorInit($event)"
+  />
+</div>

--- a/libs/editor/ui/src/lib/monaco-editor/monaco-editor.component.ts
+++ b/libs/editor/ui/src/lib/monaco-editor/monaco-editor.component.ts
@@ -6,17 +6,7 @@ import type { editor } from 'monaco-editor';
 @Component({
   selector: 'choh-monaco-editor',
   imports: [FormsModule, MonacoEditorModule],
-  template: `
-    <div class="flex h-full min-h-0 min-w-0 flex-col">
-      <ngx-monaco-editor
-        class="block min-h-0 min-w-0 flex-1"
-        [options]="editorOptions()"
-        [ngModel]="code()"
-        (ngModelChange)="code.set($event)"
-        (onInit)="onEditorInit($event)"
-      />
-    </div>
-  `,
+  templateUrl: './monaco-editor.component.html',
 })
 export class MonacoEditorComponent {
   code = model<string>('');

--- a/libs/file-manager/ui/src/lib/file-context-menu/file-context-menu.component.html
+++ b/libs/file-manager/ui/src/lib/file-context-menu/file-context-menu.component.html
@@ -1,0 +1,3 @@
+<div class="file-context-menu">
+  TODO: ファイル用コンテキストメニューを表示します。
+</div>

--- a/libs/file-manager/ui/src/lib/file-context-menu/file-context-menu.component.ts
+++ b/libs/file-manager/ui/src/lib/file-context-menu/file-context-menu.component.ts
@@ -2,10 +2,6 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'lib-file-context-menu',
-  template: `
-    <div class="file-context-menu">
-      TODO: ファイル用コンテキストメニューを表示します。
-    </div>
-  `,
+  templateUrl: './file-context-menu.component.html',
 })
 export class FileContextMenuComponent {}

--- a/libs/file-manager/ui/src/lib/file-tree/file-tree.component.html
+++ b/libs/file-manager/ui/src/lib/file-tree/file-tree.component.html
@@ -1,0 +1,25 @@
+<div class="file-tree text-sm">
+  @if (!nodes().length) {
+    <p class="text-gray-500">No files</p>
+  } @else {
+    <ul class="space-y-1">
+      @for (node of nodes(); track node.path) {
+        <li>
+          <button
+            type="button"
+            class="inline-flex w-full items-center gap-1 text-left px-2 py-1 rounded hover:bg-gray-100"
+            (click)="onSelect(node)"
+          >
+            @if (node.isDirectory) {
+              <mat-icon aria-hidden="true" class="shrink-0 text-amber-500">folder</mat-icon>
+              <span>{{ node.name }}</span>
+            } @else {
+              <mat-icon aria-hidden="true" class="shrink-0">article</mat-icon>
+              <span>{{ node.name }}</span>
+            }
+          </button>
+        </li>
+      }
+    </ul>
+  }
+</div>

--- a/libs/file-manager/ui/src/lib/file-tree/file-tree.component.ts
+++ b/libs/file-manager/ui/src/lib/file-tree/file-tree.component.ts
@@ -5,33 +5,7 @@ import { FileTreeNode } from '@libs-file-manager-util';
 @Component({
   selector: 'lib-file-tree',
   imports: [MatIcon],
-  template: `
-    <div class="file-tree text-sm">
-      @if (!nodes().length) {
-        <p class="text-gray-500">No files</p>
-      } @else {
-        <ul class="space-y-1">
-          @for (node of nodes(); track node.path) {
-            <li>
-              <button
-                type="button"
-                class="inline-flex w-full items-center gap-1 text-left px-2 py-1 rounded hover:bg-gray-100"
-                (click)="onSelect(node)"
-              >
-                @if (node.isDirectory) {
-                  <mat-icon aria-hidden="true" class="shrink-0 text-amber-500">folder</mat-icon>
-                  <span>{{ node.name }}</span>
-                } @else {
-                  <mat-icon aria-hidden="true" class="shrink-0">article</mat-icon>
-                  <span>{{ node.name }}</span>
-                }
-              </button>
-            </li>
-          }
-        </ul>
-      }
-    </div>
-  `,
+  templateUrl: './file-tree.component.html',
 })
 export class FileTreeComponent {
   readonly nodes = input<FileTreeNode[]>([]);

--- a/libs/file-manager/ui/src/lib/upload-button/upload-button.component.html
+++ b/libs/file-manager/ui/src/lib/upload-button/upload-button.component.html
@@ -1,0 +1,3 @@
+<button type="button">
+  Upload
+</button>

--- a/libs/file-manager/ui/src/lib/upload-button/upload-button.component.ts
+++ b/libs/file-manager/ui/src/lib/upload-button/upload-button.component.ts
@@ -2,11 +2,7 @@ import { Component, output } from '@angular/core';
 
 @Component({
   selector: 'lib-upload-button',
-  template: `
-    <button type="button">
-      Upload
-    </button>
-  `,
+  templateUrl: './upload-button.component.html',
 })
 export class UploadButtonComponent {
   readonly upload = output<void>();

--- a/libs/pin-assign-panel/ui/src/lib/pin-accordion/pin-accordion.component.html
+++ b/libs/pin-assign-panel/ui/src/lib/pin-accordion/pin-accordion.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/libs/pin-assign-panel/ui/src/lib/pin-accordion/pin-accordion.component.ts
+++ b/libs/pin-assign-panel/ui/src/lib/pin-accordion/pin-accordion.component.ts
@@ -6,6 +6,6 @@ import { Component } from '@angular/core';
  */
 @Component({
   selector: 'choh-pin-accordion',
-  template: `<ng-content></ng-content>`,
+  templateUrl: './pin-accordion.component.html',
 })
 export class PinAccordionComponent {}

--- a/libs/remote/ui/src/lib/remote-run-button/remote-run-button.component.html
+++ b/libs/remote/ui/src/lib/remote-run-button/remote-run-button.component.html
@@ -1,0 +1,6 @@
+<choh-button
+  [label]="label()"
+  type="button"
+  [disabled]="disabled()"
+  (clickEvent)="runClick.emit()"
+/>

--- a/libs/remote/ui/src/lib/remote-run-button/remote-run-button.component.ts
+++ b/libs/remote/ui/src/lib/remote-run-button/remote-run-button.component.ts
@@ -4,14 +4,7 @@ import { ButtonComponent } from '@libs-shared-ui';
 @Component({
   selector: 'lib-remote-run-button',
   imports: [ButtonComponent],
-  template: `
-    <choh-button
-      [label]="label()"
-      type="button"
-      [disabled]="disabled()"
-      (clickEvent)="runClick.emit()"
-    />
-  `,
+  templateUrl: './remote-run-button.component.html',
 })
 export class RemoteRunButtonComponent {
   readonly label = input('起動');

--- a/libs/remote/ui/src/lib/remote-status-list/remote-status-list.component.html
+++ b/libs/remote/ui/src/lib/remote-status-list/remote-status-list.component.html
@@ -1,0 +1,30 @@
+<div>
+  <h3 class="text-base font-semibold mb-2">実行中のアプリ (forever)</h3>
+</div>
+<div
+  class="max-h-[min(360px,40vh)] overflow-y-auto w-full border border-gray-200 rounded"
+  role="list"
+>
+  @for (p of processes(); track trackKey(p)) {
+    <button
+      type="button"
+      role="listitem"
+      class="w-full text-left px-3 py-2 border-b border-gray-100 hover:bg-gray-50"
+      [class.bg-blue-50]="isSelected(p)"
+      (click)="rowSelected.emit(p)"
+    >
+      <div class="font-mono text-sm">{{ p.uid }}</div>
+      <div class="text-xs text-gray-600 break-all">{{ p.script }}</div>
+      <div class="text-xs mt-0.5" [class.text-green-700]="p.running" [class.text-gray-500]="!p.running">
+        {{ p.running ? '実行中' : '停止' }}
+        @if (p.uptime) {
+          <span class="text-gray-400"> · {{ p.uptime }}</span>
+        }
+      </div>
+    </button>
+  } @empty {
+    <p class="p-3 text-sm text-gray-600">
+      プロセスがありません。「更新」で一覧を取得してください。
+    </p>
+  }
+</div>

--- a/libs/remote/ui/src/lib/remote-status-list/remote-status-list.component.ts
+++ b/libs/remote/ui/src/lib/remote-status-list/remote-status-list.component.ts
@@ -3,38 +3,7 @@ import type { ForeverProcess } from '@libs-shared-types';
 
 @Component({
   selector: 'lib-remote-status-list',
-  template: `
-    <div>
-      <h3 class="text-base font-semibold mb-2">実行中のアプリ (forever)</h3>
-    </div>
-    <div
-      class="max-h-[min(360px,40vh)] overflow-y-auto w-full border border-gray-200 rounded"
-      role="list"
-    >
-      @for (p of processes(); track trackKey(p)) {
-        <button
-          type="button"
-          role="listitem"
-          class="w-full text-left px-3 py-2 border-b border-gray-100 hover:bg-gray-50"
-          [class.bg-blue-50]="isSelected(p)"
-          (click)="rowSelected.emit(p)"
-        >
-          <div class="font-mono text-sm">{{ p.uid }}</div>
-          <div class="text-xs text-gray-600 break-all">{{ p.script }}</div>
-          <div class="text-xs mt-0.5" [class.text-green-700]="p.running" [class.text-gray-500]="!p.running">
-            {{ p.running ? '実行中' : '停止' }}
-            @if (p.uptime) {
-              <span class="text-gray-400"> · {{ p.uptime }}</span>
-            }
-          </div>
-        </button>
-      } @empty {
-        <p class="p-3 text-sm text-gray-600">
-          プロセスがありません。「更新」で一覧を取得してください。
-        </p>
-      }
-    </div>
-  `,
+  templateUrl: './remote-status-list.component.html',
 })
 export class RemoteStatusListComponent {
   readonly processes = input<ForeverProcess[]>([]);

--- a/libs/remote/ui/src/lib/remote-stop-button/remote-stop-button.component.html
+++ b/libs/remote/ui/src/lib/remote-stop-button/remote-stop-button.component.html
@@ -1,0 +1,6 @@
+<choh-button
+  [label]="label()"
+  type="button"
+  [disabled]="disabled()"
+  (clickEvent)="stopClick.emit()"
+/>

--- a/libs/remote/ui/src/lib/remote-stop-button/remote-stop-button.component.ts
+++ b/libs/remote/ui/src/lib/remote-stop-button/remote-stop-button.component.ts
@@ -4,14 +4,7 @@ import { ButtonComponent } from '@libs-shared-ui';
 @Component({
   selector: 'lib-remote-stop-button',
   imports: [ButtonComponent],
-  template: `
-    <choh-button
-      [label]="label()"
-      type="button"
-      [disabled]="disabled()"
-      (clickEvent)="stopClick.emit()"
-    />
-  `,
+  templateUrl: './remote-stop-button.component.html',
 })
 export class RemoteStopButtonComponent {
   readonly label = input('停止');

--- a/libs/terminal/feature/src/lib/terminal-page/terminal-page.component.html
+++ b/libs/terminal/feature/src/lib/terminal-page/terminal-page.component.html
@@ -1,0 +1,5 @@
+<div
+  class="box-border h-full min-h-0 min-w-0 bg-black pt-1 pr-1 pb-1 pl-1"
+>
+  <choh-terminal-view [remotePrompt]="remotePrompt" />
+</div>

--- a/libs/terminal/feature/src/lib/terminal-page/terminal-page.component.ts
+++ b/libs/terminal/feature/src/lib/terminal-page/terminal-page.component.ts
@@ -5,13 +5,7 @@ import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
 @Component({
   selector: 'choh-terminal',
   imports: [TerminalViewComponent],
-  template: `
-    <div
-      class="box-border h-full min-h-0 min-w-0 bg-black pt-1 pr-1 pb-1 pl-1"
-    >
-      <choh-terminal-view [remotePrompt]="remotePrompt" />
-    </div>
-  `,
+  templateUrl: './terminal-page.component.html',
 })
 export default class TerminalPageComponent {
   readonly remotePrompt = PI_ZERO_PROMPT;

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.html
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.html
@@ -1,0 +1,6 @@
+<div class="flex h-full min-h-0 min-w-0 flex-col">
+  <div
+    #consoleDom
+    class="min-h-0 min-w-0 flex-1 overflow-hidden"
+  ></div>
+</div>

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -36,14 +36,7 @@ import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
   host: {
     class: 'block h-full min-h-0 min-w-0',
   },
-  template: `
-    <div class="flex h-full min-h-0 min-w-0 flex-col">
-      <div
-        #consoleDom
-        class="min-h-0 min-w-0 flex-1 overflow-hidden"
-      ></div>
-    </div>
-  `,
+  templateUrl: './terminal-view.component.html',
 })
 export class TerminalViewComponent implements AfterViewInit, OnDestroy {
   /**

--- a/libs/wifi/ui/src/lib/wifi-connect-dialog/wifi-connect-dialog.component.html
+++ b/libs/wifi/ui/src/lib/wifi-connect-dialog/wifi-connect-dialog.component.html
@@ -1,0 +1,37 @@
+<div class="flex flex-col gap-4 p-4 min-w-[280px]">
+  <h2 class="text-lg font-medium m-0">WiFi に接続</h2>
+  <form class="flex flex-col gap-3" (ngSubmit)="$event.preventDefault(); connect()">
+    <mat-form-field appearance="outline">
+      <mat-label>SSID</mat-label>
+      <input matInput name="ssid" [(ngModel)]="ssid" [disabled]="connecting()" />
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>パスワード</mat-label>
+      <input
+        matInput
+        type="password"
+        name="password"
+        [(ngModel)]="password"
+        [disabled]="connecting()"
+        autocomplete="off"
+      />
+    </mat-form-field>
+    <div class="flex justify-end gap-2">
+      <button
+        mat-stroked-button
+        type="button"
+        (click)="cancel()"
+        [disabled]="connecting()"
+      >
+        キャンセル
+      </button>
+      <button mat-flat-button color="primary" type="submit" [disabled]="connecting()">
+        @if (connecting()) {
+          接続中…
+        } @else {
+          接続
+        }
+      </button>
+    </div>
+  </form>
+</div>

--- a/libs/wifi/ui/src/lib/wifi-connect-dialog/wifi-connect-dialog.component.ts
+++ b/libs/wifi/ui/src/lib/wifi-connect-dialog/wifi-connect-dialog.component.ts
@@ -14,45 +14,7 @@ export interface WifiConnectDialogData {
 @Component({
   selector: 'choh-wifi-connect-dialog',
   imports: [FormsModule, MatFormFieldModule, MatInputModule, MatButtonModule],
-  template: `
-    <div class="flex flex-col gap-4 p-4 min-w-[280px]">
-      <h2 class="text-lg font-medium m-0">WiFi に接続</h2>
-      <form class="flex flex-col gap-3" (ngSubmit)="$event.preventDefault(); connect()">
-        <mat-form-field appearance="outline">
-          <mat-label>SSID</mat-label>
-          <input matInput name="ssid" [(ngModel)]="ssid" [disabled]="connecting()" />
-        </mat-form-field>
-        <mat-form-field appearance="outline">
-          <mat-label>パスワード</mat-label>
-          <input
-            matInput
-            type="password"
-            name="password"
-            [(ngModel)]="password"
-            [disabled]="connecting()"
-            autocomplete="off"
-          />
-        </mat-form-field>
-        <div class="flex justify-end gap-2">
-          <button
-            mat-stroked-button
-            type="button"
-            (click)="cancel()"
-            [disabled]="connecting()"
-          >
-            キャンセル
-          </button>
-          <button mat-flat-button color="primary" type="submit" [disabled]="connecting()">
-            @if (connecting()) {
-              接続中…
-            } @else {
-              接続
-            }
-          </button>
-        </div>
-      </form>
-    </div>
-  `,
+  templateUrl: './wifi-connect-dialog.component.html',
 })
 export class WifiConnectDialogComponent implements OnInit {
   private readonly dialogRef = inject(DialogRef<boolean>);

--- a/libs/wifi/ui/src/lib/wifi-form/wifi-form.component.html
+++ b/libs/wifi/ui/src/lib/wifi-form/wifi-form.component.html
@@ -1,0 +1,10 @@
+<form class="flex flex-row items-center" (ngSubmit)="onSubmit($event)">
+  <mat-form-field class="mr-2.5">
+    <mat-label>SSID</mat-label>
+    <input matInput type="text" name="ssid" [(ngModel)]="ssid" />
+  </mat-form-field>
+  <mat-form-field class="mr-2.5">
+    <mat-label>Password</mat-label>
+    <input matInput [type]="'password'" name="password" [(ngModel)]="password" />
+  </mat-form-field>
+</form>

--- a/libs/wifi/ui/src/lib/wifi-form/wifi-form.component.ts
+++ b/libs/wifi/ui/src/lib/wifi-form/wifi-form.component.ts
@@ -14,18 +14,7 @@ export interface WifiFormSubmit {
 @Component({
   selector: 'choh-wifi-form',
   imports: [FormsModule, MatFormFieldModule, MatInputModule],
-  template: `
-    <form class="flex flex-row items-center" (ngSubmit)="onSubmit($event)">
-      <mat-form-field class="mr-2.5">
-        <mat-label>SSID</mat-label>
-        <input matInput type="text" name="ssid" [(ngModel)]="ssid" />
-      </mat-form-field>
-      <mat-form-field class="mr-2.5">
-        <mat-label>Password</mat-label>
-        <input matInput [type]="'password'" name="password" [(ngModel)]="password" />
-      </mat-form-field>
-    </form>
-  `,
+  templateUrl: './wifi-form.component.html',
 })
 export class WifiFormComponent {
   ssid = '';

--- a/libs/wifi/ui/src/lib/wifi-list/wifi-list.component.html
+++ b/libs/wifi/ui/src/lib/wifi-list/wifi-list.component.html
@@ -1,0 +1,13 @@
+<div>
+  <h3>WiFi Scan Result</h3>
+</div>
+<div class="max-h-[620px] overflow-y-auto w-full">
+  @for (wifiInfo of wifiInfoList(); track wifiInfo.address + wifiInfo.ssid + $index) {
+    <choh-wifi-info
+      [wifiInfo]="wifiInfo"
+      (selectNetwork)="networkSelected.emit($event)"
+    />
+  } @empty {
+    <span>スキャン結果がありません。「Wifi Scan」で取得してください。</span>
+  }
+</div>

--- a/libs/wifi/ui/src/lib/wifi-list/wifi-list.component.ts
+++ b/libs/wifi/ui/src/lib/wifi-list/wifi-list.component.ts
@@ -9,21 +9,7 @@ import { WifiInfoComponent } from '../wifi-info/wifi-info.component';
 @Component({
   selector: 'choh-wifi-list',
   imports: [WifiInfoComponent, MatDividerModule],
-  template: `
-    <div>
-      <h3>WiFi Scan Result</h3>
-    </div>
-    <div class="max-h-[620px] overflow-y-auto w-full">
-      @for (wifiInfo of wifiInfoList(); track wifiInfo.address + wifiInfo.ssid + $index) {
-        <choh-wifi-info
-          [wifiInfo]="wifiInfo"
-          (selectNetwork)="networkSelected.emit($event)"
-        />
-      } @empty {
-        <span>スキャン結果がありません。「Wifi Scan」で取得してください。</span>
-      }
-    </div>
-  `,
+  templateUrl: './wifi-list.component.html',
 })
 export class WifiListComponent {
   readonly wifiInfoList = input<WiFiInfo[]>([]);

--- a/libs/wifi/ui/src/lib/wifi-status/wifi-status.component.html
+++ b/libs/wifi/ui/src/lib/wifi-status/wifi-status.component.html
@@ -1,0 +1,10 @@
+@if (status(); as st) {
+  <div class="wifi-status">
+    @if (st.ipInfo) {
+      <pre class="text-sm">{{ st.ipInfo }}</pre>
+    }
+    @if (st.wlInfo) {
+      <pre class="text-sm">{{ st.wlInfo }}</pre>
+    }
+  </div>
+}

--- a/libs/wifi/ui/src/lib/wifi-status/wifi-status.component.ts
+++ b/libs/wifi/ui/src/lib/wifi-status/wifi-status.component.ts
@@ -11,18 +11,7 @@ export interface WifiStatusData {
  */
 @Component({
   selector: 'choh-wifi-status',
-  template: `
-    @if (status(); as st) {
-      <div class="wifi-status">
-        @if (st.ipInfo) {
-          <pre class="text-sm">{{ st.ipInfo }}</pre>
-        }
-        @if (st.wlInfo) {
-          <pre class="text-sm">{{ st.wlInfo }}</pre>
-        }
-      </div>
-    }
-  `,
+  templateUrl: './wifi-status.component.html',
 })
 export class WifiStatusComponent {
   readonly status = input<WifiStatusData | null>(null);


### PR DESCRIPTION
## Summary

Issue #531 に対応し、`template` を TypeScript にインライン記述していた Angular コンポーネントを `*.component.html` に分離しました。
ドメイン単位で段階的に変換し、構造の一貫性と可読性を向上させています。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #531

## What changed?

- terminal / setup / connect / console-shell / dialogs / editor / file-manager / pin-assign-panel / remote / wifi の各ドメインで inline template を分離
- 各対象コンポーネントで `@Component({ template: ... })` を `templateUrl: './*.component.html'` に置換
- 変換はテンプレート分離のみに限定し、コンポーネントロジックは変更なし

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx affected -t lint --files=<changed-files>` を各ドメイン変更時に実行し、lint が通ることを確認
2. 主要画面（terminal/editor/file-manager/wifi/remote/connect/setup）を表示し、テンプレート表示崩れがないことを確認
3. 各画面の主要操作（接続、編集、一覧表示、ダイアログ表示）で回帰がないことを確認

## Environment (if relevant)

- Browser:
- OS: macOS
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)