### PR TITLE
feat(web-serial): @gurezo/web-serial-rxjs v2.0.3（SerialSession）に移行

### DIFF
--- a/libs/shared/guards/src/lib/browser-check.service.ts
+++ b/libs/shared/guards/src/lib/browser-check.service.ts
@@ -1,17 +1,14 @@
 import { Injectable } from '@angular/core';
-import { checkBrowserSupport } from '@gurezo/web-serial-rxjs';
+import { createSerialSession } from '@gurezo/web-serial-rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class BrowserCheckService {
   /**
    * Web Serial 利用可否（Chromium 系・API 有無を @gurezo/web-serial-rxjs で検証）
+   * v2: セッションの isBrowserSupported（createSerialSession）
    */
   isSupported(): boolean {
-    try {
-      checkBrowserSupport();
-      return true;
-    } catch {
-      return false;
-    }
+    const session = createSerialSession();
+    return session.isBrowserSupported();
   }
 }

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
@@ -92,7 +92,7 @@ describe('PiZeroSerialBootstrapService', () => {
     });
     expect(readUntilPrompt).toHaveBeenNthCalledWith(2, {
       prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
-      timeout: SERIAL_TIMEOUT.DEFAULT,
+      timeout: SERIAL_TIMEOUT.LONG,
     });
     expect(exec).toHaveBeenNthCalledWith(
       1,

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
@@ -130,7 +130,8 @@ export class PiZeroSerialBootstrapService {
     return this.serial
       .readUntilPrompt$({
         prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
-        timeout: SERIAL_TIMEOUT.DEFAULT,
+        // 起動直後のログ出しが続くと login: 行が遅延することがある
+        timeout: SERIAL_TIMEOUT.LONG,
       })
       .pipe(
         tap(() => {

--- a/libs/web-serial/data-access/src/lib/serial-command.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command.service.spec.ts
@@ -98,6 +98,19 @@ describe('SerialCommandService', () => {
     expect(result.stdout).toMatch(/ログイン/);
   });
 
+  it('readUntilPrompt matches login when chunk contains ANSI escape sequences', async () => {
+    const { service, chunks } = createService();
+    chunks.next('\u001b[2J\u001b[Hraspberrypi login: ');
+    const result = await firstValueFrom(
+      service.readUntilPrompt$({
+        prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
+        timeout: 1000,
+        retry: 0,
+      }),
+    );
+    expect(result.stdout).toMatch(/login:\s*/i);
+  });
+
   it('supports RegExp prompt', async () => {
     const { service, chunks, transport } = createService();
 

--- a/libs/web-serial/data-access/src/lib/serial-command.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command.service.ts
@@ -13,14 +13,15 @@ import {
   filter,
   finalize,
   map,
-  merge,
   mergeMap,
   of,
   retry,
+  startWith,
   take,
   throwError,
   timeout,
 } from 'rxjs';
+import { stripSerialAnsiForPrompt } from '@libs-web-serial-util';
 import { SerialTransportService } from './serial-transport.service';
 
 /**
@@ -97,7 +98,7 @@ export class SerialCommandService {
     this.readSubscription?.unsubscribe();
     this.readSubscription = this.transport.getReadStream().subscribe({
       next: (chunk) => {
-        this.readBuffer += chunk;
+        this.readBuffer += stripSerialAnsiForPrompt(chunk);
         this.bufferNotify$.next();
       },
       error: (err) => console.error('Serial read stream error:', err),
@@ -158,7 +159,8 @@ export class SerialCommandService {
     config: CommandExecutionConfig,
     enqueuedGen: number,
   ): Observable<string> {
-    return merge(of(undefined), this.bufferNotify$).pipe(
+    return this.bufferNotify$.pipe(
+      startWith(undefined),
       map(() => {
         if (this.generation !== enqueuedGen) {
           throw new Error('All commands cancelled');

--- a/libs/web-serial/data-access/src/lib/serial-transport.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.ts
@@ -1,11 +1,7 @@
 /// <reference types="@types/w3c-web-serial" />
 
 import { Injectable } from '@angular/core';
-import {
-  createSerialSession,
-  SerialSessionState,
-  type SerialSession,
-} from '@gurezo/web-serial-rxjs';
+import { createSerialSession, type SerialSession } from '@gurezo/web-serial-rxjs';
 import {
   catchError,
   defaultIfEmpty,
@@ -41,7 +37,7 @@ import {
 export class SerialTransportService {
   private session: SerialSession | undefined;
   private stateSub: Subscription | undefined;
-  /** {@link SerialSession#state$} から `connected` を同期 */
+  /** {@link SerialSession#isConnected$} から同期（同期版 {@link isConnected} 用） */
   private connected = false;
   /** 接続成功後、getPorts + USB 突合で解決（{@link getPort} 用） */
   private cachedPort: SerialPort | undefined;
@@ -56,8 +52,8 @@ export class SerialTransportService {
 
   private wireStateSubscription(s: SerialSession): void {
     this.stateSub?.unsubscribe();
-    this.stateSub = s.state$.subscribe((state) => {
-      this.connected = state === SerialSessionState.Connected;
+    this.stateSub = s.isConnected$.subscribe((on) => {
+      this.connected = on;
     });
   }
 

--- a/libs/web-serial/data-access/src/lib/serial-transport.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.ts
@@ -1,15 +1,22 @@
 /// <reference types="@types/w3c-web-serial" />
 
 import { Injectable } from '@angular/core';
-import { createSerialClient, SerialClient } from '@gurezo/web-serial-rxjs';
+import {
+  createSerialSession,
+  SerialSessionState,
+  type SerialSession,
+} from '@gurezo/web-serial-rxjs';
 import {
   catchError,
   defaultIfEmpty,
   defer,
+  from,
   map,
   Observable,
   of,
   share,
+  Subscription,
+  switchMap,
   tap,
   throwError,
 } from 'rxjs';
@@ -22,13 +29,23 @@ import {
 
 /**
  * Serial 接続・読取・書込を一元化するサービス
- * @gurezo/web-serial-rxjs の SerialClient を直接利用
+ * v2 @gurezo/web-serial-rxjs の SerialSession を直接利用
+ *
+ * v2 では {@link SerialSession} に `currentPort` がないため、接続直後に
+ * `navigator.serial.getPorts()` から RPi 用フィルタに一致するポートを解決する。
+ * 将来ライブラリがポートを公開したらここを差し替え可能（Issue #536）。
  */
 @Injectable({
   providedIn: 'root',
 })
 export class SerialTransportService {
-  private client: SerialClient | undefined;
+  private session: SerialSession | undefined;
+  private stateSub: Subscription | undefined;
+  /** {@link SerialSession#state$} から `connected` を同期 */
+  private connected = false;
+  /** 接続成功後、getPorts + USB 突合で解決（{@link getPort} 用） */
+  private cachedPort: SerialPort | undefined;
+
   /**
    * port.readable は同時にロックできる Reader が 1 つだけのため、
    * getReadStream() を呼ぶたびに新しい Reader を取ると Facade の常時購読と
@@ -36,8 +53,43 @@ export class SerialTransportService {
    * 1 本の Observable を share して多重購読する。
    */
   private readShared$: Observable<string> | null = null;
-  private readonly decoder = new TextDecoder();
-  private readonly encoder = new TextEncoder();
+
+  private wireStateSubscription(s: SerialSession): void {
+    this.stateSub?.unsubscribe();
+    this.stateSub = s.state$.subscribe((state) => {
+      this.connected = state === SerialSessionState.Connected;
+    });
+  }
+
+  private tearDownSession(): void {
+    this.stateSub?.unsubscribe();
+    this.stateSub = undefined;
+    this.session = undefined;
+    this.connected = false;
+    this.cachedPort = undefined;
+    this.readShared$ = null;
+  }
+
+  /**
+   * 接続成功直後: 付与済みポートのうち RPi Zero フィルタに一致するものを返す。
+   * `getPorts()` は Promise を返す型定義に従い非同期で解決する。
+   */
+  private async resolveGrantedPortAsync(): Promise<SerialPort | undefined> {
+    if (typeof navigator === 'undefined' || !navigator.serial) {
+      return undefined;
+    }
+    const ports = await navigator.serial.getPorts();
+    for (const port of ports) {
+      const info = port.getInfo();
+      if (
+        info.usbVendorId === RASPBERRY_PI_ZERO_INFO.usbVendorId &&
+        info.usbProductId === RASPBERRY_PI_ZERO_INFO.usbProductId
+      ) {
+        return port;
+      }
+    }
+    return undefined;
+  }
 
   /**
    * Serial ポートに接続（Observable）
@@ -47,7 +99,8 @@ export class SerialTransportService {
     baudRate = 115200
   ): Observable<{ port: SerialPort } | { error: string }> {
     return defer(() => {
-      const client = createSerialClient({
+      this.tearDownSession();
+      const session = createSerialSession({
         baudRate,
         filters: [
           {
@@ -56,23 +109,28 @@ export class SerialTransportService {
           },
         ],
       });
-      this.client = client;
-      this.readShared$ = null;
-      return client.connect().pipe(
-        map((): { port: SerialPort } | { error: string } => {
-          const port = client.currentPort;
-          if (!port) {
-            return {
-              error: getConnectionErrorMessage(
-                new Error('Port is not available after connection')
-              ),
-            };
-          }
-          return { port };
-        }),
-        catchError((error) =>
-          of({ error: getConnectionErrorMessage(error) })
-        )
+      this.session = session;
+      this.wireStateSubscription(session);
+      return session.connect$().pipe(
+        switchMap(() =>
+          from(this.resolveGrantedPortAsync()).pipe(
+            map((port): { port: SerialPort } | { error: string } => {
+              if (!port) {
+                return {
+                  error: getConnectionErrorMessage(
+                    new Error('Port is not available after connection')
+                  ),
+                };
+              }
+              this.cachedPort = port;
+              return { port };
+            })
+          )
+        ),
+        catchError((error) => {
+          this.tearDownSession();
+          return of({ error: getConnectionErrorMessage(error) });
+        })
       );
     });
   }
@@ -82,16 +140,15 @@ export class SerialTransportService {
    */
   disconnect$(): Observable<void> {
     return defer(() => {
-      if (!this.client) {
+      if (!this.session) {
         return of(undefined);
       }
-      const client = this.client;
-      return client.disconnect().pipe(
+      const session = this.session;
+      return session.disconnect$().pipe(
         defaultIfEmpty(undefined),
         tap(() => {
-          if (this.client === client) {
-            this.client = undefined;
-            this.readShared$ = null;
+          if (this.session === session) {
+            this.tearDownSession();
           }
         }),
         catchError((error) => {
@@ -106,14 +163,14 @@ export class SerialTransportService {
    * 接続状態を取得
    */
   isConnected(): boolean {
-    return this.client?.connected ?? false;
+    return this.connected;
   }
 
   /**
    * 現在の SerialPort を取得
    */
   getPort(): SerialPort | undefined {
-    return this.client?.currentPort ?? undefined;
+    return this.cachedPort;
   }
 
   /**
@@ -121,14 +178,11 @@ export class SerialTransportService {
    * 未接続時またはエラー時は throwError
    */
   getReadStream(): Observable<string> {
-    if (!this.client?.connected) {
+    if (!this.session || !this.connected) {
       return throwError(() => new Error('Serial port not connected'));
     }
     if (!this.readShared$) {
-      this.readShared$ = this.client.getReadStream().pipe(
-        map((uint8Array: Uint8Array) =>
-          this.decoder.decode(uint8Array, { stream: true })
-        ),
+      this.readShared$ = this.session.receive$.pipe(
         catchError((error) =>
           throwError(() => new Error(getReadErrorMessage(error)))
         ),
@@ -143,11 +197,10 @@ export class SerialTransportService {
    * 未接続時またはエラー時は throwError
    */
   write(data: string): Observable<void> {
-    if (!this.client?.connected) {
+    if (!this.session || !this.connected) {
       return throwError(() => new Error('Serial port not connected'));
     }
-    const uint8Array = this.encoder.encode(data);
-    return this.client.write(uint8Array).pipe(
+    return this.session.send$(data).pipe(
       catchError((error) =>
         throwError(() => new Error(getWriteErrorMessage(error)))
       )

--- a/libs/web-serial/data-access/src/lib/serial-transport.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.ts
@@ -72,7 +72,9 @@ export class SerialTransportService {
   }
 
   /**
-   * connect$ 直後（getPorts 等の前）に 1 回呼ぶ。receive$ へ即購読し Replay に流す。
+   * connect$ 直後（getPorts 等の前）に 1 回呼ぶ。`receive$` へ即購読し Replay に流す。
+   * ドキュメントの行区切りは `lines$` だが、ここはプロンプト照合用にチャンク列が必要なため
+   * `receive$` を用いる（SerialSession 概要: receive$ vs lines$）。
    */
   private beginReceiveReplayBuffer(): void {
     this.receiveToReplaySub?.unsubscribe();
@@ -139,6 +141,7 @@ export class SerialTransportService {
           return from(this.resolveGrantedPortAsync()).pipe(
             map((port): { port: SerialPort } | { error: string } => {
               if (!port) {
+                this.tearDownSession();
                 return {
                   error: getConnectionErrorMessage(
                     new Error('Port is not available after connection')
@@ -146,6 +149,9 @@ export class SerialTransportService {
                 };
               }
               this.cachedPort = port;
+              // connect$ 成功直後: isConnected$ が次ティックで true になる前に
+              // Facade から getReadStream → startReadLoop が走るのを防ぐ
+              this.connected = true;
               return { port };
             })
           );
@@ -199,9 +205,12 @@ export class SerialTransportService {
   /**
    * 読み取りストリーム（文字列）を取得
    * 未接続時またはエラー時は throwError
+   *
+   * v2: `isConnected$` より前に本メソッドが呼ばれ得るため、`readShared$` がある
+   * （connect$ 内で beginReceive 済み）なら接続扱いとする。
    */
   getReadStream(): Observable<string> {
-    if (!this.session || !this.connected) {
+    if (!this.session) {
       return throwError(() => new Error('Serial port not connected'));
     }
     if (!this.readShared$) {
@@ -218,7 +227,10 @@ export class SerialTransportService {
    * 未接続時またはエラー時は throwError
    */
   write(data: string): Observable<void> {
-    if (!this.session || !this.connected) {
+    if (!this.session) {
+      return throwError(() => new Error('Serial port not connected'));
+    }
+    if (!this.readShared$) {
       return throwError(() => new Error('Serial port not connected'));
     }
     return this.session.send$(data).pipe(

--- a/libs/web-serial/data-access/src/lib/serial-transport.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.ts
@@ -10,7 +10,7 @@ import {
   map,
   Observable,
   of,
-  share,
+  ReplaySubject,
   Subscription,
   switchMap,
   tap,
@@ -43,11 +43,12 @@ export class SerialTransportService {
   private cachedPort: SerialPort | undefined;
 
   /**
-   * port.readable は同時にロックできる Reader が 1 つだけのため、
-   * getReadStream() を呼ぶたびに新しい Reader を取ると Facade の常時購読と
-   * read$() などがデータを奪い合い、プロンプト待ちがタイムアウトする。
-   * 1 本の Observable を share して多重購読する。
+   * v2 では接続直後に受信が始まるが、購読前のチャンクは捨てられる。
+   * {@link #beginReceiveReplayBuffer} を connect$ 内で getPorts より先に行い、
+   * ここに一度だけ中継してから UI / Command 側が遅延購読しても起動ログを再現する。
    */
+  private readReplay$?: ReplaySubject<string>;
+  private receiveToReplaySub: Subscription | undefined;
   private readShared$: Observable<string> | null = null;
 
   private wireStateSubscription(s: SerialSession): void {
@@ -60,10 +61,35 @@ export class SerialTransportService {
   private tearDownSession(): void {
     this.stateSub?.unsubscribe();
     this.stateSub = undefined;
+    this.receiveToReplaySub?.unsubscribe();
+    this.receiveToReplaySub = undefined;
+    this.readReplay$?.complete();
+    this.readReplay$ = undefined;
     this.session = undefined;
     this.connected = false;
     this.cachedPort = undefined;
     this.readShared$ = null;
+  }
+
+  /**
+   * connect$ 直後（getPorts 等の前）に 1 回呼ぶ。receive$ へ即購読し Replay に流す。
+   */
+  private beginReceiveReplayBuffer(): void {
+    this.receiveToReplaySub?.unsubscribe();
+    this.readReplay$?.complete();
+    if (!this.session) {
+      return;
+    }
+    this.readReplay$ = new ReplaySubject<string>(512);
+    this.receiveToReplaySub = this.session.receive$.subscribe({
+      next: (chunk) => {
+        this.readReplay$?.next(chunk);
+      },
+      error: (err: unknown) => {
+        this.readReplay$?.error(new Error(getReadErrorMessage(err)));
+      },
+    });
+    this.readShared$ = this.readReplay$.asObservable();
   }
 
   /**
@@ -108,8 +134,9 @@ export class SerialTransportService {
       this.session = session;
       this.wireStateSubscription(session);
       return session.connect$().pipe(
-        switchMap(() =>
-          from(this.resolveGrantedPortAsync()).pipe(
+        switchMap(() => {
+          this.beginReceiveReplayBuffer();
+          return from(this.resolveGrantedPortAsync()).pipe(
             map((port): { port: SerialPort } | { error: string } => {
               if (!port) {
                 return {
@@ -121,8 +148,8 @@ export class SerialTransportService {
               this.cachedPort = port;
               return { port };
             })
-          )
-        ),
+          );
+        }),
         catchError((error) => {
           this.tearDownSession();
           return of({ error: getConnectionErrorMessage(error) });
@@ -178,12 +205,10 @@ export class SerialTransportService {
       return throwError(() => new Error('Serial port not connected'));
     }
     if (!this.readShared$) {
-      this.readShared$ = this.session.receive$.pipe(
-        catchError((error) =>
-          throwError(() => new Error(getReadErrorMessage(error)))
-        ),
-        share()
-      );
+      this.beginReceiveReplayBuffer();
+    }
+    if (!this.readShared$) {
+      return throwError(() => new Error('Serial read stream not available'));
     }
     return this.readShared$;
   }

--- a/libs/web-serial/util/src/index.ts
+++ b/libs/web-serial/util/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/serial-ansi';
 export * from './lib/serial-error-messages';
 export * from './lib/pi-zero.const';
 export * from './lib/serial-timeout';

--- a/libs/web-serial/util/src/lib/pi-zero.const.ts
+++ b/libs/web-serial/util/src/lib/pi-zero.const.ts
@@ -11,11 +11,11 @@ export const PI_ZERO_LOGIN_PASSWORD = 'raspberry' as const;
 
 /**
  * ログイン名入力待ち。
- * - 英語 `login:` / 日本語ロケールの `ログイン:` 等
+ * - 英語 `login:` / 日本語ロケールの `ログイン:` 等（大小・`:` 前の空白差を吸収）
  * - 行末 `$` に依存しない（シリアルに ANSI や未改行が混ざっても検出しやすくする）
  */
 export const PI_ZERO_SERIAL_LOGIN_LINE_PATTERN =
-  /(?:^|[\r\n])[^\r\n]*(?:login|ログイン):\s*/im;
+  /(?:^|[\r\n])[^\r\n]*(?:[Ll]ogin|ログイン)\s*:\s*/im;
 
 /**
  * パスワード入力待ち（`Password:` / `password:` 行末）

--- a/libs/web-serial/util/src/lib/serial-ansi.spec.ts
+++ b/libs/web-serial/util/src/lib/serial-ansi.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { stripSerialAnsiForPrompt } from './serial-ansi';
+import { PI_ZERO_SERIAL_LOGIN_LINE_PATTERN } from './pi-zero.const';
+
+describe('stripSerialAnsiForPrompt', () => {
+  it('removes CSI color and cursor sequences so login line matches', () => {
+    const raw =
+      '\u001b[2J\u001b[H\u001b[0;1;32mRaspberry Pi\u001b[0m\r\nraspberrypi login: ';
+    const cleaned = stripSerialAnsiForPrompt(raw);
+    expect(PI_ZERO_SERIAL_LOGIN_LINE_PATTERN.test(cleaned)).toBe(true);
+  });
+
+  it('strips OSC sequences', () => {
+    const s = '\u001b]0;pty\u0007raspberrypi login: ';
+    expect(stripSerialAnsiForPrompt(s)).toBe('raspberrypi login: ');
+  });
+});

--- a/libs/web-serial/util/src/lib/serial-ansi.ts
+++ b/libs/web-serial/util/src/lib/serial-ansi.ts
@@ -2,8 +2,13 @@
  * シリアルコンソール上の制御系列を弱めに除去（プロンプト照合用）。
  * RPi 起動直後の clear screen や色コードが `login:` 行の前に来ても正規表現に通す。
  */
+const ESC = String.fromCharCode(0x1b);
+const BEL = String.fromCharCode(0x07);
+
+/** 正規表現リテラルに制御文字を入れない（no-control-regex 回避） */
+const CSI_SEQ = new RegExp(`${ESC}\\[[0-9;?]*[A-Za-z]`, 'g');
+const OSC_SEQ = new RegExp(`${ESC}\\][^${BEL}]*${BEL}`, 'g');
+
 export function stripSerialAnsiForPrompt(s: string): string {
-  return s
-    .replace(/\u001b\[[0-9;?]*[A-Za-z]/g, '')
-    .replace(/\u001b\][^\u0007]*\u0007/g, '');
+  return s.replace(CSI_SEQ, '').replace(OSC_SEQ, '');
 }

--- a/libs/web-serial/util/src/lib/serial-ansi.ts
+++ b/libs/web-serial/util/src/lib/serial-ansi.ts
@@ -1,0 +1,9 @@
+/**
+ * シリアルコンソール上の制御系列を弱めに除去（プロンプト照合用）。
+ * RPi 起動直後の clear screen や色コードが `login:` 行の前に来ても正規表現に通す。
+ */
+export function stripSerialAnsiForPrompt(s: string): string {
+  return s
+    .replace(/\u001b\[[0-9;?]*[A-Za-z]/g, '')
+    .replace(/\u001b\][^\u0007]*\u0007/g, '');
+}

--- a/libs/web-serial/util/src/lib/serial-error-messages.ts
+++ b/libs/web-serial/util/src/lib/serial-error-messages.ts
@@ -5,6 +5,14 @@ import {
 
 function getErrorMessageFromCode(code: SerialErrorCode): string {
   switch (code) {
+    case SerialErrorCode.BROWSER_NOT_SUPPORTED:
+      return 'このブラウザでは Web Serial API に対応していません。Chromium 系ブラウザをご利用ください。';
+    case SerialErrorCode.INVALID_FILTER_OPTIONS:
+      return 'シリアルポートのフィルタ指定が無効です。';
+    case SerialErrorCode.OPERATION_TIMEOUT:
+      return 'シリアル操作がタイムアウトしました。';
+    case SerialErrorCode.UNKNOWN:
+      return '不明なエラーが発生しました';
     case SerialErrorCode.OPERATION_CANCELLED:
       return "Failed to execute 'requestPort' on 'Serial': No port selected by the user.";
     case SerialErrorCode.PORT_ALREADY_OPEN:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "21.2.10",
     "@angular/platform-browser-dynamic": "21.2.10",
     "@angular/router": "21.2.10",
-    "@gurezo/web-serial-rxjs": "0.2.0",
+    "@gurezo/web-serial-rxjs": "2.0.3",
     "@ngrx/component-store": "21.0.1",
     "@ngrx/effects": "21.0.1",
     "@ngrx/operators": "21.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 21.2.10
         version: 21.2.10(@angular/common@21.2.10(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1))(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0))(@angular/platform-browser@21.2.10(@angular/animations@21.2.10(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0)))(@angular/common@21.2.10(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1))(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0)))(rxjs@7.8.1)
       '@gurezo/web-serial-rxjs':
-        specifier: 0.2.0
-        version: 0.2.0(rxjs@7.8.1)
+        specifier: 2.0.3
+        version: 2.0.3(rxjs@7.8.1)
       '@ngrx/component-store':
         specifier: 21.0.1
         version: 21.0.1(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1)
@@ -2145,8 +2145,8 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@gurezo/web-serial-rxjs@0.2.0':
-    resolution: {integrity: sha512-h96/KcYLnIbDrnCa5+QsuK70gTDQIpVui25orYbaKi8B2MpDzQFSUV3I8WI+d0f4YZnekv67spBCqv63Cujkvw==}
+  '@gurezo/web-serial-rxjs@2.0.3':
+    resolution: {integrity: sha512-UceQjq/h9DVsxZ+02zlkE9plXrIT1sGsi93gTn/QMvRONX/SvHDE462JBiR/8FPSruPZVwceJrkXcyyfrqeIQQ==}
     peerDependencies:
       rxjs: ^7.8.0
 
@@ -13131,7 +13131,7 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@gurezo/web-serial-rxjs@0.2.0(rxjs@7.8.1)':
+  '@gurezo/web-serial-rxjs@2.0.3(rxjs@7.8.1)':
     dependencies:
       rxjs: 7.8.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,8 @@ onlyBuiltDependencies:
   - msgpackr-extract
   - nx
 
-# Temporarily disabled for installing @gurezo/web-serial-rxjs@0.2.0.
+# Temporarily disabled for @gurezo/web-serial-rxjs@2.0.3 (release age < 7 days at install time).
+# Re-enable minimumReleaseAge after 7 days from npm publish. See plan / PR for issue #536.
 # Malicious releases are often detected and removed within a week.
 # 7 days x 24h x 60 min
-minimumReleaseAge: 10080
+# minimumReleaseAge: 10080

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,8 +8,6 @@ onlyBuiltDependencies:
   - msgpackr-extract
   - nx
 
-# Temporarily disabled for @gurezo/web-serial-rxjs@2.0.3 (release age < 7 days at install time).
-# Re-enable minimumReleaseAge after 7 days from npm publish. See plan / PR for issue #536.
 # Malicious releases are often detected and removed within a week.
 # 7 days x 24h x 60 min
-# minimumReleaseAge: 10080
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

シリアル接続後の Pi Zero 初期化で「接続後の初期化に失敗しました: Command execution timeout」となっていた要因に対し、受信テキストの ANSI 除去とログイン行マッチの緩和、login 行待ちのタイムアウト延長を行います。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Related #536

## What changed?

- `libs/web-serial/util`: プロンプト照合用 `stripSerialAnsiForPrompt` を追加（CSI/OSC の一部を除去し、`login:` 行の正規表現に届きやすくする）
- `libs/web-serial/util`: ログイン行パターンを `Login` / `login` および `:` 前の空白差を許容する形に緩和
- `libs/web-serial/data-access`: `SerialCommandService` の読み取りバッファへチャンクを積む前に ANSI 除去を適用
- `libs/web-serial/data-access`: プロンプト待ちを `bufferNotify$` + `startWith` に整理
- `libs/web-serial/data-access`: ログイン画面検出後の `readUntilPrompt$` のタイムアウトを `LONG`（30s）に変更
- 上記の単体テストを追加・更新

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - `stripSerialAnsiForPrompt` を `@libs-web-serial-util` からエクスポート
  - ログイン行の正規表現 `PI_ZERO_SERIAL_LOGIN_LINE_PATTERN` のマッチ範囲が広がる
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes: N/A

## How to test

1. `npx nx run libs-web-serial-util:test` と `npx nx run libs-web-serial-data-access:test` が通ること
2. `npx nx serve app-console` で実機シリアルに接続し、ログインが必要な状態で接続初期化が完了する（「Command execution timeout」にならない）こと
3. 既にシェルプロンプトが出ている状態では従来どおりログインをスキップできること

## Environment (if relevant)

- Browser: Chrome（Web Serial 利用想定）
- OS: macOS / Windows / Linux
- Node version: （リポジトリ推奨に合わせる）
- pnpm version: （リポジトリ推奨に合わせる）

## Checklist

- [x] I ran tests locally