### PR TITLE
refactor(web-serial): remove unused cancelCommand stub

### DIFF
--- a/libs/web-serial/data-access/src/lib/serial-command/command-runner.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/command-runner.service.ts
@@ -288,13 +288,6 @@ export class SerialCommandService {
     );
   }
 
-  /**
-   * 単一の待機 ID によるキャンセルはサポートしない（世代ベースの cancelAllCommands を利用）。
-   */
-  cancelCommand(commandId: string): void {
-    void commandId;
-  }
-
   cancelAllCommands(): void {
     this.commandQueue.cancelAllCommands();
   }


### PR DESCRIPTION
## Summary

`SerialTransportService` を `@gurezo/web-serial-rxjs` v2.1 の `SerialSession` に寄せ、`receive$` / `receiveReplay$` の橋渡しと `getReadStream` / `write` の委譲で二重管理を減らした。また、未使用の `cancelCommand` スタブを削除した。issue #558（および #557 の transport 部分）に対応する。

## Type of change

- [ ] Bug fix
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #558
- Related to #557

## What changed?

- `SerialTransportService` に `receive$` / `receiveReplay$` を追加し、`getReadStream` を `lines$` 委譲、`write` を `send$` 委譲に整理した。
- 上記の単体テストを追加した。
- `SerialCommandService` の未使用 `cancelCommand` を削除した。

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)

  - Details: `SerialTransportService` に `receive$` / `receiveReplay$` ゲッターを追加。`write` の未接続時エラー文言がライブラリ経由（例: `PORT_NOT_OPEN` の日本語メッセージ）になる場合がある。`cancelCommand` は参照がなく削除（公開 API の死蔵メソッド削除）。

- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test

1. `pnpm exec nx run libs-web-serial-data-access:test`
2. シリアル接続・切断・コマンド実行・ターミナル表示の smoke を行う

## Environment (if relevant)

- Browser:
- OS: macOS
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant