### PR TITLE
refactor(web-serial): SerialFacadeService の責務をオーケストレーション委譲のみに整理する (#548)

### DIFF
--- a/libs/web-serial/data-access/src/lib/serial-command/command-runner.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/command-runner.service.ts
@@ -18,6 +18,10 @@ import {
   throwError,
   timeout,
 } from 'rxjs';
+import {
+  SERIAL_TIMEOUT,
+  type SerialExecOptions,
+} from '@libs-web-serial-util';
 import { stripLineForPromptDetection } from './ansi-strip.util';
 import { CommandQueueService } from './command-queue.service';
 import { matchesPrompt } from './prompt-detector.util';
@@ -192,6 +196,54 @@ export class SerialCommandService {
       );
     });
     return this.withPromptAttemptRetries(attempt$, retryCount);
+  }
+
+  private serialOptionsToConfig(
+    options: SerialExecOptions,
+  ): CommandExecutionConfig {
+    const {
+      prompt,
+      timeout = SERIAL_TIMEOUT.DEFAULT,
+      retry = 0,
+    } = options;
+    return { prompt, timeout, retry };
+  }
+
+  /**
+   * {@link SerialExecOptions}（timeout / retry の既定あり）でコマンド実行
+   */
+  execWithSerialOptions$(
+    cmd: string,
+    options: SerialExecOptions,
+    onAttemptStart?: () => void,
+  ): Observable<CommandResult> {
+    return this.exec$(
+      cmd,
+      this.serialOptionsToConfig(options),
+      onAttemptStart,
+    );
+  }
+
+  execRawWithSerialOptions$(
+    cmdRaw: string,
+    options: SerialExecOptions,
+    onAttemptStart?: () => void,
+  ): Observable<CommandResult> {
+    return this.execRaw$(
+      cmdRaw,
+      this.serialOptionsToConfig(options),
+      onAttemptStart,
+    );
+  }
+
+  readUntilPromptWithSerialOptions$(
+    options: SerialExecOptions,
+    onAttemptStart?: () => void,
+  ): Observable<CommandResult> {
+    return this.readUntilPrompt$(
+      this.serialOptionsToConfig(options),
+      onAttemptStart,
+    );
   }
 
   /**

--- a/libs/web-serial/data-access/src/lib/serial-connection-orchestration.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-connection-orchestration.service.ts
@@ -1,0 +1,89 @@
+/// <reference types="@types/w3c-web-serial" />
+
+import { Injectable, inject } from '@angular/core';
+import {
+  catchError,
+  defer,
+  of,
+  type Observable,
+  Subject,
+  switchMap,
+  take,
+  throwError,
+} from 'rxjs';
+import { getConnectionErrorMessage } from '@libs-web-serial-util';
+import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
+import { SerialCommandService } from './serial-command.service';
+import { SerialTransportService } from './serial-transport.service';
+
+/** {@link SerialConnectionOrchestrationService#connect$} の結果 */
+export type SerialConnectResult =
+  | { ok: true }
+  | { ok: false; errorMessage: string };
+
+/**
+ * Transport / Command / ShellReadiness を接続ライフサイクル単位で束ねる。
+ * {@link SerialFacadeService} は本サービスへの委譲のみとし、ここにオーケストレーションを集約する。
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class SerialConnectionOrchestrationService {
+  private readonly transport = inject(SerialTransportService);
+  private readonly command = inject(SerialCommandService);
+  private readonly shellReadiness = inject(PiZeroShellReadinessService);
+
+  private connectionEpoch = 0;
+
+  private readonly connectionEstablished = new Subject<void>();
+  readonly connectionEstablished$ = this.connectionEstablished.asObservable();
+
+  connect$(baudRate = 115200): Observable<SerialConnectResult> {
+    return defer(() =>
+      this.transport.isConnected$.pipe(
+        take(1),
+        switchMap((connected) =>
+          connected ? this.disconnect$() : of(undefined),
+        ),
+        switchMap(() => this.transport.connect$(baudRate)),
+        switchMap((result) => {
+          if ('error' in result) {
+            console.error('Connection failed:', result.error);
+            return of<SerialConnectResult>({
+              ok: false,
+              errorMessage: result.error,
+            });
+          }
+          this.command.startReadLoop();
+          this.connectionEpoch += 1;
+          this.shellReadiness.reset();
+          this.connectionEstablished.next();
+          return of<SerialConnectResult>({ ok: true });
+        }),
+        catchError((error: unknown) => {
+          console.error('Connection error:', error);
+          return of<SerialConnectResult>({
+            ok: false,
+            errorMessage: getConnectionErrorMessage(error),
+          });
+        }),
+      ),
+    );
+  }
+
+  disconnect$(): Observable<void> {
+    this.shellReadiness.reset();
+    this.command.cancelAllCommands();
+    this.command.stopReadLoop();
+    return this.transport.disconnect$().pipe(
+      catchError((error) => {
+        console.error('Disconnect error:', error);
+        return throwError(() => error);
+      }),
+    );
+  }
+
+  getConnectionEpoch(): number {
+    return this.connectionEpoch;
+  }
+}

--- a/libs/web-serial/data-access/src/lib/serial-facade.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-facade.service.spec.ts
@@ -1,0 +1,129 @@
+import '@angular/compiler';
+import { Injector } from '@angular/core';
+import { SerialSessionState } from '@gurezo/web-serial-rxjs';
+import { type SerialExecOptions } from '@libs-web-serial-util';
+import { EMPTY, firstValueFrom, of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SerialCommandService } from './serial-command.service';
+import { SerialConnectionOrchestrationService } from './serial-connection-orchestration.service';
+import { SerialFacadeService } from './serial-facade.service';
+import { SerialTransportService } from './serial-transport.service';
+import { SerialValidatorService } from './serial-validator.service';
+
+describe('SerialFacadeService', () => {
+  let facade: SerialFacadeService;
+  let transport: Partial<SerialTransportService>;
+  let command: Partial<SerialCommandService>;
+  let validator: Partial<SerialValidatorService>;
+  let connection: Partial<SerialConnectionOrchestrationService>;
+
+  beforeEach(async () => {
+    transport = {
+      state$: of(SerialSessionState.Idle),
+      isConnected$: of(false),
+      errors$: EMPTY,
+      portInfo$: of(null),
+      getReadStream: vi.fn(() => of('line')),
+      write: vi.fn(() => of(undefined)),
+      getPort: vi.fn(() => undefined),
+    };
+    command = {
+      execWithSerialOptions$: vi.fn(() => of({ stdout: '' })),
+      execRawWithSerialOptions$: vi.fn(() => of({ stdout: '' })),
+      readUntilPromptWithSerialOptions$: vi.fn(() => of({ stdout: '' })),
+      isReading: vi.fn(() => false),
+      getPendingCommandCount: vi.fn(() => 0),
+    };
+    validator = {
+      isRaspberryPiZeroSerialAccess: vi.fn(() => Promise.resolve(false)),
+    };
+    connection = {
+      connectionEstablished$: EMPTY,
+      connect$: vi.fn(() => of({ ok: true } as const)),
+      disconnect$: vi.fn(() => of(undefined)),
+      getConnectionEpoch: vi.fn(() => 42),
+    };
+
+    const injector = Injector.create({
+      providers: [
+        SerialFacadeService,
+        { provide: SerialTransportService, useValue: transport },
+        { provide: SerialCommandService, useValue: command },
+        { provide: SerialValidatorService, useValue: validator },
+        {
+          provide: SerialConnectionOrchestrationService,
+          useValue: connection,
+        },
+      ],
+    });
+    facade = injector.get(SerialFacadeService);
+  });
+
+  it('connect$ delegates to SerialConnectionOrchestrationService.connect$', async () => {
+    const result = await firstValueFrom(facade.connect$(115200));
+    expect(connection.connect$).toHaveBeenCalledWith(115200);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('disconnect$ delegates to SerialConnectionOrchestrationService.disconnect$', async () => {
+    await firstValueFrom(facade.disconnect$());
+    expect(connection.disconnect$).toHaveBeenCalled();
+  });
+
+  it('exec$ delegates to command.execWithSerialOptions$', async () => {
+    const options: SerialExecOptions = {
+      prompt: 'pi@raspberrypi',
+      timeout: 5000,
+      retry: 1,
+    };
+    await firstValueFrom(facade.exec$('ls', options));
+    expect(command.execWithSerialOptions$).toHaveBeenCalledWith('ls', options);
+  });
+
+  it('execRaw$ delegates to command.execRawWithSerialOptions$', async () => {
+    const options: SerialExecOptions = { prompt: /#$/, timeout: 3000 };
+    await firstValueFrom(facade.execRaw$('id\n', options));
+    expect(command.execRawWithSerialOptions$).toHaveBeenCalledWith(
+      'id\n',
+      options,
+    );
+  });
+
+  it('readUntilPrompt$ delegates to command.readUntilPromptWithSerialOptions$', async () => {
+    const options: SerialExecOptions = { prompt: 'login:', timeout: 2000 };
+    await firstValueFrom(facade.readUntilPrompt$(options));
+    expect(
+      command.readUntilPromptWithSerialOptions$,
+    ).toHaveBeenCalledWith(options);
+  });
+
+  it('write$ delegates to transport.write', async () => {
+    await firstValueFrom(facade.write$('hello'));
+    expect(transport.write).toHaveBeenCalledWith('hello');
+  });
+
+  it('read$ takes one line from transport.getReadStream', async () => {
+    const line = await firstValueFrom(facade.read$());
+    expect(transport.getReadStream).toHaveBeenCalled();
+    expect(line).toBe('line');
+  });
+
+  it('getConnectionEpoch delegates to connection', () => {
+    expect(facade.getConnectionEpoch()).toBe(42);
+    expect(connection.getConnectionEpoch).toHaveBeenCalled();
+  });
+
+  it('isRaspberryPiZero delegates to validator with transport', async () => {
+    await facade.isRaspberryPiZero();
+    expect(validator.isRaspberryPiZeroSerialAccess).toHaveBeenCalledWith(
+      transport,
+    );
+  });
+
+  it('isReading and getPendingCommandCount delegate to command', () => {
+    expect(facade.isReading()).toBe(false);
+    expect(facade.getPendingCommandCount()).toBe(0);
+    expect(command.isReading).toHaveBeenCalled();
+    expect(command.getPendingCommandCount).toHaveBeenCalled();
+  });
+});

--- a/libs/web-serial/data-access/src/lib/serial-facade.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-facade.service.ts
@@ -2,38 +2,28 @@
 
 import { Injectable, inject } from '@angular/core';
 import type { SerialError } from '@gurezo/web-serial-rxjs';
-import {
-  catchError,
-  defer,
-  of,
-  type Observable,
-  Subject,
-  switchMap,
-  take,
-  throwError,
-} from 'rxjs';
+import { type Observable, take } from 'rxjs';
 import {
   type CommandResult,
   SerialCommandService,
 } from './serial-command.service';
 import {
-  getConnectionErrorMessage,
-  SERIAL_TIMEOUT,
+  type SerialConnectResult,
+  SerialConnectionOrchestrationService,
+} from './serial-connection-orchestration.service';
+import {
   type SerialExecOptions,
 } from '@libs-web-serial-util';
-import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
 import { SerialTransportService } from './serial-transport.service';
 import { SerialValidatorService } from './serial-validator.service';
 
-/** {@link SerialFacadeService#connect$} の結果 */
-export type SerialFacadeConnectResult =
-  | { ok: true }
-  | { ok: false; errorMessage: string };
+/** {@link SerialFacadeService#connect$} の結果（後方互換の別名） */
+export type SerialFacadeConnectResult = SerialConnectResult;
 
 /**
  * Serial Facade サービス
  *
- * Transport / Validator（ポート情報） / Command を統合し、シンプルな API を提供
+ * Transport / Validator / Command / 接続オーケストレーションを束ね、アプリ向け API を提供する薄い層。
  */
 @Injectable({
   providedIn: 'root',
@@ -42,23 +32,12 @@ export class SerialFacadeService {
   private transport = inject(SerialTransportService);
   private command = inject(SerialCommandService);
   private validator = inject(SerialValidatorService);
-  private shellReadiness = inject(PiZeroShellReadinessService);
+  private connection = inject(SerialConnectionOrchestrationService);
 
-  /** 接続成功のたびに増加（同一接続の post-connect 処理を1回に制限するため） */
-  private connectionEpoch = 0;
+  readonly connectionEstablished$ = this.connection.connectionEstablished$;
 
-  private readonly connectionEstablished = new Subject<void>();
-  /**
-   * シリアル接続が確立されるたびに通知（ターミナルが後からマウントされる場合のブートストラップ用）
-   * {@link SerialTransportService.state$} が `connected` になる回と同期。
-   */
-  readonly connectionEstablished$ = this.connectionEstablished.asObservable();
-
-  /** ライブラリ `SerialSession.state$` の橋渡し（未接続は `idle`） */
   readonly state$ = this.transport.state$;
-  /** ライブラリ `SerialSession.isConnected$` の橋渡し */
   readonly isConnected$ = this.transport.isConnected$;
-  /** ライブラリ主エラーチャネル（未接続時は購読しても何も来ない） */
   get errors$(): Observable<SerialError> {
     return this.transport.errors$;
   }
@@ -66,135 +45,48 @@ export class SerialFacadeService {
     return this.transport.portInfo$;
   }
 
-  /**
-   * 受信行ストリーム（{@link SerialTransportService#getReadStream} と同等、1 行ずつ）。
-   * 未接続時は購読時にエラーとなる。
-   */
   get data$() {
     return this.transport.getReadStream();
   }
 
-  /**
-   * Serial ポートに接続（Observable）
-   *
-   * @param baudRate ボーレート (デフォルト: 115200)
-   */
   connect$(baudRate = 115200): Observable<SerialFacadeConnectResult> {
-    return defer(() =>
-      this.transport.isConnected$.pipe(
-        take(1),
-        switchMap((connected) =>
-          connected ? this.disconnect$() : of(undefined)
-        ),
-        switchMap(() => this.transport.connect$(baudRate)),
-        switchMap((result) => {
-          if ('error' in result) {
-            console.error('Connection failed:', result.error);
-            return of<SerialFacadeConnectResult>({
-              ok: false,
-              errorMessage: result.error,
-            });
-          }
-          this.startReadStreamSubscription();
-          this.connectionEpoch += 1;
-          this.shellReadiness.reset();
-          this.connectionEstablished.next();
-          return of<SerialFacadeConnectResult>({ ok: true });
-        }),
-        catchError((error: unknown) => {
-          console.error('Connection error:', error);
-          return of<SerialFacadeConnectResult>({
-            ok: false,
-            errorMessage: getConnectionErrorMessage(error),
-          });
-        })
-      )
-    );
+    return this.connection.connect$(baudRate);
   }
 
-  private startReadStreamSubscription(): void {
-    this.command.startReadLoop();
-  }
-
-  /**
-   * Serial ポートから切断（Observable）
-   */
   disconnect$(): Observable<void> {
-    this.shellReadiness.reset();
-    this.command.cancelAllCommands();
-    this.command.stopReadLoop();
-    return this.transport.disconnect$().pipe(
-      catchError((error) => {
-        console.error('Disconnect error:', error);
-        return throwError(() => error);
-      })
-    );
+    return this.connection.disconnect$();
   }
 
-  /**
-   * データを書き込む（Observable）
-   */
   write$(data: string): Observable<void> {
     return this.transport.write(data);
   }
 
-  /**
-   * 行を 1 本だけ読み取る（Observable）。
-   */
   read$(): Observable<string> {
     return this.transport.getReadStream().pipe(take(1));
   }
 
-  /**
-   * コマンド実行（stdout 相当を返す）
-   */
   exec$(
     cmd: string,
     options: SerialExecOptions,
   ): Observable<CommandResult> {
-    const {
-      prompt,
-      timeout = SERIAL_TIMEOUT.DEFAULT,
-      retry = 0,
-    } = options;
-    return this.command.exec$(cmd, { prompt, timeout, retry });
+    return this.command.execWithSerialOptions$(cmd, options);
   }
 
-  /**
-   * raw コマンド実行（改行制御が必要なケース向け）
-   */
   execRaw$(
     cmdRaw: string,
     options: SerialExecOptions,
   ): Observable<CommandResult> {
-    const {
-      prompt,
-      timeout = SERIAL_TIMEOUT.DEFAULT,
-      retry = 0,
-    } = options;
-    return this.command.execRaw$(cmdRaw, { prompt, timeout, retry });
+    return this.command.execRawWithSerialOptions$(cmdRaw, options);
   }
 
-  /**
-   * 送信せずに prompt まで待機
-   */
   readUntilPrompt$(options: SerialExecOptions): Observable<CommandResult> {
-    const {
-      prompt,
-      timeout = SERIAL_TIMEOUT.DEFAULT,
-      retry = 0,
-    } = options;
-    return this.command.readUntilPrompt$({ prompt, timeout, retry });
+    return this.command.readUntilPromptWithSerialOptions$(options);
   }
 
-  /** 現在のシリアル接続セッション番号（切断後も値は保持され、次回接続で増える） */
   getConnectionEpoch(): number {
-    return this.connectionEpoch;
+    return this.connection.getConnectionEpoch();
   }
 
-  /**
-   * 読み取り中かどうか（ストリーム購読中は true）
-   */
   isReading(): boolean {
     return this.command.isReading();
   }
@@ -203,16 +95,8 @@ export class SerialFacadeService {
     return this.command.getPendingCommandCount();
   }
 
-  async isRaspberryPiZero(): Promise<boolean> {
-    const syncInfo = this.transport.getPortInfo();
-    if (this.validator.isPiZeroPortInfo(syncInfo)) {
-      return true;
-    }
-    const port = this.transport.getPort();
-    if (!port) {
-      return false;
-    }
-    return this.validator.isRaspberryPiZero(port);
+  isRaspberryPiZero(): Promise<boolean> {
+    return this.validator.isRaspberryPiZeroSerialAccess(this.transport);
   }
 
   getPort(): SerialPort | null {

--- a/libs/web-serial/data-access/src/lib/serial-validator.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-validator.service.ts
@@ -29,6 +29,24 @@ export class SerialValidatorService {
   }
 
   /**
+   * 同期 `portInfo` または `SerialPort#getInfo()` で Pi Zero 相当か判定する。
+   * {@link SerialTransportService} 等、ポート取得 API を持つオブジェクト向け。
+   */
+  async isRaspberryPiZeroSerialAccess(access: {
+    getPortInfo(): SerialPortInfo | null;
+    getPort(): SerialPort | undefined;
+  }): Promise<boolean> {
+    if (this.isPiZeroPortInfo(access.getPortInfo())) {
+      return true;
+    }
+    const port = access.getPort();
+    if (!port) {
+      return false;
+    }
+    return this.isRaspberryPiZero(port);
+  }
+
+  /**
    * Raspberry Pi Zero かどうかを検証
    * @param port SerialPort
    * @returns Raspberry Pi Zero の場合 true


### PR DESCRIPTION
## Summary

Issue #542 の残タスクである #548 に対応し、`SerialFacadeService` をアプリ向け API の薄いファサードに限定しました。接続ライフサイクルや `SerialExecOptions` の既定値適用は下位サービスへ寄せ、Facade は呼び出しの組み立てに集中します。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #548
- Refs #542

## What changed?

- `SerialConnectionOrchestrationService` を追加し、`connect$` / `disconnect$` / `connectionEstablished$` / `getConnectionEpoch` 周りのオーケストレーションを集約した。
- `SerialFacadeService` は上記および `SerialTransportService` / `SerialCommandService` / `SerialValidatorService` への委譲中心に変更した。
- `SerialValidatorService.isRaspberryPiZeroSerialAccess` を追加し、Pi Zero 判定の組み合わせを Validator に移した。
- `SerialCommandService` に `SerialExecOptions` 向けの `execWithSerialOptions$` などを追加した。
- `serial-facade.service.spec.ts` で Facade の委譲を検証した。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

（公開メソッドシグネチャと `SerialFacadeConnectResult` の意味は維持。新規の `SerialConnectResult` / `SerialConnectionOrchestrationService` はライブラリの `index.ts` からはエクスポートしていない。）

## How to test

1. `pnpm nx run libs-web-serial-data-access:test`
2. `pnpm nx run libs-web-serial-data-access:lint`

## Environment (if relevant)

- Browser: （該当なし）
- OS: macOS / Windows / Linux
- Node version: （ローカルに合わせて記載）
- pnpm version: （ローカルに合わせて記載）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant