### PR TITLE
refactor(web-serial): 受信を lines$ ベースに移行する（#545）

### DIFF
--- a/libs/web-serial/data-access/src/lib/serial-command.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command.service.spec.ts
@@ -7,10 +7,18 @@ import {
 } from '@libs-web-serial-util';
 import type { SerialTransportService } from './serial-transport.service';
 
+/** チャンク入力の代わりに、改行区切りで 1 行ずつ emit（getReadStream＝lines$ 相当）。 */
+function emitAsLines(subject: Subject<string>, raw: string): void {
+  const normalized = raw.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  for (const line of normalized.split('\n')) {
+    subject.next(line);
+  }
+}
+
 function createService() {
-  const chunks = new Subject<string>();
+  const lines = new Subject<string>();
   const transport = {
-    getReadStream: () => chunks.asObservable(),
+    getReadStream: () => lines.asObservable(),
     write: vi.fn(
       () =>
         new Observable<void>((subscriber) => {
@@ -23,12 +31,12 @@ function createService() {
     transport as unknown as SerialTransportService
   );
   service.startReadLoop();
-  return { service, chunks, transport };
+  return { service, lines, transport };
 }
 
 describe('SerialCommandService', () => {
   it('exec resolves when prompt matches', async () => {
-    const { service, chunks, transport } = createService();
+    const { service, lines, transport } = createService();
 
     let releaseWrite: (() => void) | undefined;
     transport.write = vi.fn(
@@ -46,7 +54,7 @@ describe('SerialCommandService', () => {
     );
 
     releaseWrite?.();
-    chunks.next(`ls\r\noutput\r\n${PI_ZERO_PROMPT}`);
+    emitAsLines(lines, `ls\r\noutput\r\n${PI_ZERO_PROMPT}`);
 
     const result = await execPromise;
     expect(result.stdout).toContain(PI_ZERO_PROMPT);
@@ -54,7 +62,7 @@ describe('SerialCommandService', () => {
   });
 
   it('readUntilPrompt resolves without writing', async () => {
-    const { service, chunks } = createService();
+    const { service, lines } = createService();
 
     const readPromise = firstValueFrom(
       service.readUntilPrompt$({
@@ -65,7 +73,7 @@ describe('SerialCommandService', () => {
     );
 
     queueMicrotask(() => {
-      chunks.next(`welcome\r\n${PI_ZERO_PROMPT}`);
+      emitAsLines(lines, `welcome\r\n${PI_ZERO_PROMPT}`);
     });
 
     const result = await readPromise;
@@ -73,8 +81,8 @@ describe('SerialCommandService', () => {
   });
 
   it('readUntilPrompt sees data already buffered before the wait starts', async () => {
-    const { service, chunks } = createService();
-    chunks.next('Raspberry Pi OS\r\n\r\nraspberrypi login: ');
+    const { service, lines } = createService();
+    emitAsLines(lines, 'Raspberry Pi OS\r\n\r\nraspberrypi login: ');
     const result = await firstValueFrom(
       service.readUntilPrompt$({
         prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
@@ -86,8 +94,8 @@ describe('SerialCommandService', () => {
   });
 
   it('readUntilPrompt matches Japanese login prompt in buffer', async () => {
-    const { service, chunks } = createService();
-    chunks.next('ホスト名 ログイン: ');
+    const { service, lines } = createService();
+    emitAsLines(lines, 'ホスト名 ログイン: ');
     const result = await firstValueFrom(
       service.readUntilPrompt$({
         prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
@@ -98,9 +106,9 @@ describe('SerialCommandService', () => {
     expect(result.stdout).toMatch(/ログイン/);
   });
 
-  it('readUntilPrompt matches login when chunk contains ANSI escape sequences', async () => {
-    const { service, chunks } = createService();
-    chunks.next('\u001b[2J\u001b[Hraspberrypi login: ');
+  it('readUntilPrompt matches login when line contains ANSI escape sequences', async () => {
+    const { service, lines } = createService();
+    emitAsLines(lines, '\u001b[2J\u001b[Hraspberrypi login: ');
     const result = await firstValueFrom(
       service.readUntilPrompt$({
         prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
@@ -112,7 +120,7 @@ describe('SerialCommandService', () => {
   });
 
   it('supports RegExp prompt', async () => {
-    const { service, chunks, transport } = createService();
+    const { service, lines, transport } = createService();
 
     let releaseWrite: (() => void) | undefined;
     transport.write = vi.fn(
@@ -135,14 +143,14 @@ describe('SerialCommandService', () => {
     );
 
     releaseWrite?.();
-    chunks.next(`echo hi\r\nhi\r\n${PI_ZERO_PROMPT}`);
+    emitAsLines(lines, `echo hi\r\nhi\r\n${PI_ZERO_PROMPT}`);
 
     const result = await execPromise;
     expect(result.stdout).toContain('hi');
   });
 
   it('exec$ resolves via firstValueFrom like exec', async () => {
-    const { service, chunks, transport } = createService();
+    const { service, lines, transport } = createService();
 
     let releaseWrite: (() => void) | undefined;
     transport.write = vi.fn(
@@ -160,7 +168,7 @@ describe('SerialCommandService', () => {
     );
 
     releaseWrite?.();
-    chunks.next(`ls\r\noutput\r\n${PI_ZERO_PROMPT}`);
+    emitAsLines(lines, `ls\r\noutput\r\n${PI_ZERO_PROMPT}`);
 
     const result = await resultPromise;
     expect(result.stdout).toContain(PI_ZERO_PROMPT);

--- a/libs/web-serial/data-access/src/lib/serial-command.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command.service.ts
@@ -59,7 +59,7 @@ export interface CommandResult {
 export class SerialCommandService {
   private readBuffer = '';
   private readSubscription: Subscription | null = null;
-  /** 受信チャンクでバッファが更新されたことを Observable 側の待機に伝える */
+  /** 受信行でバッファが更新されたことを Observable 側の待機に伝える */
   private readonly bufferNotify$ = new Subject<void>();
   /** コマンド実行を直列化（複数 exec$ が同時に走らない） */
   private readonly executionQueue$ = new Subject<Observable<unknown>>();
@@ -91,14 +91,17 @@ export class SerialCommandService {
   }
 
   /**
-   * 接続後に呼び出し、シリアル読み取りを購読してバッファに蓄積する
+   * 接続後に呼び出し、{@link SerialTransportService#getReadStream}（行単位）を購読し
+   * プロンプト検出用バッファに蓄積する（行ごとに改行を復元）。
    */
   startReadLoop(): void {
     this.readBuffer = '';
     this.readSubscription?.unsubscribe();
     this.readSubscription = this.transport.getReadStream().subscribe({
-      next: (chunk) => {
-        this.readBuffer += stripSerialAnsiForPrompt(chunk);
+      next: (line) => {
+        this.readBuffer +=
+          stripSerialAnsiForPrompt(line) +
+          '\n';
         this.bufferNotify$.next();
       },
       error: (err) => console.error('Serial read stream error:', err),

--- a/libs/web-serial/data-access/src/lib/serial-facade.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-facade.service.ts
@@ -67,8 +67,8 @@ export class SerialFacadeService {
   }
 
   /**
-   * データストリーム (Observable)
-   * 未接続時は購読時にエラーとなる（{@link SerialTransportService#getReadStream}）。
+   * 受信行ストリーム（{@link SerialTransportService#getReadStream} と同等、1 行ずつ）。
+   * 未接続時は購読時にエラーとなる。
    */
   get data$() {
     return this.transport.getReadStream();
@@ -139,7 +139,7 @@ export class SerialFacadeService {
   }
 
   /**
-   * 1 チャンクだけ読み取る（Observable）
+   * 行を 1 本だけ読み取る（Observable）。
    */
   read$(): Observable<string> {
     return this.transport.getReadStream().pipe(take(1));

--- a/libs/web-serial/data-access/src/lib/serial-transport.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.spec.ts
@@ -7,8 +7,10 @@ import {
 import {
   BehaviorSubject,
   EMPTY,
+  type Observable,
   firstValueFrom,
   of,
+  Subject,
   take,
 } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -25,7 +27,10 @@ vi.mock('@gurezo/web-serial-rxjs', async (importOriginal) => {
   };
 });
 
-function buildMockSession(port: SerialPort | null): SerialSession {
+function buildMockSession(
+  port: SerialPort | null,
+  lines$?: Observable<string>,
+): SerialSession {
   const state$ = new BehaviorSubject<SerialSessionState>(
     SerialSessionState.Connecting
   );
@@ -55,8 +60,7 @@ function buildMockSession(port: SerialPort | null): SerialSession {
     getCurrentPort,
     errors$: EMPTY,
     receive$: EMPTY,
-    receiveReplay$: of('chunk'),
-    lines$: of('line1'),
+    lines$: lines$ ?? of('line1'),
     send$: vi.fn(() => of(undefined)),
   } as unknown as SerialSession;
 }
@@ -132,5 +136,18 @@ describe('SerialTransportService', () => {
     await firstValueFrom(service.connect$());
     const line = await firstValueFrom(service.lines$.pipe(take(1)));
     expect(line).toBe('line1');
+  });
+
+  it('getReadStream should emit line strings from lines$', async () => {
+    const mockPort = {} as SerialPort;
+    const lineSubject = new Subject<string>();
+    mockCreateSerialSession.mockReturnValue(
+      buildMockSession(mockPort, lineSubject.asObservable()),
+    );
+
+    await firstValueFrom(service.connect$());
+    const readPromise = firstValueFrom(service.getReadStream().pipe(take(1)));
+    queueMicrotask(() => lineSubject.next('expected-line'));
+    expect(await readPromise).toBe('expected-line');
   });
 });

--- a/libs/web-serial/data-access/src/lib/serial-transport.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.ts
@@ -39,9 +39,9 @@ import {
  * 本サービスは `activeSession$` のみで「どのセッションを流すか」を切り替え、
  * ライブラリの Observable を重ねて二重管理しない。
  *
- * 受信はチャンク単位: `createSerialSession({ receiveReplay: { enabled: true } })` により
- * {@link SerialSession.receiveReplay$} を使い、同一接続内で遅延購読者（例: ターミナル）へ
- * 直近バッファを引き渡す。行単位が欲しい場合はライブラリの `lines$` を別経路で購読する（シェル exec はチャンク蓄積が必要なため従来どおり `receiveReplay$` + Command バッファ）。
+ * 読み取りストリーム {@link #getReadStream} は {@link SerialSession.lines$} を橋渡しする
+ * （行単位。区切りはライブラリ側の改行処理に従う）。チャンク生データは
+ * {@link SerialSession.receive$} を直接使用する必要がある場合のみ利用する。
  */
 @Injectable({
   providedIn: 'root',
@@ -118,7 +118,6 @@ export class SerialTransportService {
             usbProductId: RASPBERRY_PI_ZERO_INFO.usbProductId,
           },
         ],
-        receiveReplay: { enabled: true, bufferSize: 512 },
       });
       this.session = session;
       this.activeSession$.next(session);
@@ -172,8 +171,8 @@ export class SerialTransportService {
   }
 
   /**
-   * 読み取りストリーム（文字列）を取得
-   * 未接続時またはエラー時は throwError
+   * 読み取りストリーム（**1 改行区切りごとに 1 エミット**する行文字列）を取得。
+   * 未接続時または未接続状態で呼び出した場合は throwError
    */
   getReadStream(): Observable<string> {
     return defer(() => {
@@ -185,7 +184,7 @@ export class SerialTransportService {
         take(1),
         switchMap((connected) =>
           connected
-            ? s.receiveReplay$.pipe(
+            ? s.lines$.pipe(
                 catchError((err: unknown) =>
                   throwError(() => new Error(getReadErrorMessage(err)))
                 ),


### PR DESCRIPTION
## Summary

Web Serial の読み取りをチャンク由来の `receiveReplay$` から、ライブラリの行ストリーム `lines$` に切り替える。`SerialCommandService` のプロンプト検出用バッファは行単位の受信に合わせて改行を復元して蓄積する。Issue #542 の「受信処理の簡素化」サブタスク（#545）に対応する。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #545
- Related to #542

## What changed?

- `SerialTransportService`: `createSerialSession` の `receiveReplay` オプションを廃止し、`getReadStream()` を `SerialSession.lines$` 経由に変更（JSDoc を行単位である旨に更新）。
- `SerialCommandService`: `startReadLoop` で受け取る値を行として扱い、バッファに `\n` を付与して従来のプロンプト検出と整合。
- `SerialFacadeService`: `data$` / `read$()` の説明を「行ストリーム」「1 行取得」に更新。
- ユニットテスト: Transport / Command のモックを行単位 emit（`emitAsLines`）に変更し、`getReadStream` の検証を追加。

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - Details: `SerialTransportService#getReadStream` の各 emit は **改行区切りの 1 行**（旧チャンク単位ではない）。`SerialFacadeService#data$` / `read$()` も同様。利用箇所がチャンク前提の解析をしている場合は確認が必要。
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test

1. `npx nx run libs-web-serial-data-access:test`
2. 任意: `npx nx run-many -t test -p libs-terminal-ui,libs-connect-feature,libs-wifi-feature,libs-remote-feature,libs-chirimen-setup-feature,libs-console-shell-feature --parallel=3`
3. 実機: シリアル接続後、コンソールでのコマンド実行とプロンプト待ちが従来どおりになることを確認

## Environment (if relevant)

- Browser: Chromium 系（Web Serial 利用時）
- OS: macOS / Windows / Linux
- Node version: （ローカル実行時の `node -v` を記載）
- pnpm version: （`pnpm -v` を記載）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant