### PR TITLE
feat(web-serial): @gurezo/web-serial-rxjs を v2.1.0 に更新

### DIFF
--- a/libs/web-serial/data-access/src/lib/serial-transport.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.ts
@@ -6,11 +6,8 @@ import {
   catchError,
   defaultIfEmpty,
   defer,
-  from,
-  map,
   Observable,
   of,
-  ReplaySubject,
   Subscription,
   switchMap,
   tap,
@@ -27,9 +24,8 @@ import {
  * Serial 接続・読取・書込を一元化するサービス
  * v2 @gurezo/web-serial-rxjs の SerialSession を直接利用
  *
- * v2 では {@link SerialSession} に `currentPort` がないため、接続直後に
- * `navigator.serial.getPorts()` から RPi 用フィルタに一致するポートを解決する。
- * 将来ライブラリがポートを公開したらここを差し替え可能（Issue #536）。
+ * v2.1.0 では {@link SerialSession.receiveReplay$} と {@link SerialSession.getCurrentPort}
+ * により、自前の ReplaySubject 中継や getPorts 突合が不要。
  */
 @Injectable({
   providedIn: 'root',
@@ -39,17 +35,6 @@ export class SerialTransportService {
   private stateSub: Subscription | undefined;
   /** {@link SerialSession#isConnected$} から同期（同期版 {@link isConnected} 用） */
   private connected = false;
-  /** 接続成功後、getPorts + USB 突合で解決（{@link getPort} 用） */
-  private cachedPort: SerialPort | undefined;
-
-  /**
-   * v2 では接続直後に受信が始まるが、購読前のチャンクは捨てられる。
-   * {@link #beginReceiveReplayBuffer} を connect$ 内で getPorts より先に行い、
-   * ここに一度だけ中継してから UI / Command 側が遅延購読しても起動ログを再現する。
-   */
-  private readReplay$?: ReplaySubject<string>;
-  private receiveToReplaySub: Subscription | undefined;
-  private readShared$: Observable<string> | null = null;
 
   private wireStateSubscription(s: SerialSession): void {
     this.stateSub?.unsubscribe();
@@ -61,58 +46,8 @@ export class SerialTransportService {
   private tearDownSession(): void {
     this.stateSub?.unsubscribe();
     this.stateSub = undefined;
-    this.receiveToReplaySub?.unsubscribe();
-    this.receiveToReplaySub = undefined;
-    this.readReplay$?.complete();
-    this.readReplay$ = undefined;
     this.session = undefined;
     this.connected = false;
-    this.cachedPort = undefined;
-    this.readShared$ = null;
-  }
-
-  /**
-   * connect$ 直後（getPorts 等の前）に 1 回呼ぶ。`receive$` へ即購読し Replay に流す。
-   * ドキュメントの行区切りは `lines$` だが、ここはプロンプト照合用にチャンク列が必要なため
-   * `receive$` を用いる（SerialSession 概要: receive$ vs lines$）。
-   */
-  private beginReceiveReplayBuffer(): void {
-    this.receiveToReplaySub?.unsubscribe();
-    this.readReplay$?.complete();
-    if (!this.session) {
-      return;
-    }
-    this.readReplay$ = new ReplaySubject<string>(512);
-    this.receiveToReplaySub = this.session.receive$.subscribe({
-      next: (chunk) => {
-        this.readReplay$?.next(chunk);
-      },
-      error: (err: unknown) => {
-        this.readReplay$?.error(new Error(getReadErrorMessage(err)));
-      },
-    });
-    this.readShared$ = this.readReplay$.asObservable();
-  }
-
-  /**
-   * 接続成功直後: 付与済みポートのうち RPi Zero フィルタに一致するものを返す。
-   * `getPorts()` は Promise を返す型定義に従い非同期で解決する。
-   */
-  private async resolveGrantedPortAsync(): Promise<SerialPort | undefined> {
-    if (typeof navigator === 'undefined' || !navigator.serial) {
-      return undefined;
-    }
-    const ports = await navigator.serial.getPorts();
-    for (const port of ports) {
-      const info = port.getInfo();
-      if (
-        info.usbVendorId === RASPBERRY_PI_ZERO_INFO.usbVendorId &&
-        info.usbProductId === RASPBERRY_PI_ZERO_INFO.usbProductId
-      ) {
-        return port;
-      }
-    }
-    return undefined;
   }
 
   /**
@@ -132,29 +67,25 @@ export class SerialTransportService {
             usbProductId: RASPBERRY_PI_ZERO_INFO.usbProductId,
           },
         ],
+        receiveReplay: { enabled: true, bufferSize: 512 },
       });
       this.session = session;
       this.wireStateSubscription(session);
       return session.connect$().pipe(
         switchMap(() => {
-          this.beginReceiveReplayBuffer();
-          return from(this.resolveGrantedPortAsync()).pipe(
-            map((port): { port: SerialPort } | { error: string } => {
-              if (!port) {
-                this.tearDownSession();
-                return {
-                  error: getConnectionErrorMessage(
-                    new Error('Port is not available after connection')
-                  ),
-                };
-              }
-              this.cachedPort = port;
-              // connect$ 成功直後: isConnected$ が次ティックで true になる前に
-              // Facade から getReadStream → startReadLoop が走るのを防ぐ
-              this.connected = true;
-              return { port };
-            })
-          );
+          const port = session.getCurrentPort();
+          if (!port) {
+            this.tearDownSession();
+            return of({
+              error: getConnectionErrorMessage(
+                new Error('Port is not available after connection')
+              ),
+            });
+          }
+          // connect$ 成功直後: isConnected$ が次ティックで true になる前に
+          // Facade から getReadStream → startReadLoop が走るのを防ぐ
+          this.connected = true;
+          return of({ port });
         }),
         catchError((error) => {
           this.tearDownSession();
@@ -199,27 +130,24 @@ export class SerialTransportService {
    * 現在の SerialPort を取得
    */
   getPort(): SerialPort | undefined {
-    return this.cachedPort;
+    return this.session?.getCurrentPort() ?? undefined;
   }
 
   /**
    * 読み取りストリーム（文字列）を取得
    * 未接続時またはエラー時は throwError
    *
-   * v2: `isConnected$` より前に本メソッドが呼ばれ得るため、`readShared$` がある
-   * （connect$ 内で beginReceive 済み）なら接続扱いとする。
+   * チャンクの replay は {@link SerialSession.receiveReplay$}（createSerialSession 時に有効化）。
    */
   getReadStream(): Observable<string> {
     if (!this.session) {
       return throwError(() => new Error('Serial port not connected'));
     }
-    if (!this.readShared$) {
-      this.beginReceiveReplayBuffer();
-    }
-    if (!this.readShared$) {
-      return throwError(() => new Error('Serial read stream not available'));
-    }
-    return this.readShared$;
+    return this.session.receiveReplay$.pipe(
+      catchError((err: unknown) =>
+        throwError(() => new Error(getReadErrorMessage(err)))
+      )
+    );
   }
 
   /**
@@ -227,10 +155,7 @@ export class SerialTransportService {
    * 未接続時またはエラー時は throwError
    */
   write(data: string): Observable<void> {
-    if (!this.session) {
-      return throwError(() => new Error('Serial port not connected'));
-    }
-    if (!this.readShared$) {
+    if (!this.session || !this.connected) {
       return throwError(() => new Error('Serial port not connected'));
     }
     return this.session.send$(data).pipe(

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "21.2.10",
     "@angular/platform-browser-dynamic": "21.2.10",
     "@angular/router": "21.2.10",
-    "@gurezo/web-serial-rxjs": "2.0.3",
+    "@gurezo/web-serial-rxjs": "2.1.0",
     "@ngrx/component-store": "21.0.1",
     "@ngrx/effects": "21.0.1",
     "@ngrx/operators": "21.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 21.2.10
         version: 21.2.10(@angular/common@21.2.10(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1))(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0))(@angular/platform-browser@21.2.10(@angular/animations@21.2.10(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0)))(@angular/common@21.2.10(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1))(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0)))(rxjs@7.8.1)
       '@gurezo/web-serial-rxjs':
-        specifier: 2.0.3
-        version: 2.0.3(rxjs@7.8.1)
+        specifier: 2.1.0
+        version: 2.1.0(rxjs@7.8.1)
       '@ngrx/component-store':
         specifier: 21.0.1
         version: 21.0.1(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1)
@@ -2145,8 +2145,8 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@gurezo/web-serial-rxjs@2.0.3':
-    resolution: {integrity: sha512-UceQjq/h9DVsxZ+02zlkE9plXrIT1sGsi93gTn/QMvRONX/SvHDE462JBiR/8FPSruPZVwceJrkXcyyfrqeIQQ==}
+  '@gurezo/web-serial-rxjs@2.1.0':
+    resolution: {integrity: sha512-QWFC0VVp3nlZgp2K3Rir4TeVaPEmaH3tl2cD7aBDyzmQGUGVTJ+LLs0KOmeDLXMjUq9IXa/rQxqrbQ1yAmeqsA==}
     peerDependencies:
       rxjs: ^7.8.0
 
@@ -13131,7 +13131,7 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@gurezo/web-serial-rxjs@2.0.3(rxjs@7.8.1)':
+  '@gurezo/web-serial-rxjs@2.1.0(rxjs@7.8.1)':
     dependencies:
       rxjs: 7.8.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,4 +10,4 @@ onlyBuiltDependencies:
 
 # Malicious releases are often detected and removed within a week.
 # 7 days x 24h x 60 min
-# minimumReleaseAge: 10080
+minimumReleaseAge: 10080

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,4 +10,4 @@ onlyBuiltDependencies:
 
 # Malicious releases are often detected and removed within a week.
 # 7 days x 24h x 60 min
-minimumReleaseAge: 10080
+# minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary

受信ストリームの replay 対応が入った `@gurezo/web-serial-rxjs` v2.1.0 へ更新し、`SerialTransportService` の自前 `ReplaySubject` 中継と `getPorts` によるポート解決をやめ、ライブラリの `receiveReplay$` と `getCurrentPort()` に寄せました。新規公開パッケージのインストールのため一時的に `minimumReleaseAge` を無効化し、インストール後に復元しています。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #538

## What changed?

- `pnpm-workspace.yaml`: 依存追加時のみ `minimumReleaseAge` をコメントアウトし、完了後に復元
- `package.json` / `pnpm-lock.yaml`: `@gurezo/web-serial-rxjs` を 2.1.0 に更新
- `libs/web-serial/data-access/src/lib/serial-transport.service.ts`: `receiveReplay` オプション、`receiveReplay$` の利用、`getCurrentPort()` で `getPort` を実装

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

アプリの公開 API は変更なし。シリアル受信はライブラリ側の replay バッファに依存するため、内部実装のみ差し替え。

## How to test

1. Chromium 系で Raspberry Pi Zero へ Web Serial 接続する
2. 接続直後のログ・シェルプロンプト待ちが従来どおり動くことを確認する
3. `pnpm exec nx run libs-web-serial-data-access:test` および `pnpm exec nx run libs-web-serial-util:test`

## Environment (if relevant)

- Browser: Chromium 系（Web Serial 利用）
- OS: macOS / Windows / Linux
- Node version: （ローカルで使用したバージョン）
- pnpm version: （ローカルで使用したバージョン）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant