### PR TITLE
refactor(web-serial): 接続状態を SerialSession 由来のストリームに一本化（#544）

### DIFF
--- a/libs/chirimen-setup/feature/src/lib/setup-page/setup-page.component.spec.ts
+++ b/libs/chirimen-setup/feature/src/lib/setup-page/setup-page.component.spec.ts
@@ -4,6 +4,7 @@ import { SetupCommandService } from '@libs-chirimen-setup-data-access';
 import { DialogService } from '@libs-dialogs-util';
 import { NotificationService } from '@libs-shared-ui';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
+import { of } from 'rxjs';
 import { SetupPageComponent } from './setup-page.component';
 
 describe('SetupPageComponent', () => {
@@ -20,7 +21,7 @@ describe('SetupPageComponent', () => {
         },
         {
           provide: SerialFacadeService,
-          useValue: { isConnected: () => true },
+          useValue: { isConnected$: of(true) },
         },
         { provide: DialogService, useValue: { close: vi.fn() } },
         {

--- a/libs/chirimen-setup/feature/src/lib/setup-page/setup-page.component.ts
+++ b/libs/chirimen-setup/feature/src/lib/setup-page/setup-page.component.ts
@@ -23,6 +23,7 @@ import { DialogService } from '@libs-dialogs-util';
 import { NotificationService } from '@libs-shared-ui';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import { MatDividerModule } from '@angular/material/divider';
+import { firstValueFrom, take } from 'rxjs';
 
 @Component({
   selector: 'lib-setup-page',
@@ -81,7 +82,10 @@ export class SetupPageComponent {
   }
 
   async runSetup(): Promise<void> {
-    if (!this.serial.isConnected()) {
+    const connected = await firstValueFrom(
+      this.serial.isConnected$.pipe(take(1)),
+    );
+    if (!connected) {
       this.notify.warning('Setup', 'シリアル接続してください');
       return;
     }

--- a/libs/remote/feature/src/lib/remote-page/remote-page.component.spec.ts
+++ b/libs/remote/feature/src/lib/remote-page/remote-page.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DialogService } from '@libs-dialogs-util';
 import {
@@ -17,8 +17,10 @@ const PLAIN_ROW =
 describe('RemotePageComponent', () => {
   let component: RemotePageComponent;
   let fixture: ComponentFixture<RemotePageComponent>;
+  let serialConnected: BehaviorSubject<boolean>;
 
   beforeEach(async () => {
+    serialConnected = new BehaviorSubject(true);
     const dialogRef = { closed: of(true) };
     await TestBed.configureTestingModule({
       imports: [RemotePageComponent],
@@ -41,7 +43,11 @@ describe('RemotePageComponent', () => {
         },
         {
           provide: SerialFacadeService,
-          useValue: { isConnected: vi.fn().mockReturnValue(true) },
+          useFactory: () => ({
+            get isConnected$() {
+              return serialConnected.asObservable();
+            },
+          }),
         },
         {
           provide: RemoteStatusService,
@@ -77,10 +83,7 @@ describe('RemotePageComponent', () => {
   });
 
   it('refreshList warns when serial disconnected', async () => {
-    const serial = TestBed.inject(SerialFacadeService) as unknown as {
-      isConnected: ReturnType<typeof vi.fn>;
-    };
-    serial.isConnected.mockReturnValue(false);
+    serialConnected.next(false);
     const notify = TestBed.inject(NotificationService) as unknown as {
       warning: ReturnType<typeof vi.fn>;
     };

--- a/libs/remote/feature/src/lib/remote-page/remote-page.component.ts
+++ b/libs/remote/feature/src/lib/remote-page/remote-page.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatDividerModule } from '@angular/material/divider';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, take } from 'rxjs';
 import { ConfirmDialogComponent } from '@libs-dialogs-ui';
 import { DialogService } from '@libs-dialogs-util';
 import {
@@ -54,8 +54,11 @@ export class RemotePageComponent {
     this.dialogService.close();
   }
 
-  private ensureSerial(): boolean {
-    if (!this.serial.isConnected()) {
+  private async ensureSerial(): Promise<boolean> {
+    const ok = await firstValueFrom(
+      this.serial.isConnected$.pipe(take(1)),
+    );
+    if (!ok) {
       this.notify.warning('Remote', 'シリアル接続してください');
       return false;
     }
@@ -67,7 +70,7 @@ export class RemotePageComponent {
   }
 
   async refreshList(): Promise<void> {
-    if (!this.ensureSerial()) {
+    if (!(await this.ensureSerial())) {
       return;
     }
     this.listInProgress.set(true);
@@ -93,7 +96,7 @@ export class RemotePageComponent {
 
   async startScript(): Promise<void> {
     const path = this.scriptPath.trim();
-    if (!path || !this.ensureSerial()) {
+    if (!path || !(await this.ensureSerial())) {
       return;
     }
     this.actionInProgress.set(true);
@@ -111,7 +114,7 @@ export class RemotePageComponent {
 
   async stopSelected(): Promise<void> {
     const target = this.selected;
-    if (!target || !this.ensureSerial()) {
+    if (!target || !(await this.ensureSerial())) {
       return;
     }
     this.actionInProgress.set(true);
@@ -129,7 +132,7 @@ export class RemotePageComponent {
   }
 
   async confirmStopAll(): Promise<void> {
-    if (!this.ensureSerial()) {
+    if (!(await this.ensureSerial())) {
       return;
     }
     const ref = this.dialogService.open(ConfirmDialogComponent, {

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
@@ -38,14 +38,14 @@ describe('TerminalViewComponent', () => {
     execMock = vi.fn().mockResolvedValue({
       stdout: `i2cdetect -y 1\n     0  1\n${PI_ZERO_PROMPT} `,
     });
-    shouldRunAfterConnectMock = vi.fn(() => true);
+    shouldRunAfterConnectMock = vi.fn(() => of(true));
     runAfterConnectMock = vi.fn(() => of(undefined));
     await TestBed.configureTestingModule({
       imports: [TerminalViewComponent],
     })
       .overrideProvider(SerialFacadeService, {
         useValue: {
-          isConnected: () => true,
+          isConnected$: of(true),
           exec$: (...args: unknown[]) =>
             from(execMock(...(args as [string, unknown]))),
           connectionEstablished$: NEVER,
@@ -54,7 +54,7 @@ describe('TerminalViewComponent', () => {
       })
       .overrideProvider(PiZeroSerialBootstrapService, {
         useValue: {
-          shouldRunAfterConnect: shouldRunAfterConnectMock,
+          shouldRunAfterConnect$: shouldRunAfterConnectMock,
           runAfterConnect$: runAfterConnectMock,
         },
       })
@@ -87,7 +87,7 @@ describe('TerminalViewComponent', () => {
 
   it('skips bootstrap execution when already initialized', async () => {
     runAfterConnectMock.mockClear();
-    shouldRunAfterConnectMock.mockReturnValue(false);
+    shouldRunAfterConnectMock.mockReturnValue(of(false));
 
     fixture.destroy();
     fixture = TestBed.createComponent(TerminalViewComponent);

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -16,6 +16,7 @@ import {
   finalize,
   firstValueFrom,
   switchMap,
+  take,
 } from 'rxjs';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
@@ -62,18 +63,25 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
   private commandRequestSub?: Subscription;
   private resizeObserver?: ResizeObserver;
 
+  /** {@link SerialFacadeService#isConnected$} の直近値（キー入力可否用） */
+  private serialInputEnabled = false;
+
   ngAfterViewInit(): void {
     this.configTerminal();
     this.serial.connectionEstablished$
       .pipe(
-        switchMap(() => {
-          if (!this.serial.isConnected()) {
-            return EMPTY;
-          }
-          return this.bootstrapAfterConnect$(
-            '[コンソール] シリアルに接続しました。',
-          );
-        }),
+        switchMap(() =>
+          this.serial.isConnected$.pipe(
+            take(1),
+            switchMap((connected) =>
+              connected
+                ? this.bootstrapAfterConnect$(
+                    '[コンソール] シリアルに接続しました。',
+                  )
+                : EMPTY
+            ),
+          ),
+        ),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe();
@@ -104,14 +112,24 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
     this.resizeObserver = new ResizeObserver(() => this.fitTerminal());
     this.resizeObserver.observe(el);
 
+    this.serial.isConnected$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((c) => {
+        this.serialInputEnabled = c;
+      });
+
     this.xterminal.reset();
-    if (this.serial.isConnected()) {
-      this.bootstrapAfterConnect$('[コンソール] シリアル接続済み。')
-        .pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe();
-    } else {
-      this.xterminal.writeln('$ ');
-    }
+    this.serial.isConnected$
+      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe((connected) => {
+        if (connected) {
+          this.bootstrapAfterConnect$('[コンソール] シリアル接続済み。')
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe();
+        } else {
+          this.xterminal.writeln('$ ');
+        }
+      });
 
     attachTerminalInput(
       this.xterminal,
@@ -124,13 +142,16 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
           return sanitizeSerialStdout(stdout, command, this.remotePrompt());
         });
       },
-      () => this.serial.isConnected(),
+      () => this.serialInputEnabled,
     );
 
     this.commandRequestSub = this.commandRequests.commandRequests$.subscribe(
       (cmd) => {
         void this.enqueueExec(async () => {
-          if (!this.serial.isConnected()) {
+          const connected = await firstValueFrom(
+            this.serial.isConnected$.pipe(take(1)),
+          );
+          if (!connected) {
             this.xterminal.writeln(`$ ${cmd}`);
             this.xterminal.writeln('Command failed: Serial port not connected');
             this.xterminal.write('$ ');
@@ -171,15 +192,20 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
   }
 
   private bootstrapAfterConnect$(prefixMessage: string) {
-    if (!this.piZeroBootstrap.shouldRunAfterConnect()) {
-      this.xterminal.writeln(`${prefixMessage} 初期化済みのためスキップします。`);
-      this.xterminal.write('$ ');
-      return EMPTY;
-    }
-    this.xterminal.writeln(`${prefixMessage} 初期化しています...`);
-    return this.piZeroBootstrap.runAfterConnect$((line) =>
-      this.xterminal.writeln(line),
-    ).pipe(
+    return this.piZeroBootstrap.shouldRunAfterConnect$().pipe(
+      switchMap((should) => {
+        if (!should) {
+          this.xterminal.writeln(
+            `${prefixMessage} 初期化済みのためスキップします。`,
+          );
+          this.xterminal.write('$ ');
+          return EMPTY;
+        }
+        this.xterminal.writeln(`${prefixMessage} 初期化しています...`);
+        return this.piZeroBootstrap.runAfterConnect$((line) =>
+          this.xterminal.writeln(line),
+        );
+      }),
       catchError(() => EMPTY),
       finalize(() => this.xterminal.write('$ ')),
     );

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { firstValueFrom, from } from 'rxjs';
+import { firstValueFrom, from, of } from 'rxjs';
 import {
   PI_ZERO_LOGIN_PASSWORD,
   PI_ZERO_LOGIN_USER,
@@ -32,7 +32,7 @@ describe('PiZeroSerialBootstrapService', () => {
     });
     const exec = vi.fn().mockResolvedValue({ stdout: '' });
     const serial = {
-      isConnected: () => true,
+      isConnected$: of(true),
       getConnectionEpoch: () => 1,
       readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
       exec$: (c: string, o: unknown) => from(exec(c, o)),
@@ -73,7 +73,7 @@ describe('PiZeroSerialBootstrapService', () => {
       .mockResolvedValueOnce({ stdout: 'raspberrypi login: ' });
     const exec = vi.fn().mockResolvedValue({ stdout: `Password: \r\n` });
     const serial = {
-      isConnected: () => true,
+      isConnected$: of(true),
       getConnectionEpoch: () => 1,
       readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
       exec$: (c: string, o: unknown) => from(exec(c, o)),
@@ -137,7 +137,7 @@ describe('PiZeroSerialBootstrapService', () => {
     });
     const exec = vi.fn().mockResolvedValue({ stdout: '' });
     const serial = {
-      isConnected: () => true,
+      isConnected$: of(true),
       getConnectionEpoch: () => 1,
       readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
       exec$: (c: string, o: unknown) => from(exec(c, o)),
@@ -160,7 +160,7 @@ describe('PiZeroSerialBootstrapService', () => {
     });
     const exec = vi.fn().mockResolvedValue({ stdout: '' });
     const serial = {
-      isConnected: () => true,
+      isConnected$: of(true),
       getConnectionEpoch: () => epoch,
       readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
       exec$: (c: string, o: unknown) => from(exec(c, o)),
@@ -188,7 +188,7 @@ describe('PiZeroSerialBootstrapService', () => {
         stdout: `${TZ_STATUS_CMD}\r\n       Time zone: Asia/Tokyo (${PI_ZERO_PROMPT} `,
       });
     const serial = {
-      isConnected: () => true,
+      isConnected$: of(true),
       getConnectionEpoch: () => 1,
       readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
       exec$: (c: string, o: unknown) => from(exec(c, o)),

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
@@ -25,6 +25,7 @@ import {
   of,
   shareReplay,
   switchMap,
+  take,
   tap,
   throwError,
 } from 'rxjs';
@@ -48,17 +49,23 @@ export class PiZeroSerialBootstrapService {
   ) {}
 
   /**
-   * 接続セッションごとに1回、シェル到達（必要ならログイン）と接続直後の初期化を行う。
+   * 接続セッションごとに1回、初期化パイプラインを走らせるか。
+   * 状態の参照は {@link SerialFacadeService#isConnected$} のみ。
    */
-  shouldRunAfterConnect(): boolean {
-    if (!this.serial.isConnected()) {
-      return false;
-    }
-    const epoch = this.serial.getConnectionEpoch();
-    if (epoch === this.lastBootstrappedEpoch) {
-      return false;
-    }
-    return true;
+  shouldRunAfterConnect$(): Observable<boolean> {
+    return this.serial.isConnected$.pipe(
+      take(1),
+      map((connected) => {
+        if (!connected) {
+          return false;
+        }
+        const epoch = this.serial.getConnectionEpoch();
+        if (epoch === this.lastBootstrappedEpoch) {
+          return false;
+        }
+        return true;
+      }),
+    );
   }
 
   /**
@@ -69,44 +76,55 @@ export class PiZeroSerialBootstrapService {
   ): Observable<void> {
     const log = onStatus ?? (() => undefined);
 
-    if (!this.shouldRunAfterConnect()) {
-      return of(undefined);
-    }
-    const epoch = this.serial.getConnectionEpoch();
-
-    if (
-      this.activeBootstrap$ !== null &&
-      this.activeBootstrapEpoch === epoch
-    ) {
-      return this.activeBootstrap$;
-    }
-
-    this.activeBootstrapEpoch = epoch;
-
-    this.activeBootstrap$ = defer(() => this.runPipeline$(log)).pipe(
-      tap(() => {
-        if (this.serial.isConnected()) {
-          this.lastBootstrappedEpoch = epoch;
-          this.shellReadiness.setReady(true);
+    return this.shouldRunAfterConnect$().pipe(
+      switchMap((shouldRun) => {
+        if (!shouldRun) {
+          return of(undefined);
         }
-      }),
-      map(() => undefined),
-      catchError((error: unknown) => {
-        const message =
-          error instanceof Error ? error.message : String(error);
-        log(`[コンソール] 接続後の初期化に失敗しました: ${message}`);
-        return throwError(() => error);
-      }),
-      finalize(() => {
-        if (this.activeBootstrapEpoch === epoch) {
-          this.activeBootstrap$ = null;
-          this.activeBootstrapEpoch = null;
+        const epoch = this.serial.getConnectionEpoch();
+
+        if (
+          this.activeBootstrap$ !== null &&
+          this.activeBootstrapEpoch === epoch
+        ) {
+          return this.activeBootstrap$;
         }
+
+        this.activeBootstrapEpoch = epoch;
+
+        this.activeBootstrap$ = defer(() => this.runPipeline$(log)).pipe(
+          switchMap(() =>
+            this.serial.isConnected$.pipe(
+              take(1),
+              tap((connected) => {
+                if (connected) {
+                  this.lastBootstrappedEpoch = epoch;
+                  this.shellReadiness.setReady(true);
+                }
+              }),
+              map(() => undefined),
+            ),
+          ),
+          catchError((error: unknown) => {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            log(
+              `[コンソール] 接続後の初期化に失敗しました: ${message}`,
+            );
+            return throwError(() => error);
+          }),
+          finalize(() => {
+            if (this.activeBootstrapEpoch === epoch) {
+              this.activeBootstrap$ = null;
+              this.activeBootstrapEpoch = null;
+            }
+          }),
+          shareReplay({ bufferSize: 1, refCount: true }),
+        );
+
+        return this.activeBootstrap$;
       }),
-      shareReplay({ bufferSize: 1, refCount: true }),
     );
-
-    return this.activeBootstrap$;
   }
 
   private runPipeline$(log: PiZeroBootstrapStatusHandler): Observable<void> {

--- a/libs/web-serial/data-access/src/lib/serial-facade.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-facade.service.ts
@@ -68,11 +68,9 @@ export class SerialFacadeService {
 
   /**
    * データストリーム (Observable)
+   * 未接続時は購読時にエラーとなる（{@link SerialTransportService#getReadStream}）。
    */
   get data$() {
-    if (!this.transport.isConnected()) {
-      throw new Error('Serial port not connected');
-    }
     return this.transport.getReadStream();
   }
 
@@ -82,11 +80,12 @@ export class SerialFacadeService {
    * @param baudRate ボーレート (デフォルト: 115200)
    */
   connect$(baudRate = 115200): Observable<SerialFacadeConnectResult> {
-    return defer(() => {
-      const preConnect$ = this.isConnected()
-        ? this.disconnect$()
-        : of(undefined);
-      return preConnect$.pipe(
+    return defer(() =>
+      this.transport.isConnected$.pipe(
+        take(1),
+        switchMap((connected) =>
+          connected ? this.disconnect$() : of(undefined)
+        ),
         switchMap(() => this.transport.connect$(baudRate)),
         switchMap((result) => {
           if ('error' in result) {
@@ -109,8 +108,8 @@ export class SerialFacadeService {
             errorMessage: getConnectionErrorMessage(error),
           });
         })
-      );
-    });
+      )
+    );
   }
 
   private startReadStreamSubscription(): void {
@@ -136,9 +135,6 @@ export class SerialFacadeService {
    * データを書き込む（Observable）
    */
   write$(data: string): Observable<void> {
-    if (!this.transport.isConnected()) {
-      return throwError(() => new Error('Serial port not connected'));
-    }
     return this.transport.write(data);
   }
 
@@ -146,9 +142,6 @@ export class SerialFacadeService {
    * 1 チャンクだけ読み取る（Observable）
    */
   read$(): Observable<string> {
-    if (!this.transport.isConnected()) {
-      return throwError(() => new Error('Serial port not connected'));
-    }
     return this.transport.getReadStream().pipe(take(1));
   }
 
@@ -199,19 +192,11 @@ export class SerialFacadeService {
     return this.connectionEpoch;
   }
 
-  isConnected(): boolean {
-    return this.transport.isConnected();
-  }
-
   /**
    * 読み取り中かどうか（ストリーム購読中は true）
    */
   isReading(): boolean {
     return this.command.isReading();
-  }
-
-  isWriteReady(): boolean {
-    return this.transport.isConnected();
   }
 
   getPendingCommandCount(): number {

--- a/libs/web-serial/data-access/src/lib/serial-transport.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.spec.ts
@@ -74,7 +74,6 @@ describe('SerialTransportService', () => {
     expect(state).toBe(SerialSessionState.Idle);
     const connectedFlag = await firstValueFrom(service.isConnected$);
     expect(connectedFlag).toBe(false);
-    expect(service.isConnected()).toBe(false);
     expect(service.getPort()).toBeUndefined();
     expect(service.getPortInfo()).toBeNull();
   });
@@ -90,7 +89,6 @@ describe('SerialTransportService', () => {
     expect(state).toBe(SerialSessionState.Connected);
     const connectedFlag = await firstValueFrom(service.isConnected$);
     expect(connectedFlag).toBe(true);
-    expect(service.isConnected()).toBe(true);
     expect(service.getPort()).toBe(mockPort);
     expect(session.connect$).toHaveBeenCalledTimes(1);
   });
@@ -100,13 +98,17 @@ describe('SerialTransportService', () => {
     mockCreateSerialSession.mockReturnValue(buildMockSession(mockPort));
 
     await firstValueFrom(service.connect$());
-    expect(service.isConnected()).toBe(true);
+    expect(
+      await firstValueFrom(service.isConnected$.pipe(take(1))),
+    ).toBe(true);
 
     await firstValueFrom(service.disconnect$());
 
     const state = await firstValueFrom(service.state$);
     expect(state).toBe(SerialSessionState.Idle);
-    expect(service.isConnected()).toBe(false);
+    expect(
+      await firstValueFrom(service.isConnected$.pipe(take(1))),
+    ).toBe(false);
     expect(service.getPort()).toBeUndefined();
   });
 

--- a/libs/web-serial/data-access/src/lib/serial-transport.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.ts
@@ -19,6 +19,7 @@ import {
   Observable,
   of,
   switchMap,
+  take,
   tap,
   throwError,
 } from 'rxjs';
@@ -166,13 +167,6 @@ export class SerialTransportService {
     });
   }
 
-  /**
-   * 同期の接続判定。ライブラリの {@link SerialSession.getCurrentPort} に委譲。
-   */
-  isConnected(): boolean {
-    return this.session?.getCurrentPort() != null;
-  }
-
   getPort(): SerialPort | undefined {
     return this.session?.getCurrentPort() ?? undefined;
   }
@@ -182,14 +176,24 @@ export class SerialTransportService {
    * 未接続時またはエラー時は throwError
    */
   getReadStream(): Observable<string> {
-    if (!this.session) {
-      return throwError(() => new Error('Serial port not connected'));
-    }
-    return this.session.receiveReplay$.pipe(
-      catchError((err: unknown) =>
-        throwError(() => new Error(getReadErrorMessage(err)))
-      )
-    );
+    return defer(() => {
+      const s = this.session;
+      if (!s) {
+        return throwError(() => new Error('Serial port not connected'));
+      }
+      return s.isConnected$.pipe(
+        take(1),
+        switchMap((connected) =>
+          connected
+            ? s.receiveReplay$.pipe(
+                catchError((err: unknown) =>
+                  throwError(() => new Error(getReadErrorMessage(err)))
+                ),
+              )
+            : throwError(() => new Error('Serial port not connected'))
+        )
+      );
+    });
   }
 
   /**
@@ -197,14 +201,26 @@ export class SerialTransportService {
    * 未接続時またはエラー時は throwError
    */
   write(data: string): Observable<void> {
-    if (!this.session || !this.isConnected()) {
-      return throwError(() => new Error('Serial port not connected'));
-    }
-    return this.session.send$(data).pipe(
-      catchError((error) =>
-        throwError(() => new Error(getWriteErrorMessage(error)))
-      )
-    );
+    return defer(() => {
+      const s = this.session;
+      if (!s) {
+        return throwError(() => new Error('Serial port not connected'));
+      }
+      return s.isConnected$.pipe(
+        take(1),
+        switchMap((connected) =>
+          connected
+            ? s.send$(data).pipe(
+                catchError((error) =>
+                  throwError(
+                    () => new Error(getWriteErrorMessage(error)),
+                  )
+                )
+              )
+            : throwError(() => new Error('Serial port not connected'))
+        )
+      );
+    });
   }
 
   private tearDownSession(): void {

--- a/libs/wifi/feature/src/lib/wifi-page/wifi-page.component.spec.ts
+++ b/libs/wifi/feature/src/lib/wifi-page/wifi-page.component.spec.ts
@@ -1,6 +1,6 @@
 import { Dialog } from '@angular/cdk/dialog';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { BehaviorSubject, of } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NotificationService } from '@libs-shared-ui';
 import {
@@ -43,7 +43,7 @@ describe('WifiPageComponent', () => {
         },
         {
           provide: SerialFacadeService,
-          useValue: { isConnected: vi.fn().mockReturnValue(true) },
+          useValue: { isConnected$: new BehaviorSubject(true) },
         },
         {
           provide: WifiScanService,

--- a/libs/wifi/feature/src/lib/wifi-page/wifi-page.component.ts
+++ b/libs/wifi/feature/src/lib/wifi-page/wifi-page.component.ts
@@ -11,7 +11,7 @@ import {
   type WifiConnectDialogData,
   WifiListComponent,
 } from '@libs-wifi-ui';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, take } from 'rxjs';
 
 /**
  * WiFi 設定画面（スマートコンポーネント）
@@ -34,8 +34,11 @@ export class WifiPageComponent {
   private readonly wifiScan = inject(WifiScanService);
   private readonly wifiReboot = inject(WifiRebootFlowService);
 
-  private ensureSerial(): boolean {
-    if (!this.serial.isConnected()) {
+  private async ensureSerial(): Promise<boolean> {
+    const ok = await firstValueFrom(
+      this.serial.isConnected$.pipe(take(1)),
+    );
+    if (!ok) {
       this.notify.warning('WiFi', 'シリアル接続してください');
       return false;
     }
@@ -43,7 +46,7 @@ export class WifiPageComponent {
   }
 
   async runWifiScan(): Promise<void> {
-    if (!this.ensureSerial()) {
+    if (!(await this.ensureSerial())) {
       return;
     }
     this.scanInProgress.set(true);
@@ -63,13 +66,15 @@ export class WifiPageComponent {
   }
 
   openConnectDialog(initialSsid?: string): void {
-    if (!this.ensureSerial()) {
-      return;
-    }
-    this.dialog.open(WifiConnectDialogComponent, {
-      width: '400px',
-      data: { initialSsid } satisfies WifiConnectDialogData,
-    });
+    void (async () => {
+      if (!(await this.ensureSerial())) {
+        return;
+      }
+      this.dialog.open(WifiConnectDialogComponent, {
+        width: '400px',
+        data: { initialSsid } satisfies WifiConnectDialogData,
+      });
+    })();
   }
 
   onNetworkSelected(info: WiFiInfo): void {
@@ -78,7 +83,7 @@ export class WifiPageComponent {
   }
 
   async showWifiInfo(): Promise<void> {
-    if (!this.ensureSerial()) {
+    if (!(await this.ensureSerial())) {
       return;
     }
     this.actionInProgress.set(true);
@@ -105,7 +110,7 @@ export class WifiPageComponent {
   }
 
   async resetWifi(): Promise<void> {
-    if (!this.ensureSerial()) {
+    if (!(await this.ensureSerial())) {
       return;
     }
     this.actionInProgress.set(true);
@@ -121,7 +126,7 @@ export class WifiPageComponent {
   }
 
   async rebootDevice(): Promise<void> {
-    if (!this.ensureSerial()) {
+    if (!(await this.ensureSerial())) {
       return;
     }
     const ref = this.dialog.open(ConfirmDialogComponent, {
@@ -149,7 +154,7 @@ export class WifiPageComponent {
   }
 
   async checkConnectivity(): Promise<void> {
-    if (!this.ensureSerial()) {
+    if (!(await this.ensureSerial())) {
       return;
     }
     this.actionInProgress.set(true);


### PR DESCRIPTION
## Summary

Issue #542 配下の #544 対応として、同期 `isConnected()`（`getCurrentPort` 由来）と二重管理をやめ、接続の参照先を `SerialSession` の `isConnected$` / `state$` 経路に揃えました。

## Type of change

- [x] Refactor
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #544
- Related #542

## What changed?

- `SerialTransportService` から同期接続判定を削除し、read/write を `isConnected$` ベースに変更した。
- `SerialFacadeService` の `connect$` 前処理と `data$` / `write$` / `read$` 周りをストリーム前提に整理し、`isConnected()` / `isWriteReady()` を削除した。
- `PiZeroSerialBootstrapService` を `shouldRunAfterConnect$` と `isConnected$` 中心に変更した。
- ターミナル / WiFi / Remote / Setup で `isConnected$` または `firstValueFrom` を用いるよう変更し、各 spec のモックを更新した。

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - Details: `SerialFacadeService` から `isConnected()` と `isWriteReady()` を削除。`PiZeroSerialBootstrapService` の `shouldRunAfterConnect()` を `shouldRunAfterConnect$()` に変更（Observable）。
- [ ] This change is backward compatible
- [x] This change introduces a breaking change
  - Migration notes: 上記の削除・シグナチャ変更に追従すれば可。接続判定は `isConnected$` または `state$` を利用する。

## How to test

1. ブラウザで Web Serial 接続 → 接続画面・ターミナル・ブートストラップが従来どおり動くこと。
2. 接続後に WiFi / Remote / Setup の各操作が通知なく実行できること。
3. 未接続で各画面のガード（警告）が従来どおり出ること。
4. ローカルで `nx run-many -t test --all` を実行する。

## Environment (if relevant)

- Browser:（検証したブラウザ）
- OS: macOS / Windows / Linux
- Node version:（`node -v`）
- pnpm version:（`pnpm -v`）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

