### PR TITLE
refactor(web-serial): コマンドキューと retry/timeout を整理する (#547)

### DIFF
--- a/libs/web-serial/data-access/src/lib/serial-command/command-queue.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/command-queue.service.spec.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 import {
   Observable,
   Subject,
+  delay,
   firstValueFrom,
   map,
   of,
   take,
+  timer,
 } from 'rxjs';
 import { CommandQueueService } from './command-queue.service';
 
@@ -29,6 +31,31 @@ describe('CommandQueueService', () => {
           sub.next('b');
           sub.complete();
         });
+      }),
+    );
+    const [a, b] = await Promise.all([p1, p2]);
+    expect(a).toBe('a');
+    expect(b).toBe('b');
+    expect(order).toEqual([1, 2]);
+  });
+
+  it('runs first delayed job to completion before starting the second', async () => {
+    const queue = new CommandQueueService();
+    const order: number[] = [];
+    const p1 = firstValueFrom(
+      queue.enqueueCommand$(() =>
+        timer(25).pipe(
+          map(() => {
+            order.push(1);
+            return 'a';
+          }),
+        ),
+      ),
+    );
+    const p2 = firstValueFrom(
+      queue.enqueueCommand$(() => {
+        order.push(2);
+        return of('b').pipe(delay(0));
       }),
     );
     const [a, b] = await Promise.all([p1, p2]);

--- a/libs/web-serial/data-access/src/lib/serial-command/command-queue.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/command-queue.service.ts
@@ -1,25 +1,34 @@
 import { Injectable } from '@angular/core';
 import {
+  EMPTY,
   Observable,
   Subject,
+  Subscriber,
   catchError,
   concatMap,
   defer,
-  EMPTY,
   finalize,
   mergeMap,
   throwError,
 } from 'rxjs';
 
 /**
- * シリアルコマンド実行を直列化し、世代ベースで一括キャンセルする
+ * シリアルコマンド実行を直列化し、世代ベースで一括キャンセルする。
+ *
+ * **契約**
+ * - `enqueueCommand$` 1 回につき、呼び出し元の Observable は **単一の next の後 complete**（または error）する。
+ * - 内部の `concatMap` により、前のジョブが完了するまで次の `factory` は走らない（直列実行）。
+ * - `factory` は `defer` 内で実行される。実行直前に `generation` を再チェックし、
+ *   `cancelAllCommands` 済みなら `All commands cancelled` で打ち切る。
+ * - `enqueuedGen` は enqueue 時点の世代。キャンセル後もキューに積まれた古いジョブは
+ *   実行開始時に世代不一致で棄却される。
  */
 @Injectable({
   providedIn: 'root',
 })
 export class CommandQueueService {
   private readonly executionQueue$ = new Subject<Observable<unknown>>();
-  /** cancelAllCommands 用。enqueue 時点の世代と異なれば実行を打ち切る */
+  /** `cancelAllCommands` のたびに増加。enqueue 時点の世代と比較して実行可否を決める */
   private generation = 0;
   private pendingCount = 0;
 
@@ -52,27 +61,38 @@ export class CommandQueueService {
       const enqueuedGen = this.generation;
       this.pendingCount++;
       this.executionQueue$.next(
-        defer(() => {
-          if (this.generation !== enqueuedGen) {
-            return throwError(() => new Error('All commands cancelled'));
-          }
-          return factory(enqueuedGen);
-        }).pipe(
-          finalize(() => {
-            this.pendingCount--;
-          }),
-          mergeMap((value) => {
-            subscriber.next(value as T);
-            subscriber.complete();
-            return EMPTY;
-          }),
-          catchError((err: unknown) => {
-            subscriber.error(err);
-            return EMPTY;
-          }),
-        ),
+        this.createQueuedWork$(enqueuedGen, factory, subscriber),
       );
     });
+  }
+
+  /**
+   * concatMap 1 単位: 世代チェック → factory 実行 → 結果を呼び出し元 subscriber へ一度だけ配送
+   */
+  private createQueuedWork$<T>(
+    enqueuedGen: number,
+    factory: (enqueuedGen: number) => Observable<T>,
+    subscriber: Subscriber<T>,
+  ): Observable<unknown> {
+    return defer(() => {
+      if (this.generation !== enqueuedGen) {
+        return throwError(() => new Error('All commands cancelled'));
+      }
+      return factory(enqueuedGen);
+    }).pipe(
+      finalize(() => {
+        this.pendingCount--;
+      }),
+      mergeMap((value) => {
+        subscriber.next(value as T);
+        subscriber.complete();
+        return EMPTY;
+      }),
+      catchError((err: unknown) => {
+        subscriber.error(err);
+        return EMPTY;
+      }),
+    );
   }
 
   cancelAllCommands(): void {

--- a/libs/web-serial/data-access/src/lib/serial-command/command-runner.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/command-runner.service.ts
@@ -104,6 +104,10 @@ export class SerialCommandService {
     this.readBuffer = '';
   }
 
+  /**
+   * 1 試行あたりのプロンプト待ち。
+   * 受信バッファがプロンプトに一致するまで待ち、**初回一致まで**が `config.timeout` で打ち切られる。
+   */
   private waitForPromptMatch$(
     config: CommandExecutionConfig,
     enqueuedGen: number,
@@ -124,13 +128,26 @@ export class SerialCommandService {
         return stdout;
       }),
       timeout({ first: config.timeout }),
-      catchError((err: unknown) => {
-        if (err instanceof TimeoutError) {
-          return throwError(() => new Error('Command execution timeout'));
-        }
-        return throwError(() => err);
-      }),
+      catchError((err: unknown) => this.mapPromptWaitError$(err)),
     );
+  }
+
+  private mapPromptWaitError$(err: unknown): Observable<never> {
+    if (err instanceof TimeoutError) {
+      return throwError(() => new Error('Command execution timeout'));
+    }
+    return throwError(() => err);
+  }
+
+  /**
+   * `retry({ count })` はこの Observable をエラー時に再購読する。
+   * `defer` 内が毎回やり直されるため、**送信・バッファクリア・プロンプト待ちが 1 試行単位**で繰り返される。
+   */
+  private withPromptAttemptRetries<T>(
+    attempt$: Observable<T>,
+    retryCount: number,
+  ): Observable<T> {
+    return attempt$.pipe(retry({ count: retryCount }));
   }
 
   private buildExecPipeline$(
@@ -151,7 +168,7 @@ export class SerialCommandService {
         map((stdout) => ({ stdout })),
       );
     });
-    return attempt$.pipe(retry({ count: retryCount }));
+    return this.withPromptAttemptRetries(attempt$, retryCount);
   }
 
   private buildReadUntilPromptPipeline$(
@@ -174,7 +191,7 @@ export class SerialCommandService {
         map((stdout) => ({ stdout })),
       );
     });
-    return attempt$.pipe(retry({ count: retryCount }));
+    return this.withPromptAttemptRetries(attempt$, retryCount);
   }
 
   /**

--- a/libs/web-serial/data-access/src/lib/serial-command/serial-command.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/serial-command.service.spec.ts
@@ -176,4 +176,75 @@ describe('SerialCommandService', () => {
     const result = await resultPromise;
     expect(result.stdout).toContain(PI_ZERO_PROMPT);
   });
+
+  it('exec rejects when prompt never appears before timeout', async () => {
+    const { service, transport } = createService();
+    transport.write = vi.fn(
+      () =>
+        new Observable<void>((subscriber) => {
+          subscriber.next();
+          subscriber.complete();
+        }),
+    );
+    const p = firstValueFrom(
+      service.exec$('ls', {
+        prompt: PI_ZERO_PROMPT,
+        timeout: 40,
+        retry: 0,
+      }),
+    );
+    await expect(p).rejects.toThrow('Command execution timeout');
+  });
+
+  it('exec retries after timeout and succeeds on second attempt', async () => {
+    const { service, lines, transport } = createService();
+    let writeCount = 0;
+    transport.write = vi.fn(
+      () =>
+        new Observable<void>((subscriber) => {
+          writeCount++;
+          subscriber.next();
+          subscriber.complete();
+        }),
+    );
+    const execPromise = firstValueFrom(
+      service.exec$('ls', {
+        prompt: PI_ZERO_PROMPT,
+        timeout: 50,
+        retry: 1,
+      }),
+    );
+    await new Promise((r) => setTimeout(r, 70));
+    emitAsLines(lines, `out\r\n${PI_ZERO_PROMPT}`);
+    const result = await execPromise;
+    expect(result.stdout).toContain(PI_ZERO_PROMPT);
+    expect(writeCount).toBe(2);
+  });
+
+  it('exec rejects after retries are exhausted', async () => {
+    const { service, transport } = createService();
+    transport.write = vi.fn(
+      () =>
+        new Observable<void>((subscriber) => {
+          subscriber.next();
+          subscriber.complete();
+        }),
+    );
+    const outcome = await new Promise<unknown>((resolve) => {
+      service
+        .exec$('ls', {
+          prompt: PI_ZERO_PROMPT,
+          timeout: 35,
+          retry: 1,
+        })
+        .subscribe({
+          next: (v) =>
+            resolve(new Error(`unexpected next: ${JSON.stringify(v)}`)),
+          error: (e) => resolve(e),
+          complete: () => resolve(new Error('unexpected complete')),
+        });
+    });
+    expect(outcome).toBeInstanceOf(Error);
+    expect((outcome as Error).message).toContain('Command execution timeout');
+  });
 });


### PR DESCRIPTION
## Summary

Issue #547 に基づき、Web Serial のコマンド実行キュー（enqueue）の意図を明確にし、プロンプト待ちまわりの timeout / retry を読みやすく整理しました。あわせてキュー順序・タイムアウト・リトライのテストを追加・更新しています。親 Epic #542 の一部です。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Closes #547
- Related #542

## What changed?

- `CommandQueueService` の enqueue / 世代キャンセルの意図をコード上で明確化（必要に応じて軽い構造整理）
- `SerialCommandService`（command-runner）側の timeout・retry の責務境界を整理
- キュー順序・timeout / retry のテストを追加または更新

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
- Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
- Migration notes:

## How to test

1. `pnpm nx test web-serial-data-access`（または該当プロジェクトの Vitest ターゲット）を実行
2. 実機／シミュレータでシリアル接続後、既存のコマンド実行・キャンセルが従来どおり動くことを確認

## Environment (if relevant)

- Browser: （任意）
- OS: macOS / Windows / Linux
- Node version: （任意）
- pnpm version: （任意）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

