### PR TITLE
refactor(web-serial): SerialTransportService を SerialSession 基準の thin adapter に整理

### DIFF
--- a/libs/web-serial/data-access/src/lib/serial-transport.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.spec.ts
@@ -30,12 +30,14 @@ vi.mock('@gurezo/web-serial-rxjs', async (importOriginal) => {
 function buildMockSession(
   port: SerialPort | null,
   lines$?: Observable<string>,
+  receive$?: Observable<string>,
 ): SerialSession {
   const state$ = new BehaviorSubject<SerialSessionState>(
     SerialSessionState.Connecting
   );
   const isConnected$ = new BehaviorSubject(false);
   const getCurrentPort = vi.fn<[], SerialPort | null>(() => port);
+  const receiveStream = receive$ ?? EMPTY;
 
   return {
     isBrowserSupported: () => true,
@@ -59,7 +61,8 @@ function buildMockSession(
     getPortInfo: vi.fn(() => null),
     getCurrentPort,
     errors$: EMPTY,
-    receive$: EMPTY,
+    receive$: receiveStream,
+    receiveReplay$: receiveStream,
     lines$: lines$ ?? of('line1'),
     send$: vi.fn(() => of(undefined)),
   } as unknown as SerialSession;
@@ -149,5 +152,32 @@ describe('SerialTransportService', () => {
     const readPromise = firstValueFrom(service.getReadStream().pipe(take(1)));
     queueMicrotask(() => lineSubject.next('expected-line'));
     expect(await readPromise).toBe('expected-line');
+  });
+
+  it('should emit from receive$ and receiveReplay$ when session is active', async () => {
+    const mockPort = {} as SerialPort;
+    const chunkSubject = new Subject<string>();
+    mockCreateSerialSession.mockReturnValue(
+      buildMockSession(mockPort, undefined, chunkSubject.asObservable()),
+    );
+
+    await firstValueFrom(service.connect$());
+
+    const receivePromise = firstValueFrom(service.receive$.pipe(take(1)));
+    const replayPromise = firstValueFrom(service.receiveReplay$.pipe(take(1)));
+    queueMicrotask(() => chunkSubject.next('raw-chunk'));
+    expect(await receivePromise).toBe('raw-chunk');
+    expect(await replayPromise).toBe('raw-chunk');
+  });
+
+  it('write should delegate to session send$', async () => {
+    const mockPort = {} as SerialPort;
+    const session = buildMockSession(mockPort);
+    mockCreateSerialSession.mockReturnValue(session);
+
+    await firstValueFrom(service.connect$());
+    await firstValueFrom(service.write('hello'));
+
+    expect(session.send$).toHaveBeenCalledWith('hello');
   });
 });

--- a/libs/web-serial/data-access/src/lib/serial-transport.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.ts
@@ -19,7 +19,6 @@ import {
   Observable,
   of,
   switchMap,
-  take,
   tap,
   throwError,
 } from 'rxjs';
@@ -39,9 +38,9 @@ import {
  * 本サービスは `activeSession$` のみで「どのセッションを流すか」を切り替え、
  * ライブラリの Observable を重ねて二重管理しない。
  *
- * 読み取りストリーム {@link #getReadStream} は {@link SerialSession.lines$} を橋渡しする
- * （行単位。区切りはライブラリ側の改行処理に従う）。チャンク生データは
- * {@link SerialSession.receive$} を直接使用する必要がある場合のみ利用する。
+ * {@link #lines$} / {@link #getReadStream} は {@link SerialSession.lines$} を橋渡しする
+ * （行単位）。生チャンクは {@link #receive$}、後から購読する用途は
+ * {@link #receiveReplay$}（セッション作成時の replay 設定に従う）。
  */
 @Injectable({
   providedIn: 'root',
@@ -81,6 +80,24 @@ export class SerialTransportService {
   readonly lines$ = this.activeSession$.pipe(
     switchMap((s) => (s ? s.lines$ : NEVER))
   );
+
+  /**
+   * ライブラリ {@link SerialSession.receive$}。未接続時は空ストリーム。
+   */
+  get receive$(): Observable<string> {
+    return this.activeSession$.pipe(
+      switchMap((s) => s?.receive$ ?? EMPTY)
+    );
+  }
+
+  /**
+   * ライブラリ {@link SerialSession.receiveReplay$}。未接続時は空ストリーム。
+   */
+  get receiveReplay$(): Observable<string> {
+    return this.activeSession$.pipe(
+      switchMap((s) => s?.receiveReplay$ ?? EMPTY)
+    );
+  }
 
   /**
    * I/O エラー（`SerialError`）のライブラリ本流。未接続時は空ストリーム。
@@ -171,8 +188,8 @@ export class SerialTransportService {
   }
 
   /**
-   * 読み取りストリーム（**1 改行区切りごとに 1 エミット**する行文字列）を取得。
-   * 未接続時または未接続状態で呼び出した場合は throwError
+   * 読み取りストリーム（**1 改行区切りごとに 1 エミット**する行文字列）。
+   * {@link SerialSession.lines$} へ委譲。セッションが無い場合は throwError。
    */
   getReadStream(): Observable<string> {
     return defer(() => {
@@ -180,24 +197,17 @@ export class SerialTransportService {
       if (!s) {
         return throwError(() => new Error('Serial port not connected'));
       }
-      return s.isConnected$.pipe(
-        take(1),
-        switchMap((connected) =>
-          connected
-            ? s.lines$.pipe(
-                catchError((err: unknown) =>
-                  throwError(() => new Error(getReadErrorMessage(err)))
-                ),
-              )
-            : throwError(() => new Error('Serial port not connected'))
+      return s.lines$.pipe(
+        catchError((err: unknown) =>
+          throwError(() => new Error(getReadErrorMessage(err)))
         )
       );
     });
   }
 
   /**
-   * データを書き込む
-   * 未接続時またはエラー時は throwError
+   * データを書き込む。{@link SerialSession.send$} へ委譲（未接続時はライブラリが fail fast）。
+   * セッションが無い場合のみ throwError（`Serial port not connected`）。
    */
   write(data: string): Observable<void> {
     return defer(() => {
@@ -205,18 +215,9 @@ export class SerialTransportService {
       if (!s) {
         return throwError(() => new Error('Serial port not connected'));
       }
-      return s.isConnected$.pipe(
-        take(1),
-        switchMap((connected) =>
-          connected
-            ? s.send$(data).pipe(
-                catchError((error) =>
-                  throwError(
-                    () => new Error(getWriteErrorMessage(error)),
-                  )
-                )
-              )
-            : throwError(() => new Error('Serial port not connected'))
+      return s.send$(data).pipe(
+        catchError((error) =>
+          throwError(() => new Error(getWriteErrorMessage(error)))
         )
       );
     });


### PR DESCRIPTION
## Summary

`SerialSession`（web-serial-rxjs v2.1）を接続状態の source of truth とし、`SerialTransportService` で `receive$` / `receiveReplay$` をそのまま公開、`getReadStream` と `write` を `lines$` / `send$` へ委譲するよう整理した。issue #558 の完了条件に対応し、#557 の transport 層の一部を前進させる。

## Type of change

- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #558
- Related to #557

## What changed?

- `receive$` / `receiveReplay$` を `SerialSession` から橋渡しで公開した。
- `getReadStream()` を `lines$` への委譲に簡素化した。
- `write()` を `send$` への委譲に簡素化し、二重の接続判定をなくした。
- 上記の単体テストを追加した。

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)

  - Details: `SerialTransportService` に `receive$` / `receiveReplay$` のゲッターが追加された。既存メソッドの契約は維持しつつ、未接続時の `write` エラーがライブラリ経由のメッセージ（例: PORT_NOT_OPEN の日本語文言）になる場合がある。

- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test

1. `pnpm exec nx run libs-web-serial-data-access:test`
2. 実機またはモックでシリアル接続・切断・送信・ターミナル表示の smoke を行う

## Environment (if relevant)

- Browser:
- OS: macOS
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant