### PR TITLE
refactor(web-serial): リファクタ後の不要コードと未使用テストを整理する (#549)

### DIFF
--- a/libs/web-serial/data-access/src/lib/serial-notification.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-notification.service.ts
@@ -29,27 +29,4 @@ export class SerialNotificationService {
       }
     );
   }
-
-  /**
-   * Web Serial切断時の通知
-   */
-  notifyDisconnection(): void {
-    this.toastr.info('Web Serial接続が切断されました', '切断', {
-      timeOut: 3000,
-    });
-  }
-
-  /**
-   * Web Serialデバイス検出時の通知
-   * @param deviceName デバイス名
-   */
-  notifyDeviceDetected(deviceName: string): void {
-    this.toastr.success(
-      `デバイスを検出しました: ${deviceName}`,
-      'デバイス検出',
-      {
-        timeOut: 3000,
-      }
-    );
-  }
 }

--- a/libs/web-serial/util/src/lib/serial-error-messages.spec.ts
+++ b/libs/web-serial/util/src/lib/serial-error-messages.spec.ts
@@ -2,7 +2,6 @@ import { SerialError, SerialErrorCode } from '@gurezo/web-serial-rxjs';
 import {
   getConnectionErrorMessage,
   getReadErrorMessage,
-  getRaspberryPiZeroError,
   getWriteErrorMessage,
 } from './serial-error-messages';
 
@@ -81,14 +80,6 @@ describe('serial-error-messages', () => {
 
     it('should return Unknown write error for unknown', () => {
       expect(getWriteErrorMessage(null)).toBe('Unknown write error');
-    });
-  });
-
-  describe('getRaspberryPiZeroError', () => {
-    it('should return fixed message', () => {
-      expect(getRaspberryPiZeroError()).toBe(
-        'Web Serial is not Raspberry Pi Zero'
-      );
     });
   });
 });

--- a/libs/web-serial/util/src/lib/serial-error-messages.ts
+++ b/libs/web-serial/util/src/lib/serial-error-messages.ts
@@ -95,12 +95,3 @@ export function getWriteErrorMessage(error: unknown): string {
   }
   return 'Unknown write error';
 }
-
-/**
- * Raspberry Pi Zero 検証エラーメッセージを返す
- * @returns エラーメッセージ
- */
-export function getRaspberryPiZeroError(): string {
-  return 'Web Serial is not Raspberry Pi Zero';
-}
-


### PR DESCRIPTION
## Summary

Issue #549 対応として、Web Serial 周辺で本番から参照されていないヘルパー・通知メソッドと、それに紐づくテストのみを削除しました。親 Epic #542 の「不要コードを残さない」締めとして、挙動を変えずに整理しています。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #549

## What changed?

- `getRaspberryPiZeroError` とその単体テストを削除（どの本番コードからも import されていなかった）
- `SerialNotificationService` から `notifyDisconnection` / `notifyDeviceDetected` を削除（未使用）

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

本 PR で export されていた `getRaspberryPiZeroError` を削除するため、外部パッケージが当リポジトリのソースを直接参照している場合は、その利用を止める必要があります（本リポジトリ内では未使用でした）。`SerialNotificationService` の削除メソッドもリポジトリ内未呼び出しでした。

## How to test

1. `pnpm exec nx run libs-web-serial-util:test`
2. `pnpm exec nx run libs-web-serial-data-access:test`
3. `pnpm test`

## Environment (if relevant)

- Browser: （変更なし）
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [ ] I considered error handling where relevant