### PR TITLE
docs(web-serial): issue #559 受信ストリームの用途を明文化

### DIFF
--- a/libs/web-serial/data-access/README.md
+++ b/libs/web-serial/data-access/README.md
@@ -1,0 +1,21 @@
+# web-serial-data-access
+
+Angular 向けのシリアル（Web Serial + `@gurezo/web-serial-rxjs`）データアクセス層。
+
+## 受信ストリームの使い分け（`SerialSession` / `SerialTransportService`）
+
+アプリでは `@gurezo/web-serial-rxjs` の `SerialSession` が提供する受信 Observable を、用途に応じて次のように使い分ける（[#559](https://github.com/gurezo/chirimen-lite-console/issues/559)）。
+
+| 用途 | 使用する stream |
+| --- | --- |
+| ターミナル表示（生の受信を後から購読しても欠けないようにしたい） | `receiveReplay$` |
+| 通常の行単位ログ | `lines$` |
+| prompt / login / password 判定 | `receiveReplay$` または専用の prompt 用ストリーム。本リポジトリでは **行単位の `lines$`（`getReadStream`）＋プロンプト用バッファ**で判定し、チャンク境界に依存しないようにしている |
+| コマンド結果の行処理 | `lines$` |
+| 生の受信 chunk が必要な処理 | `receive$` |
+
+### 本プロジェクト内の対応
+
+- **`SerialTransportService`** が上記各ストリームを `activeSession$` 経由で橋渡しする。
+- **`SerialCommandService`（`command-runner.service.ts`）** は `getReadStream()`（= `lines$`）のみを購読し、プロンプト待ち用に行を連結したバッファを保持する（ライブラリの行分割とは別に、複数行にまたがるパターンマッチ用）。
+- **ターミナル UI（xterm）** は、現状はコマンド実行の stdout と接続後ブートストラップのステータスログで表示している。シリアルからのライブミラーを xterm に流す場合は、`receiveReplay$` の購読を検討する。

--- a/libs/web-serial/data-access/src/lib/serial-command/command-runner.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/command-runner.service.ts
@@ -52,9 +52,16 @@ export interface CommandResult {
 }
 
 /**
- * Serial コマンド実行サービス
+ * Serial 上のコマンド実行・プロンプト待ち。
  *
- * 読み取りバッファ・ストリーム購読・プロンプト待ち・書き込みを担当
+ * ### 受信（issue #559）
+ *
+ * {@link SerialTransportService#getReadStream}（= `SerialSession.lines$` と同根の**行**ストリーム）のみを購読する。
+ * プロンプト・ログイン判定は **行単位**に strip したテキストを {@link readBuffer} に連結して行い、`receive$` / `receiveReplay$` の
+ * チャンク境界には依存しない（ANSI 除去は {@link stripLineForPromptDetection}）。
+ *
+ * ライブラリの行分割と役割が重なるが、`readBuffer` は「複数行にまたがるマッチ」とコマンド境界でのクリアに必須であり、
+ * ライブラリ内バッファとの二重ではない。
  */
 @Injectable({
   providedIn: 'root',
@@ -71,8 +78,8 @@ export class SerialCommandService {
   ) {}
 
   /**
-   * 接続後に呼び出し、{@link SerialTransportService#getReadStream}（行単位）を購読し
-   * プロンプト検出用バッファに蓄積する（行ごとに改行を復元）。
+   * 接続後に呼び出し、`lines$` 経路（{@link SerialTransportService#getReadStream}）だけを購読する。
+   * 各エミットは 1 行。プロンプト検出用に {@link stripLineForPromptDetection} 後の行＋改行を {@link readBuffer} へ蓄積する。
    */
   startReadLoop(): void {
     this.readBuffer = '';

--- a/libs/web-serial/data-access/src/lib/serial-facade.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-facade.service.ts
@@ -24,6 +24,16 @@ export type SerialFacadeConnectResult = SerialConnectResult;
  * Serial Facade サービス
  *
  * Transport / Validator / Command / 接続オーケストレーションを束ね、アプリ向け API を提供する薄い層。
+ *
+ * ### 受信ストリーム（issue #559）
+ *
+ * 各ストリームの意味は {@link SerialTransportService} のクラスドキュメントおよび `libs/web-serial/data-access/README.md` を参照。
+ *
+ * - {@link #lines$} / {@link #data$} / {@link #read$} … 行単位（`SerialSession.lines$` 系）。
+ * - {@link #receive$} … 生チャンク。
+ * - {@link #receiveReplay$} … replay 付き生受信（ターミナルのライブミラー等）。
+ *
+ * プロンプト待ち・`exec$` は {@link SerialCommandService} が {@link SerialTransportService#getReadStream}（= `lines$`）のみ購読する。
  */
 @Injectable({
   providedIn: 'root',
@@ -45,6 +55,25 @@ export class SerialFacadeService {
     return this.transport.portInfo$;
   }
 
+  /** 行単位の受信。未接続時は完了しないストリーム（NEVER）。 */
+  get lines$(): Observable<string> {
+    return this.transport.lines$;
+  }
+
+  /** 生の受信チャンク。 */
+  get receive$(): Observable<string> {
+    return this.transport.receive$;
+  }
+
+  /** replay 付き生受信（ターミナル表示用ミラー等）。 */
+  get receiveReplay$(): Observable<string> {
+    return this.transport.receiveReplay$;
+  }
+
+  /**
+   * 接続済み時のみ 1 行ずつ読むストリーム（{@link SerialTransportService#getReadStream} = `lines$` 源）。
+   * 未接続で購読するとエラー。
+   */
   get data$() {
     return this.transport.getReadStream();
   }

--- a/libs/web-serial/data-access/src/lib/serial-transport.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.spec.ts
@@ -16,7 +16,10 @@ import {
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SerialTransportService } from './serial-transport.service';
 
-const mockCreateSerialSession = vi.fn<[], SerialSession>();
+/** Vitest 4 の `vi.fn<Args, R>()` は非推奨のため、実装から型を載せる */
+const mockCreateSerialSession = vi.fn((): SerialSession => {
+  throw new Error('mockCreateSerialSession: call mockReturnValue in the test');
+});
 
 vi.mock('@gurezo/web-serial-rxjs', async (importOriginal) => {
   const actual =
@@ -36,7 +39,7 @@ function buildMockSession(
     SerialSessionState.Connecting
   );
   const isConnected$ = new BehaviorSubject(false);
-  const getCurrentPort = vi.fn<[], SerialPort | null>(() => port);
+  const getCurrentPort = vi.fn((): SerialPort | null => port);
   const receiveStream = receive$ ?? EMPTY;
 
   return {
@@ -124,7 +127,9 @@ describe('SerialTransportService', () => {
     const err = new SerialError(SerialErrorCode.READ_FAILED, 'read');
     const errSubj = new BehaviorSubject(err);
     const session = buildMockSession(mockPort);
-    (session as { errors$: typeof errSubj }).errors$ = errSubj.asObservable();
+    (
+      session as unknown as { errors$: Observable<SerialError> }
+    ).errors$ = errSubj.asObservable();
     mockCreateSerialSession.mockReturnValue(session);
 
     await firstValueFrom(service.connect$());

--- a/libs/web-serial/data-access/src/lib/serial-transport.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.ts
@@ -38,9 +38,18 @@ import {
  * 本サービスは `activeSession$` のみで「どのセッションを流すか」を切り替え、
  * ライブラリの Observable を重ねて二重管理しない。
  *
- * {@link #lines$} / {@link #getReadStream} は {@link SerialSession.lines$} を橋渡しする
- * （行単位）。生チャンクは {@link #receive$}、後から購読する用途は
- * {@link #receiveReplay$}（セッション作成時の replay 設定に従う）。
+ * ### 受信ストリームの使い分け（issue #559）
+ *
+ * | 用途 | stream |
+ * | --- | --- |
+ * | ターミナル表示（replay で取りこぼしにくい生受信） | {@link #receiveReplay$} |
+ * | 通常の行単位ログ | {@link #lines$} |
+ * | prompt / login / password 判定 | `receiveReplay$` または専用 stream。本アプリでは {@link #lines$} / {@link #getReadStream} の行＋`SerialCommandService` のプロンプト用バッファで判定 |
+ * | コマンド結果の行処理 | {@link #lines$} / {@link #getReadStream} |
+ * | 生チャンク | {@link #receive$} |
+ *
+ * `receiveReplay$` はチャンク単位のため、プロンプト検出をそこに寄せると行境界・ANSI 処理と齟齬が出やすい。
+ * {@link #lines$} / {@link #getReadStream} は {@link SerialSession.lines$} への橋渡し（改行区切りの行文字列）。
  */
 @Injectable({
   providedIn: 'root',
@@ -189,15 +198,15 @@ export class SerialTransportService {
 
   /**
    * 読み取りストリーム（**1 改行区切りごとに 1 エミット**する行文字列）。
-   * {@link SerialSession.lines$} へ委譲。セッションが無い場合は throwError。
+   * {@link #lines$} と同じ {@link SerialSession.lines$} 源。接続済みチェックのため
+   * セッション欠如時は throwError（{@link #lines$} は未接続時 `NEVER`）。
    */
   getReadStream(): Observable<string> {
     return defer(() => {
-      const s = this.session;
-      if (!s) {
+      if (!this.session) {
         return throwError(() => new Error('Serial port not connected'));
       }
-      return s.lines$.pipe(
+      return this.lines$.pipe(
         catchError((err: unknown) =>
           throwError(() => new Error(getReadErrorMessage(err)))
         )


### PR DESCRIPTION
## Summary

`@gurezo/web-serial-rxjs` の `receive$` / `receiveReplay$` / `lines$` の役割を issue #559 の表に沿って文書化し、Transport / Facade / `SerialCommandService` でどのストリームを使うかを README と JSDoc で固定した。また `getReadStream` を `lines$` と同じ経路に揃え、`SerialFacadeService` から受信ストリームを参照しやすくした。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #559

## What changed?

- `libs/web-serial/data-access/README.md` を追加し、ストリームの使い分けと本プロジェクト内の対応を記載
- `SerialTransportService` / `SerialFacadeService` / `SerialCommandService`（command-runner）の JSDoc を拡充
- `getReadStream` を `lines$` パイプ経由に変更し、Facade に `lines$` / `receive$` / `receiveReplay$` ゲッターを追加

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details: `SerialFacadeService` に `lines$` / `receive$` / `receiveReplay$` の公開ゲッターを追加（既存の Transport 委譲のみ。破壊的変更なし）
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `nx test libs-web-serial-data-access` を実行する
2. 実機あり: シリアル接続後、ターミナル・ブートストラップ・`exec` とプロンプト待ちが従来どおり動くことを確認する

## Environment (if relevant)

- Browser: （任意）
- OS: macOS / Windows / Linux
- Node version: （任意）
- pnpm version: （任意）

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant