### PR TITLE
refactor(web-serial): SerialTransportService を SerialSession 由来のストリームのみに集約

### DIFF
--- a/libs/web-serial/data-access/src/lib/serial-transport.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.spec.ts
@@ -1,22 +1,134 @@
-import { SerialSessionState } from '@gurezo/web-serial-rxjs';
-import { firstValueFrom } from 'rxjs';
-import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  SerialError,
+  SerialErrorCode,
+  SerialSessionState,
+  type SerialSession,
+} from '@gurezo/web-serial-rxjs';
+import {
+  BehaviorSubject,
+  EMPTY,
+  firstValueFrom,
+  of,
+  take,
+} from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SerialTransportService } from './serial-transport.service';
+
+const mockCreateSerialSession = vi.fn<[], SerialSession>();
+
+vi.mock('@gurezo/web-serial-rxjs', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@gurezo/web-serial-rxjs')>();
+  return {
+    ...actual,
+    createSerialSession: () => mockCreateSerialSession(),
+  };
+});
+
+function buildMockSession(port: SerialPort | null): SerialSession {
+  const state$ = new BehaviorSubject<SerialSessionState>(
+    SerialSessionState.Connecting
+  );
+  const isConnected$ = new BehaviorSubject(false);
+  const getCurrentPort = vi.fn<[], SerialPort | null>(() => port);
+
+  return {
+    isBrowserSupported: () => true,
+    connect$: vi.fn(() => {
+      state$.next(SerialSessionState.Connected);
+      isConnected$.next(true);
+      if (port) {
+        getCurrentPort.mockReturnValue(port);
+      }
+      return of(undefined);
+    }),
+    disconnect$: vi.fn(() => {
+      state$.next(SerialSessionState.Idle);
+      isConnected$.next(false);
+      getCurrentPort.mockReturnValue(null);
+      return of(undefined);
+    }),
+    state$: state$.asObservable(),
+    isConnected$: isConnected$.asObservable(),
+    portInfo$: of(null),
+    getPortInfo: vi.fn(() => null),
+    getCurrentPort,
+    errors$: EMPTY,
+    receive$: EMPTY,
+    receiveReplay$: of('chunk'),
+    lines$: of('line1'),
+    send$: vi.fn(() => of(undefined)),
+  } as unknown as SerialSession;
+}
 
 describe('SerialTransportService', () => {
   let service: SerialTransportService;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     service = new SerialTransportService();
   });
 
-  it('should report not connected and idle state before any session', async () => {
-    expect(service.isConnected()).toBe(false);
-    expect(service.getPort()).toBeUndefined();
-    expect(service.getPortInfo()).toBeNull();
+  it('should expose idle / not connected before any session is created', async () => {
     const state = await firstValueFrom(service.state$);
     expect(state).toBe(SerialSessionState.Idle);
     const connectedFlag = await firstValueFrom(service.isConnected$);
     expect(connectedFlag).toBe(false);
+    expect(service.isConnected()).toBe(false);
+    expect(service.getPort()).toBeUndefined();
+    expect(service.getPortInfo()).toBeNull();
+  });
+
+  it('should delegate state$ and isConnected$ to SerialSession after connect', async () => {
+    const mockPort = {} as SerialPort;
+    const session = buildMockSession(mockPort);
+    mockCreateSerialSession.mockReturnValue(session);
+
+    await firstValueFrom(service.connect$());
+
+    const state = await firstValueFrom(service.state$);
+    expect(state).toBe(SerialSessionState.Connected);
+    const connectedFlag = await firstValueFrom(service.isConnected$);
+    expect(connectedFlag).toBe(true);
+    expect(service.isConnected()).toBe(true);
+    expect(service.getPort()).toBe(mockPort);
+    expect(session.connect$).toHaveBeenCalledTimes(1);
+  });
+
+  it('should clear session and return to idle after disconnect', async () => {
+    const mockPort = {} as SerialPort;
+    mockCreateSerialSession.mockReturnValue(buildMockSession(mockPort));
+
+    await firstValueFrom(service.connect$());
+    expect(service.isConnected()).toBe(true);
+
+    await firstValueFrom(service.disconnect$());
+
+    const state = await firstValueFrom(service.state$);
+    expect(state).toBe(SerialSessionState.Idle);
+    expect(service.isConnected()).toBe(false);
+    expect(service.getPort()).toBeUndefined();
+  });
+
+  it('should expose errors$ from the active session when connected', async () => {
+    const mockPort = {} as SerialPort;
+    const err = new SerialError(SerialErrorCode.READ_FAILED, 'read');
+    const errSubj = new BehaviorSubject(err);
+    const session = buildMockSession(mockPort);
+    (session as { errors$: typeof errSubj }).errors$ = errSubj.asObservable();
+    mockCreateSerialSession.mockReturnValue(session);
+
+    await firstValueFrom(service.connect$());
+    const emitted = await firstValueFrom(service.errors$);
+    expect(emitted).toBe(err);
+  });
+
+  it('should emit from lines$ when session is active', async () => {
+    const mockPort = {} as SerialPort;
+    mockCreateSerialSession.mockReturnValue(buildMockSession(mockPort));
+
+    await firstValueFrom(service.connect$());
+    const line = await firstValueFrom(service.lines$.pipe(take(1)));
+    expect(line).toBe('line1');
   });
 });

--- a/libs/web-serial/data-access/src/lib/serial-transport.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.ts
@@ -10,13 +10,14 @@ import {
 import {
   BehaviorSubject,
   catchError,
+  concat,
   defaultIfEmpty,
   defer,
   distinctUntilChanged,
   EMPTY,
+  NEVER,
   Observable,
   of,
-  Subscription,
   switchMap,
   tap,
   throwError,
@@ -33,6 +34,10 @@ import {
  * v2 @gurezo/web-serial-rxjs の {@link SerialSession} を直接利用し、
  * `state$` / `isConnected$` / `errors$` 等をアプリ層に橋渡しする。
  *
+ * 接続状態の Source of truth は常に `SerialSession` 側。
+ * 本サービスは `activeSession$` のみで「どのセッションを流すか」を切り替え、
+ * ライブラリの Observable を重ねて二重管理しない。
+ *
  * 受信はチャンク単位: `createSerialSession({ receiveReplay: { enabled: true } })` により
  * {@link SerialSession.receiveReplay$} を使い、同一接続内で遅延購読者（例: ターミナル）へ
  * 直近バッファを引き渡す。行単位が欲しい場合はライブラリの `lines$` を別経路で購読する（シェル exec はチャンク蓄積が必要なため従来どおり `receiveReplay$` + Command バッファ）。
@@ -42,52 +47,53 @@ import {
 })
 export class SerialTransportService {
   private session: SerialSession | undefined;
-  private sessionSubscription = new Subscription();
 
-  /** 接続中セッションの `state$` をミラー。未接続・切断後は `idle`。 */
-  private readonly lifecycleState$ = new BehaviorSubject<SerialSessionState>(
-    SerialSessionState.Idle
+  /**
+   * 現在アクティブな {@link SerialSession}（接続試行前の失敗時は undefined）。
+   * state のミラーではなく、ストリームの `switchMap` 元のみ。
+   */
+  private readonly activeSession$ = new BehaviorSubject<
+    SerialSession | undefined
+  >(undefined);
+
+  /** ライブラリ {@link SerialSession.state$}。未接続時は `idle` を継続発火。 */
+  readonly state$ = this.activeSession$.pipe(
+    switchMap((s) =>
+      s
+        ? s.state$
+        : concat(of(SerialSessionState.Idle), NEVER)
+    ),
+    distinctUntilChanged()
   );
-  private readonly isConnectedState$ = new BehaviorSubject(false);
 
-  /** @gurezo/web-serial-rxjs 2.1.0 が npm 上の最新。API は TypeDoc 参照。 */
-  readonly state$ = this.lifecycleState$
-    .asObservable()
-    .pipe(distinctUntilChanged());
+  /** ライブラリ {@link SerialSession.isConnected$}。未接続時は `false` を継続。 */
+  readonly isConnected$ = this.activeSession$.pipe(
+    switchMap((s) =>
+      s ? s.isConnected$ : concat(of(false), NEVER)
+    ),
+    distinctUntilChanged()
+  );
 
-  /** ライブラリの `isConnected$` をミラー（未接続時は `false`）。 */
-  readonly isConnected$ = this.isConnectedState$
-    .asObservable()
-    .pipe(distinctUntilChanged());
-
-  private wireSession(s: SerialSession): void {
-    this.sessionSubscription.unsubscribe();
-    this.sessionSubscription = new Subscription();
-    this.sessionSubscription.add(
-      s.state$.subscribe((st) => this.lifecycleState$.next(st))
-    );
-    this.sessionSubscription.add(
-      s.isConnected$.subscribe((on) => this.isConnectedState$.next(on))
-    );
-  }
-
-  private tearDownSession(): void {
-    this.sessionSubscription.unsubscribe();
-    this.sessionSubscription = new Subscription();
-    this.session = undefined;
-    this.lifecycleState$.next(SerialSessionState.Idle);
-    this.isConnectedState$.next(false);
-  }
+  /**
+   * ライブラリ {@link SerialSession.lines$}。未接続時は無限に完了しない空ストリーム。
+   */
+  readonly lines$ = this.activeSession$.pipe(
+    switchMap((s) => (s ? s.lines$ : NEVER))
+  );
 
   /**
    * I/O エラー（`SerialError`）のライブラリ本流。未接続時は空ストリーム。
    */
   get errors$(): Observable<SerialError> {
-    return this.session?.errors$ ?? EMPTY;
+    return this.activeSession$.pipe(
+      switchMap((s) => s?.errors$ ?? EMPTY)
+    );
   }
 
   get portInfo$(): Observable<SerialPortInfo | null> {
-    return this.session?.portInfo$ ?? of(null);
+    return this.activeSession$.pipe(
+      switchMap((s) => s?.portInfo$ ?? of(null))
+    );
   }
 
   getPortInfo(): SerialPortInfo | null {
@@ -114,7 +120,7 @@ export class SerialTransportService {
         receiveReplay: { enabled: true, bufferSize: 512 },
       });
       this.session = session;
-      this.wireSession(session);
+      this.activeSession$.next(session);
       return session.connect$().pipe(
         switchMap(() => {
           const port = session.getCurrentPort();
@@ -160,8 +166,11 @@ export class SerialTransportService {
     });
   }
 
+  /**
+   * 同期の接続判定。ライブラリの {@link SerialSession.getCurrentPort} に委譲。
+   */
   isConnected(): boolean {
-    return this.isConnectedState$.getValue();
+    return this.session?.getCurrentPort() != null;
   }
 
   getPort(): SerialPort | undefined {
@@ -196,5 +205,10 @@ export class SerialTransportService {
         throwError(() => new Error(getWriteErrorMessage(error)))
       )
     );
+  }
+
+  private tearDownSession(): void {
+    this.session = undefined;
+    this.activeSession$.next(undefined);
   }
 }


### PR DESCRIPTION
## Summary

SerialTransportService から接続状態の二重管理（BehaviorSubject によるミラー）をやめ、SerialSession 側を単一のソースとして `state$` / `isConnected$` / `errors$` / `portInfo$` / `lines$` を委譲する薄いアダプタに変更した。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #543
- Refs #542

## What changed?

- ライブラリの `state$` / `isConnected$` のミラーを廃止し、`activeSession$` と `switchMap` だけでセッション切替を表現した。
- 未接続時は `idle` / `false` を継続するストリームにし、接続判断の同期 API は `getCurrentPort()` に集約した。
- 単体テストを `createSerialSession` モックと疑似 SerialSession ベースに作り直した。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

挙動は従来と同等（接続前は idle、Facade が引き続き `isConnected()` を利用）を意図。

## How to test

1. `pnpm exec nx run libs-web-serial-data-access:test`
2. 実機: Chromium でシリアル接続 → ターミナル / Wi-Fi 等で送受信が問題ないか確認
3. 必要なら `nx run-many -t test` で関連ライブラリを一括

## Environment (if relevant)

- Browser: Chrome（Web Serial 利用時）
- OS: macOS / Windows / Linux
- Node version: （ローカルに合わせる）
- pnpm version: （ローカルに合わせる）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant