### PR TITLE
refactor(web-serial): プロンプト判定の集約と Pi Zero セッション境界の整理

### DIFF
--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
@@ -21,7 +21,7 @@ vi.mock('@xterm/addon-fit', () => ({
   },
 }));
 import {
-  PiZeroSerialBootstrapService,
+  PiZeroSessionService,
   SerialFacadeService,
 } from '@libs-web-serial-data-access';
 import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
@@ -52,10 +52,12 @@ describe('TerminalViewComponent', () => {
           getConnectionEpoch: () => 1,
         },
       })
-      .overrideProvider(PiZeroSerialBootstrapService, {
+      .overrideProvider(PiZeroSessionService, {
         useValue: {
-          shouldRunAfterConnect$: shouldRunAfterConnectMock,
-          runAfterConnect$: runAfterConnectMock,
+          bootstrap: {
+            shouldRunAfterConnect$: shouldRunAfterConnectMock,
+            runAfterConnect$: runAfterConnectMock,
+          },
         },
       })
       .compileComponents();

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -27,7 +27,7 @@ import {
 } from '@libs-terminal-util';
 import { attachTerminalInput } from '../terminal-input';
 import {
-  PiZeroSerialBootstrapService,
+  PiZeroSessionService,
   SerialFacadeService,
 } from '@libs-web-serial-data-access';
 import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
@@ -49,7 +49,7 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
   private consoleDomRef?: ElementRef<HTMLElement>;
 
   private serial = inject(SerialFacadeService);
-  private piZeroBootstrap = inject(PiZeroSerialBootstrapService);
+  private piZeroSession = inject(PiZeroSessionService);
   private commandRequests = inject(TerminalCommandRequestService);
   private destroyRef = inject(DestroyRef);
 
@@ -192,7 +192,7 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
   }
 
   private bootstrapAfterConnect$(prefixMessage: string) {
-    return this.piZeroBootstrap.shouldRunAfterConnect$().pipe(
+    return this.piZeroSession.bootstrap.shouldRunAfterConnect$().pipe(
       switchMap((should) => {
         if (!should) {
           this.xterminal.writeln(
@@ -202,7 +202,7 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
           return EMPTY;
         }
         this.xterminal.writeln(`${prefixMessage} 初期化しています...`);
-        return this.piZeroBootstrap.runAfterConnect$((line) =>
+        return this.piZeroSession.bootstrap.runAfterConnect$((line) =>
           this.xterminal.writeln(line),
         );
       }),

--- a/libs/web-serial/data-access/src/index.ts
+++ b/libs/web-serial/data-access/src/index.ts
@@ -1,4 +1,5 @@
 export type { SerialExecOptions } from '@libs-web-serial-util';
+export * from './lib/pi-zero-session.service';
 export * from './lib/pi-zero-serial-bootstrap.service';
 export * from './lib/pi-zero-shell-readiness.service';
 export * from './lib/serial-command.service';

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
@@ -4,13 +4,23 @@ import {
   PI_ZERO_LOGIN_PASSWORD,
   PI_ZERO_LOGIN_USER,
   PI_ZERO_PROMPT,
-  PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
-  PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
   SERIAL_TIMEOUT,
 } from '@libs-web-serial-util';
 import { PiZeroSerialBootstrapService } from './pi-zero-serial-bootstrap.service';
 import type { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
 import type { SerialFacadeService } from './serial-facade.service';
+import { SerialPromptDetectorService } from './serial-command/serial-prompt-detector.service';
+
+function createBootstrap(
+  serial: SerialFacadeService,
+  shellReadiness: PiZeroShellReadinessService,
+) {
+  return new PiZeroSerialBootstrapService(
+    serial,
+    shellReadiness,
+    new SerialPromptDetectorService(),
+  );
+}
 
 function createShellReadinessMock(): PiZeroShellReadinessService {
   return {
@@ -39,20 +49,24 @@ describe('PiZeroSerialBootstrapService', () => {
     } as unknown as SerialFacadeService;
 
     const shellReadiness = createShellReadinessMock();
-    const service = new PiZeroSerialBootstrapService(serial, shellReadiness);
+    const service = createBootstrap(serial, shellReadiness);
     await firstValueFrom(service.runAfterConnect$());
 
     expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
     expect(readUntilPrompt).toHaveBeenCalledTimes(1);
-    expect(readUntilPrompt).toHaveBeenCalledWith({
-      prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-      timeout: SERIAL_TIMEOUT.SHELL_PROMPT_PROBE,
-    });
+    expect(readUntilPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: '',
+        promptMatch: expect.any(Function),
+        timeout: SERIAL_TIMEOUT.SHELL_PROMPT_PROBE,
+      }),
+    );
     expect(exec).toHaveBeenNthCalledWith(
       1,
       TZ_SET_CMD,
       expect.objectContaining({
-        prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+        prompt: '',
+        promptMatch: expect.any(Function),
         timeout: SERIAL_TIMEOUT.SHORT,
       }),
     );
@@ -60,7 +74,8 @@ describe('PiZeroSerialBootstrapService', () => {
       2,
       TZ_STATUS_CMD,
       expect.objectContaining({
-        prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+        prompt: '',
+        promptMatch: expect.any(Function),
         timeout: SERIAL_TIMEOUT.SHORT,
       }),
     );
@@ -80,25 +95,34 @@ describe('PiZeroSerialBootstrapService', () => {
     } as unknown as SerialFacadeService;
 
     const shellReadiness = createShellReadinessMock();
-    const service = new PiZeroSerialBootstrapService(serial, shellReadiness);
+    const service = createBootstrap(serial, shellReadiness);
     const lines: string[] = [];
     await firstValueFrom(service.runAfterConnect$((line) => lines.push(line)));
 
     expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
     expect(readUntilPrompt).toHaveBeenCalledTimes(2);
-    expect(readUntilPrompt).toHaveBeenNthCalledWith(1, {
-      prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-      timeout: SERIAL_TIMEOUT.SHELL_PROMPT_PROBE,
-    });
-    expect(readUntilPrompt).toHaveBeenNthCalledWith(2, {
-      prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
-      timeout: SERIAL_TIMEOUT.LONG,
-    });
+    expect(readUntilPrompt).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        prompt: '',
+        promptMatch: expect.any(Function),
+        timeout: SERIAL_TIMEOUT.SHELL_PROMPT_PROBE,
+      }),
+    );
+    expect(readUntilPrompt).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        prompt: '',
+        promptMatch: expect.any(Function),
+        timeout: SERIAL_TIMEOUT.LONG,
+      }),
+    );
     expect(exec).toHaveBeenNthCalledWith(
       1,
       PI_ZERO_LOGIN_USER,
       expect.objectContaining({
-        prompt: expect.any(RegExp),
+        prompt: '',
+        promptMatch: expect.any(Function),
         timeout: SERIAL_TIMEOUT.DEFAULT,
         retry: 1,
       }),
@@ -107,7 +131,8 @@ describe('PiZeroSerialBootstrapService', () => {
       2,
       PI_ZERO_LOGIN_PASSWORD,
       expect.objectContaining({
-        prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+        prompt: '',
+        promptMatch: expect.any(Function),
         timeout: SERIAL_TIMEOUT.LONG,
         retry: 1,
       }),
@@ -117,7 +142,8 @@ describe('PiZeroSerialBootstrapService', () => {
       3,
       TZ_SET_CMD,
       expect.objectContaining({
-        prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+        prompt: '',
+        promptMatch: expect.any(Function),
         timeout: SERIAL_TIMEOUT.SHORT,
       }),
     );
@@ -125,7 +151,8 @@ describe('PiZeroSerialBootstrapService', () => {
       4,
       TZ_STATUS_CMD,
       expect.objectContaining({
-        prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+        prompt: '',
+        promptMatch: expect.any(Function),
         timeout: SERIAL_TIMEOUT.SHORT,
       }),
     );
@@ -144,7 +171,7 @@ describe('PiZeroSerialBootstrapService', () => {
     } as unknown as SerialFacadeService;
 
     const shellReadiness = createShellReadinessMock();
-    const service = new PiZeroSerialBootstrapService(serial, shellReadiness);
+    const service = createBootstrap(serial, shellReadiness);
     await firstValueFrom(service.runAfterConnect$());
     await firstValueFrom(service.runAfterConnect$());
 
@@ -167,7 +194,7 @@ describe('PiZeroSerialBootstrapService', () => {
     } as unknown as SerialFacadeService;
 
     const shellReadiness = createShellReadinessMock();
-    const service = new PiZeroSerialBootstrapService(serial, shellReadiness);
+    const service = createBootstrap(serial, shellReadiness);
 
     await firstValueFrom(service.runAfterConnect$());
     epoch = 2;
@@ -196,7 +223,7 @@ describe('PiZeroSerialBootstrapService', () => {
 
     const lines: string[] = [];
     const shellReadiness = createShellReadinessMock();
-    const service = new PiZeroSerialBootstrapService(serial, shellReadiness);
+    const service = createBootstrap(serial, shellReadiness);
     await firstValueFrom(service.runAfterConnect$((line) => lines.push(line)));
 
     expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
@@ -7,9 +7,6 @@ import { sanitizeSerialStdout } from '@libs-terminal-util';
 import {
   PI_ZERO_LOGIN_PASSWORD,
   PI_ZERO_LOGIN_USER,
-  PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
-  PI_ZERO_SERIAL_PASSWORD_LINE_PATTERN,
-  PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
   SERIAL_TIMEOUT,
 } from '@libs-web-serial-util';
 import type { Observable } from 'rxjs';
@@ -30,10 +27,15 @@ import {
   throwError,
 } from 'rxjs';
 import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
+import { SerialPromptDetectorService } from './serial-command/serial-prompt-detector.service';
 import { SerialFacadeService } from './serial-facade.service';
 
 export type PiZeroBootstrapStatusHandler = (line: string) => void;
 
+/**
+ * Pi Zero / CHIRIMEN 向けシリアル接続後のログイン・初期化（issue #557）。
+ * 汎用の送受信は {@link SerialFacadeService}、プロンプト判定は {@link SerialPromptDetectorService}。
+ */
 @Injectable({
   providedIn: 'root',
 })
@@ -46,6 +48,7 @@ export class PiZeroSerialBootstrapService {
   constructor(
     private readonly serial: SerialFacadeService,
     private readonly shellReadiness: PiZeroShellReadinessService,
+    private readonly promptDetector: SerialPromptDetectorService,
   ) {}
 
   /**
@@ -130,10 +133,13 @@ export class PiZeroSerialBootstrapService {
   private runPipeline$(log: PiZeroBootstrapStatusHandler): Observable<void> {
     const client = createConnectClient();
 
-    return this.serial.readUntilPrompt$({
-      prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
-      timeout: SERIAL_TIMEOUT.SHELL_PROMPT_PROBE,
-    }).pipe(
+    return this.serial
+      .readUntilPrompt$({
+        prompt: '',
+        promptMatch: (buf) => this.promptDetector.isShellPrompt(buf),
+        timeout: SERIAL_TIMEOUT.SHELL_PROMPT_PROBE,
+      })
+      .pipe(
       map(() => true),
       catchError(() => of(false)),
       switchMap((atShell) =>
@@ -147,7 +153,8 @@ export class PiZeroSerialBootstrapService {
     log('[コンソール] ログイン画面を検出しました。');
     return this.serial
       .readUntilPrompt$({
-        prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
+        prompt: '',
+        promptMatch: (buf) => this.promptDetector.isLoginPrompt(buf),
         // 起動直後のログ出しが続くと login: 行が遅延することがある
         timeout: SERIAL_TIMEOUT.LONG,
       })
@@ -159,7 +166,8 @@ export class PiZeroSerialBootstrapService {
         }),
         switchMap(() =>
           this.serial.exec$(PI_ZERO_LOGIN_USER, {
-            prompt: PI_ZERO_SERIAL_PASSWORD_LINE_PATTERN,
+            prompt: '',
+            promptMatch: (buf) => this.promptDetector.isPasswordPrompt(buf),
             timeout: SERIAL_TIMEOUT.DEFAULT,
             retry: 1,
           }),
@@ -169,7 +177,8 @@ export class PiZeroSerialBootstrapService {
         }),
         switchMap(() =>
           this.serial.exec$(PI_ZERO_LOGIN_PASSWORD, {
-            prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+            prompt: '',
+            promptMatch: (buf) => this.promptDetector.isShellPrompt(buf),
             timeout: SERIAL_TIMEOUT.LONG,
             retry: 1,
           }),
@@ -189,7 +198,8 @@ export class PiZeroSerialBootstrapService {
         log(step.statusMessage);
         return this.serial
           .exec$(step.command, {
-            prompt: PI_ZERO_SHELL_PROMPT_LINE_PATTERN,
+            prompt: '',
+            promptMatch: (buf) => this.promptDetector.isShellPrompt(buf),
             timeout: SERIAL_TIMEOUT.SHORT,
           })
           .pipe(

--- a/libs/web-serial/data-access/src/lib/pi-zero-session.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-session.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { PiZeroSerialBootstrapService } from './pi-zero-serial-bootstrap.service';
+import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
+
+/**
+ * Pi Zero / CHIRIMEN 固有のシリアルセッション境界（issue #557）。
+ *
+ * UI や feature 層は、汎用の送受信に {@link SerialFacadeService}、接続後のログイン・初期化に
+ * {@link PiZeroSerialBootstrapService}、シェル準備フラグに {@link PiZeroShellReadinessService} を利用する。
+ * 本サービスはそれらへの単一エントリとして DI を整理する。
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class PiZeroSessionService {
+  constructor(
+    readonly bootstrap: PiZeroSerialBootstrapService,
+    readonly shellReadiness: PiZeroShellReadinessService,
+  ) {}
+}

--- a/libs/web-serial/data-access/src/lib/serial-command/serial-command-runner.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/serial-command-runner.service.ts
@@ -109,9 +109,7 @@ export class SerialCommandRunnerService {
         }
         return this.readBuffer;
       }),
-      filter((buf) =>
-        this.promptDetector.matchesPrompt(buf, config.prompt),
-      ),
+      filter((buf) => this.bufferMatchesPrompt(buf, config)),
       take(1),
       map((buf) => {
         const stdout = buf;
@@ -173,7 +171,7 @@ export class SerialCommandRunnerService {
         return throwError(() => new Error('All commands cancelled'));
       }
       onAttemptStart?.();
-      if (this.promptDetector.matchesPrompt(this.readBuffer, config.prompt)) {
+      if (this.bufferMatchesPrompt(this.readBuffer, config)) {
         const stdout = this.readBuffer;
         this.readBuffer = '';
         return of<CommandResult>({ stdout });
@@ -188,9 +186,28 @@ export class SerialCommandRunnerService {
   serialOptionsToConfig(options: SerialExecOptions): CommandExecutionConfig {
     const {
       prompt,
+      promptMatch,
       timeout = SERIAL_TIMEOUT.DEFAULT,
       retry = 0,
     } = options;
-    return { prompt, timeout, retry };
+    if (promptMatch === undefined && prompt === undefined) {
+      throw new Error('SerialExecOptions: prompt or promptMatch is required');
+    }
+    return {
+      prompt: prompt ?? '',
+      promptMatch,
+      timeout,
+      retry,
+    };
+  }
+
+  private bufferMatchesPrompt(
+    buffer: string,
+    config: CommandExecutionConfig,
+  ): boolean {
+    if (config.promptMatch) {
+      return config.promptMatch(buffer);
+    }
+    return this.promptDetector.matchesPrompt(buffer, config.prompt);
   }
 }

--- a/libs/web-serial/data-access/src/lib/serial-command/serial-command-types.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/serial-command-types.ts
@@ -2,7 +2,13 @@
  * コマンド実行設定
  */
 export interface CommandExecutionConfig {
-  /** 期待するプロンプト文字列 */
+  /**
+   * 受信バッファ全体の一致判定。指定時は {@link prompt} より優先。
+   */
+  promptMatch?: (buffer: string) => boolean;
+  /**
+   * {@link promptMatch} 未使用時の期待プロンプト。promptMatch 使用時は未参照になり得る。
+   */
   prompt: string | RegExp;
   /** タイムアウト時間（ミリ秒） */
   timeout: number;

--- a/libs/web-serial/data-access/src/lib/serial-command/serial-command.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/serial-command.service.spec.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from 'vitest';
 import { Observable, Subject, firstValueFrom } from 'rxjs';
 import {
   PI_ZERO_PROMPT,
-  PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
 } from '@libs-web-serial-util';
 import type { SerialTransportService } from '../serial-transport.service';
 import { SerialCommandQueueService } from './serial-command-queue.service';
@@ -39,7 +38,7 @@ function createService() {
   );
   const service = new SerialCommandService(runner, queue);
   service.startReadLoop();
-  return { service, lines, transport };
+  return { service, lines, transport, promptDetector };
 }
 
 describe('SerialCommandService', () => {
@@ -89,11 +88,12 @@ describe('SerialCommandService', () => {
   });
 
   it('readUntilPrompt sees data already buffered before the wait starts', async () => {
-    const { service, lines } = createService();
+    const { service, lines, promptDetector } = createService();
     emitAsLines(lines, 'Raspberry Pi OS\r\n\r\nraspberrypi login: ');
     const result = await firstValueFrom(
       service.readUntilPrompt$({
-        prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
+        prompt: '',
+        promptMatch: (buf) => promptDetector.isLoginPrompt(buf),
         timeout: 1000,
         retry: 0,
       }),
@@ -102,11 +102,12 @@ describe('SerialCommandService', () => {
   });
 
   it('readUntilPrompt matches Japanese login prompt in buffer', async () => {
-    const { service, lines } = createService();
+    const { service, lines, promptDetector } = createService();
     emitAsLines(lines, 'ホスト名 ログイン: ');
     const result = await firstValueFrom(
       service.readUntilPrompt$({
-        prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
+        prompt: '',
+        promptMatch: (buf) => promptDetector.isLoginPrompt(buf),
         timeout: 1000,
         retry: 0,
       }),
@@ -115,11 +116,12 @@ describe('SerialCommandService', () => {
   });
 
   it('readUntilPrompt matches login when line contains ANSI escape sequences', async () => {
-    const { service, lines } = createService();
+    const { service, lines, promptDetector } = createService();
     emitAsLines(lines, '\u001b[2J\u001b[Hraspberrypi login: ');
     const result = await firstValueFrom(
       service.readUntilPrompt$({
-        prompt: PI_ZERO_SERIAL_LOGIN_LINE_PATTERN,
+        prompt: '',
+        promptMatch: (buf) => promptDetector.isLoginPrompt(buf),
         timeout: 1000,
         retry: 0,
       }),

--- a/libs/web-serial/data-access/src/lib/serial-command/serial-prompt-detector.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/serial-prompt-detector.service.spec.ts
@@ -8,9 +8,9 @@ describe('SerialPromptDetectorService', () => {
     expect(
       detector.matchesPrompt('foo\r\npi@raspberrypi:~$ ', 'pi@raspberrypi'),
     ).toBe(true);
-    expect(
-      detector.matchesPrompt('no prompt here', 'pi@raspberrypi'),
-    ).toBe(false);
+    expect(detector.matchesPrompt('no prompt here', 'pi@raspberrypi')).toBe(
+      false,
+    );
   });
 
   it('matches RegExp prompt', () => {
@@ -23,5 +23,32 @@ describe('SerialPromptDetectorService', () => {
     const re = /^x$/g;
     expect(detector.matchesPrompt('x', re)).toBe(true);
     expect(detector.matchesPrompt('x', re)).toBe(true);
+  });
+
+  it('isLoginPrompt detects English login line', () => {
+    expect(detector.isLoginPrompt('raspberrypi login: ')).toBe(true);
+    expect(detector.isLoginPrompt('foo\nraspberrypi login: ')).toBe(true);
+    expect(detector.isLoginPrompt('welcome')).toBe(false);
+  });
+
+  it('isLoginPrompt detects Japanese login line', () => {
+    expect(detector.isLoginPrompt('ホスト名 ログイン: ')).toBe(true);
+  });
+
+  it('isPasswordPrompt detects password prompt at line end', () => {
+    expect(detector.isPasswordPrompt('Password: ')).toBe(true);
+    expect(detector.isPasswordPrompt('password:\r\n')).toBe(true);
+    expect(detector.isPasswordPrompt('not password')).toBe(false);
+  });
+
+  it('isShellPrompt accepts pi@hostname:', () => {
+    expect(detector.isShellPrompt('pi@raspberrypi:~$ ')).toBe(true);
+    expect(detector.isShellPrompt('out\npi@chirimen:')).toBe(true);
+    expect(detector.isShellPrompt('root@host:~# ')).toBe(false);
+  });
+
+  it('isCommandCompleted matches shell prompt return', () => {
+    expect(detector.isCommandCompleted('pi@raspberrypi:~$ ')).toBe(true);
+    expect(detector.isCommandCompleted('running…')).toBe(false);
   });
 });

--- a/libs/web-serial/data-access/src/lib/serial-command/serial-prompt-detector.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/serial-prompt-detector.service.ts
@@ -1,12 +1,55 @@
 import { Injectable } from '@angular/core';
 
 /**
- * シリアル受信バッファが shell / login / password など期待するプロンプトを含むか判定する。
+ * Pi Zero / Raspberry Pi OS シリアルコンソール向けのプロンプト判定。
+ * 正規表現は本サービス内にのみ置き、呼び出し側は意味メソッドまたは {@link matchesPrompt} を利用する。
  */
 @Injectable({
   providedIn: 'root',
 })
 export class SerialPromptDetectorService {
+  /**
+   * ログイン名入力待ち。
+   * 英語 `login:` / 日本語 `ログイン:` 等（大小・`:` 前の空白差を吸収）。
+   */
+  private readonly loginLinePattern =
+    /(?:^|[\r\n])[^\r\n]*(?:[Ll]ogin|ログイン)\s*:\s*/im;
+
+  /**
+   * パスワード入力待ち（`Password:` / `password:` 行末）
+   */
+  private readonly passwordLinePattern = /[^\r\n]*[Pp]assword:\s*$/im;
+
+  /**
+   * pi ユーザーシェルプロンプト（`pi@<hostname>:`）
+   */
+  private readonly shellPromptLinePattern = /pi@[^:\r\n]+:/;
+
+  isLoginPrompt(text: string): boolean {
+    this.loginLinePattern.lastIndex = 0;
+    return this.loginLinePattern.test(text);
+  }
+
+  isPasswordPrompt(text: string): boolean {
+    this.passwordLinePattern.lastIndex = 0;
+    return this.passwordLinePattern.test(text);
+  }
+
+  isShellPrompt(text: string): boolean {
+    this.shellPromptLinePattern.lastIndex = 0;
+    return this.shellPromptLinePattern.test(text);
+  }
+
+  /**
+   * シリアル上のコマンド完了はシェルプロンプトへの復帰で判定する。
+   */
+  isCommandCompleted(text: string): boolean {
+    return this.isShellPrompt(text);
+  }
+
+  /**
+   * 任意の文字列／正規表現による一致（汎用コマンド実行の `prompt` オプション用）。
+   */
   matchesPrompt(input: string, prompt: string | RegExp): boolean {
     if (typeof prompt === 'string') {
       return input.includes(prompt);

--- a/libs/web-serial/util/src/lib/pi-zero.const.ts
+++ b/libs/web-serial/util/src/lib/pi-zero.const.ts
@@ -9,24 +9,4 @@ export const RASPBERRY_PI_ZERO_INFO = {
 export const PI_ZERO_LOGIN_USER = 'pi' as const;
 export const PI_ZERO_LOGIN_PASSWORD = 'raspberry' as const;
 
-/**
- * ログイン名入力待ち。
- * - 英語 `login:` / 日本語ロケールの `ログイン:` 等（大小・`:` 前の空白差を吸収）
- * - 行末 `$` に依存しない（シリアルに ANSI や未改行が混ざっても検出しやすくする）
- */
-export const PI_ZERO_SERIAL_LOGIN_LINE_PATTERN =
-  /(?:^|[\r\n])[^\r\n]*(?:[Ll]ogin|ログイン)\s*:\s*/im;
-
-/**
- * パスワード入力待ち（`Password:` / `password:` 行末）
- */
-export const PI_ZERO_SERIAL_PASSWORD_LINE_PATTERN =
-  /[^\r\n]*[Pp]assword:\s*$/im;
-
 export const PI_ZERO_PROMPT = 'pi@raspberrypi:' as const;
-
-/**
- * シリアルコンソールの pi ユーザーシェルプロンプト先頭（`pi@<hostname>:`）。
- * 固定文字列 {@link PI_ZERO_PROMPT} だけでは Chirimen 等でホスト名が異なりログイン完了を検出できない。
- */
-export const PI_ZERO_SHELL_PROMPT_LINE_PATTERN = /pi@[^:\r\n]+:/;

--- a/libs/web-serial/util/src/lib/serial-ansi.spec.ts
+++ b/libs/web-serial/util/src/lib/serial-ansi.spec.ts
@@ -1,13 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { stripSerialAnsiForPrompt } from './serial-ansi';
-import { PI_ZERO_SERIAL_LOGIN_LINE_PATTERN } from './pi-zero.const';
 
 describe('stripSerialAnsiForPrompt', () => {
   it('removes CSI color and cursor sequences so login line matches', () => {
     const raw =
       '\u001b[2J\u001b[H\u001b[0;1;32mRaspberry Pi\u001b[0m\r\nraspberrypi login: ';
     const cleaned = stripSerialAnsiForPrompt(raw);
-    expect(PI_ZERO_SERIAL_LOGIN_LINE_PATTERN.test(cleaned)).toBe(true);
+    expect(cleaned).toMatch(/raspberrypi login:\s*$/m);
   });
 
   it('strips OSC sequences', () => {

--- a/libs/web-serial/util/src/lib/serial-exec-options.ts
+++ b/libs/web-serial/util/src/lib/serial-exec-options.ts
@@ -2,7 +2,14 @@
  * {@link SerialFacadeService#exec} / execRaw / readUntilPrompt 向けオプション
  */
 export interface SerialExecOptions {
-  prompt: string | RegExp;
+  /**
+   * 受信バッファ全体に対するプロンプト一致。指定時は {@link prompt} より優先。
+   */
+  promptMatch?: (buffer: string) => boolean;
+  /**
+   * {@link promptMatch} 未指定時に必須。指定時はダミーでも可（未使用）。
+   */
+  prompt?: string | RegExp;
   timeout?: number;
   retry?: number;
 }


### PR DESCRIPTION
## Summary

- Pi Zero 向けプロンプト正規表現を `SerialPromptDetectorService` に閉じ、`isLoginPrompt` など意味ベースの API を追加した。
- シリアル実行オプションに `promptMatch` を追加し、ブートストラップは RegExp 定数に依存しない。
- `PiZeroSessionService` を追加し、ターミナル UI から Pi Zero 初期化への入口をそこに寄せた。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #561
- Ref #557

## What changed?

- `SerialPromptDetectorService` に Pi Zero 用のプロンプト判定メソッドを実装し、関連正規表現を util の定数から移した。
- `SerialExecOptions` に `promptMatch` を追加し、runner が `prompt` と両方に対応するようにした。
- `PiZeroSerialBootstrapService` が `promptMatch` と `SerialPromptDetectorService` 経由でログイン・シェル待ちを行うようにした。
- `@libs-web-serial-util` から `PI_ZERO_SERIAL_*` / `PI_ZERO_SHELL_PROMPT_LINE_PATTERN` の export を削除した。
- `PiZeroSessionService` を新設し、ターミナルは `bootstrap` をここ経由で利用するようにした。

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - Details: `@libs-web-serial-util` から Pi Zero 用シリアルプロンプト正規表現の export を削除。`SerialExecOptions` の `prompt` は `promptMatch` 未使用時に従来どおり利用可能。
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes: 上記 export を直接 import していた場合は、`SerialPromptDetectorService` の `is*` / `promptMatch` へ移行する。

## How to test

1. `pnpm nx run libs-web-serial-data-access:test`
2. `pnpm nx run libs-web-serial-util:test`
3. `pnpm nx run libs-terminal-ui:test`
4. 実機で Pi Zero に接続し、ログイン〜シェル・初期化コマンドが従来どおり動くこと

## Environment (if relevant)

- Browser: （手元で確認したブラウザ）
- OS: macOS / Windows / Linux
- Node version: （`node -v`）
- pnpm version: （`pnpm -v`）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant