### PR TITLE
refactor(web-serial): Pi Zero セッション API の整理と接続後初期化の集約

### DIFF
--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
@@ -54,10 +54,8 @@ describe('TerminalViewComponent', () => {
       })
       .overrideProvider(PiZeroSessionService, {
         useValue: {
-          bootstrap: {
-            shouldRunAfterConnect$: shouldRunAfterConnectMock,
-            runAfterConnect$: runAfterConnectMock,
-          },
+          shouldRunAfterConnect$: shouldRunAfterConnectMock,
+          runAfterConnect$: runAfterConnectMock,
         },
       })
       .compileComponents();

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -192,7 +192,7 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
   }
 
   private bootstrapAfterConnect$(prefixMessage: string) {
-    return this.piZeroSession.bootstrap.shouldRunAfterConnect$().pipe(
+    return this.piZeroSession.shouldRunAfterConnect$().pipe(
       switchMap((should) => {
         if (!should) {
           this.xterminal.writeln(
@@ -202,7 +202,7 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
           return EMPTY;
         }
         this.xterminal.writeln(`${prefixMessage} 初期化しています...`);
-        return this.piZeroSession.bootstrap.runAfterConnect$((line) =>
+        return this.piZeroSession.runAfterConnect$((line) =>
           this.xterminal.writeln(line),
         );
       }),

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
@@ -7,28 +7,14 @@ import {
   SERIAL_TIMEOUT,
 } from '@libs-web-serial-util';
 import { PiZeroSerialBootstrapService } from './pi-zero-serial-bootstrap.service';
-import type { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
 import type { SerialFacadeService } from './serial-facade.service';
 import { SerialPromptDetectorService } from './serial-command/serial-prompt-detector.service';
 
-function createBootstrap(
-  serial: SerialFacadeService,
-  shellReadiness: PiZeroShellReadinessService,
-) {
+function createBootstrap(serial: SerialFacadeService) {
   return new PiZeroSerialBootstrapService(
     serial,
-    shellReadiness,
     new SerialPromptDetectorService(),
   );
-}
-
-function createShellReadinessMock(): PiZeroShellReadinessService {
-  return {
-    setReady: vi.fn(),
-    reset: vi.fn(),
-    isReady: vi.fn(() => false),
-    ready$: vi.fn() as unknown as PiZeroShellReadinessService['ready$'],
-  } as unknown as PiZeroShellReadinessService;
 }
 
 const TZ_SET_CMD =
@@ -48,11 +34,9 @@ describe('PiZeroSerialBootstrapService', () => {
       exec$: (c: string, o: unknown) => from(exec(c, o)),
     } as unknown as SerialFacadeService;
 
-    const shellReadiness = createShellReadinessMock();
-    const service = createBootstrap(serial, shellReadiness);
-    await firstValueFrom(service.runAfterConnect$());
+    const service = createBootstrap(serial);
+    await firstValueFrom(service.runPostConnectPipeline$());
 
-    expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
     expect(readUntilPrompt).toHaveBeenCalledTimes(1);
     expect(readUntilPrompt).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -94,12 +78,12 @@ describe('PiZeroSerialBootstrapService', () => {
       exec$: (c: string, o: unknown) => from(exec(c, o)),
     } as unknown as SerialFacadeService;
 
-    const shellReadiness = createShellReadinessMock();
-    const service = createBootstrap(serial, shellReadiness);
+    const service = createBootstrap(serial);
     const lines: string[] = [];
-    await firstValueFrom(service.runAfterConnect$((line) => lines.push(line)));
+    await firstValueFrom(
+      service.runPostConnectPipeline$((line) => lines.push(line)),
+    );
 
-    expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
     expect(readUntilPrompt).toHaveBeenCalledTimes(2);
     expect(readUntilPrompt).toHaveBeenNthCalledWith(
       1,
@@ -158,52 +142,6 @@ describe('PiZeroSerialBootstrapService', () => {
     );
   });
 
-  it('runs at most once per connection epoch', async () => {
-    const readUntilPrompt = vi.fn().mockResolvedValue({
-      stdout: `${PI_ZERO_PROMPT} `,
-    });
-    const exec = vi.fn().mockResolvedValue({ stdout: '' });
-    const serial = {
-      isConnected$: of(true),
-      getConnectionEpoch: () => 1,
-      readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
-      exec$: (c: string, o: unknown) => from(exec(c, o)),
-    } as unknown as SerialFacadeService;
-
-    const shellReadiness = createShellReadinessMock();
-    const service = createBootstrap(serial, shellReadiness);
-    await firstValueFrom(service.runAfterConnect$());
-    await firstValueFrom(service.runAfterConnect$());
-
-    expect(readUntilPrompt).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
-  });
-
-  it('re-runs bootstrap when connection epoch changes', async () => {
-    let epoch = 1;
-    const readUntilPrompt = vi.fn().mockResolvedValue({
-      stdout: `${PI_ZERO_PROMPT} `,
-    });
-    const exec = vi.fn().mockResolvedValue({ stdout: '' });
-    const serial = {
-      isConnected$: of(true),
-      getConnectionEpoch: () => epoch,
-      readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
-      exec$: (c: string, o: unknown) => from(exec(c, o)),
-    } as unknown as SerialFacadeService;
-
-    const shellReadiness = createShellReadinessMock();
-    const service = createBootstrap(serial, shellReadiness);
-
-    await firstValueFrom(service.runAfterConnect$());
-    epoch = 2;
-    await firstValueFrom(service.runAfterConnect$());
-
-    expect(readUntilPrompt).toHaveBeenCalledTimes(2);
-    expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledTimes(2);
-  });
-
   it('logs timezone status stdout lines to the status handler', async () => {
     const readUntilPrompt = vi.fn().mockResolvedValue({
       stdout: `ready\r\n${PI_ZERO_PROMPT} `,
@@ -222,11 +160,11 @@ describe('PiZeroSerialBootstrapService', () => {
     } as unknown as SerialFacadeService;
 
     const lines: string[] = [];
-    const shellReadiness = createShellReadinessMock();
-    const service = createBootstrap(serial, shellReadiness);
-    await firstValueFrom(service.runAfterConnect$((line) => lines.push(line)));
+    const service = createBootstrap(serial);
+    await firstValueFrom(
+      service.runPostConnectPipeline$((line) => lines.push(line)),
+    );
 
-    expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
     expect(
       lines.some((l) => l.includes('Time zone: Asia/Tokyo')),
     ).toBe(true);

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
@@ -14,125 +14,67 @@ import {
   catchError,
   concatMap,
   defaultIfEmpty,
-  defer,
-  finalize,
   from,
   ignoreElements,
   map,
   of,
-  shareReplay,
   switchMap,
-  take,
   tap,
-  throwError,
 } from 'rxjs';
-import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
 import { SerialPromptDetectorService } from './serial-command/serial-prompt-detector.service';
 import { SerialFacadeService } from './serial-facade.service';
 
 export type PiZeroBootstrapStatusHandler = (line: string) => void;
 
 /**
- * Pi Zero / CHIRIMEN 向けシリアル接続後のログイン・初期化（issue #557）。
- * 汎用の送受信は {@link SerialFacadeService}、プロンプト判定は {@link SerialPromptDetectorService}。
+ * Pi Zero / CHIRIMEN 向けのログイン・環境初期化パイプライン（シリアル送受信は {@link SerialFacadeService}）。
+ *
+ * 接続単位での「一度だけ実行」などのオーケストレーションは {@link PiZeroSessionService}。
  */
 @Injectable({
   providedIn: 'root',
 })
 export class PiZeroSerialBootstrapService {
-  private lastBootstrappedEpoch = -1;
-  /** 同一 connectionEpoch でのブートストラップ多重起動を防ぐ */
-  private activeBootstrap$: Observable<void> | null = null;
-  private activeBootstrapEpoch: number | null = null;
-
   constructor(
     private readonly serial: SerialFacadeService,
-    private readonly shellReadiness: PiZeroShellReadinessService,
     private readonly promptDetector: SerialPromptDetectorService,
   ) {}
 
   /**
-   * 接続セッションごとに1回、初期化パイプラインを走らせるか。
-   * 状態の参照は {@link SerialFacadeService#isConnected$} のみ。
+   * シェルプロンプト到達確認。未到達ならログイン（ID / Password）まで実行する。
    */
-  shouldRunAfterConnect$(): Observable<boolean> {
-    return this.serial.isConnected$.pipe(
-      take(1),
-      map((connected) => {
-        if (!connected) {
-          return false;
-        }
-        const epoch = this.serial.getConnectionEpoch();
-        if (epoch === this.lastBootstrappedEpoch) {
-          return false;
-        }
-        return true;
-      }),
-    );
-  }
-
-  /**
-   * 接続セッション内で未初期化の場合のみ初期化パイプラインを実行する。
-   */
-  runAfterConnect$(
+  loginIfNeeded$(
     onStatus?: PiZeroBootstrapStatusHandler,
   ): Observable<void> {
     const log = onStatus ?? (() => undefined);
+    return this.loginPhase$(log);
+  }
 
-    return this.shouldRunAfterConnect$().pipe(
-      switchMap((shouldRun) => {
-        if (!shouldRun) {
-          return of(undefined);
-        }
-        const epoch = this.serial.getConnectionEpoch();
+  /**
+   * タイムゾーン等の初期化コマンドを実行する（シェル到達済みを前提）。
+   */
+  setupEnvironment$(
+    onStatus?: PiZeroBootstrapStatusHandler,
+  ): Observable<void> {
+    const log = onStatus ?? (() => undefined);
+    const client = createConnectClient();
+    return this.timezoneSequence$(log, client);
+  }
 
-        if (
-          this.activeBootstrap$ !== null &&
-          this.activeBootstrapEpoch === epoch
-        ) {
-          return this.activeBootstrap$;
-        }
-
-        this.activeBootstrapEpoch = epoch;
-
-        this.activeBootstrap$ = defer(() => this.runPipeline$(log)).pipe(
-          switchMap(() =>
-            this.serial.isConnected$.pipe(
-              take(1),
-              tap((connected) => {
-                if (connected) {
-                  this.lastBootstrappedEpoch = epoch;
-                  this.shellReadiness.setReady(true);
-                }
-              }),
-              map(() => undefined),
-            ),
-          ),
-          catchError((error: unknown) => {
-            const message =
-              error instanceof Error ? error.message : String(error);
-            log(
-              `[コンソール] 接続後の初期化に失敗しました: ${message}`,
-            );
-            return throwError(() => error);
-          }),
-          finalize(() => {
-            if (this.activeBootstrapEpoch === epoch) {
-              this.activeBootstrap$ = null;
-              this.activeBootstrapEpoch = null;
-            }
-          }),
-          shareReplay({ bufferSize: 1, refCount: true }),
-        );
-
-        return this.activeBootstrap$;
-      }),
+  /**
+   * ログイン（必要なら）後に環境セットアップを続けて実行する。
+   * 接続エポックの重複抑止は {@link PiZeroSessionService#runAfterConnect$} 側。
+   */
+  runPostConnectPipeline$(
+    onStatus?: PiZeroBootstrapStatusHandler,
+  ): Observable<void> {
+    const log = onStatus ?? (() => undefined);
+    return this.loginPhase$(log).pipe(
+      switchMap(() => this.setupEnvironment$(onStatus)),
     );
   }
 
-  private runPipeline$(log: PiZeroBootstrapStatusHandler): Observable<void> {
-    const client = createConnectClient();
-
+  private loginPhase$(log: PiZeroBootstrapStatusHandler): Observable<void> {
     return this.serial
       .readUntilPrompt$({
         prompt: '',
@@ -140,13 +82,12 @@ export class PiZeroSerialBootstrapService {
         timeout: SERIAL_TIMEOUT.SHELL_PROMPT_PROBE,
       })
       .pipe(
-      map(() => true),
-      catchError(() => of(false)),
-      switchMap((atShell) =>
-        atShell ? of(undefined) : this.loginSequence$(log),
-      ),
-      switchMap(() => this.timezoneSequence$(log, client)),
-    );
+        map(() => true),
+        catchError(() => of(false)),
+        switchMap((atShell) =>
+          atShell ? of(undefined) : this.loginSequence$(log),
+        ),
+      );
   }
 
   private loginSequence$(log: PiZeroBootstrapStatusHandler): Observable<void> {

--- a/libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { firstValueFrom, from, of } from 'rxjs';
+import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import { PiZeroSerialBootstrapService } from './pi-zero-serial-bootstrap.service';
+import type { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
+import { PiZeroSessionService } from './pi-zero-session.service';
+import type { SerialFacadeService } from './serial-facade.service';
+import { SerialPromptDetectorService } from './serial-command/serial-prompt-detector.service';
+
+function createShellReadinessMock(): PiZeroShellReadinessService {
+  return {
+    setReady: vi.fn(),
+    reset: vi.fn(),
+    isReady: vi.fn(() => false),
+    ready$: vi.fn() as unknown as PiZeroShellReadinessService['ready$'],
+  } as unknown as PiZeroShellReadinessService;
+}
+
+function createSession(
+  serial: SerialFacadeService,
+  shellReadiness: PiZeroShellReadinessService,
+): PiZeroSessionService {
+  const bootstrap = new PiZeroSerialBootstrapService(
+    serial,
+    new SerialPromptDetectorService(),
+  );
+  return new PiZeroSessionService(serial, bootstrap, shellReadiness);
+}
+
+describe('PiZeroSessionService', () => {
+  it('runs at most one post-connect pipeline per connection epoch', async () => {
+    const readUntilPrompt = vi.fn().mockResolvedValue({
+      stdout: `${PI_ZERO_PROMPT} `,
+    });
+    const exec = vi.fn().mockResolvedValue({ stdout: '' });
+    const serial = {
+      isConnected$: of(true),
+      getConnectionEpoch: () => 1,
+      readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
+      exec$: (c: string, o: unknown) => from(exec(c, o)),
+    } as unknown as SerialFacadeService;
+
+    const shellReadiness = createShellReadinessMock();
+    const service = createSession(serial, shellReadiness);
+    await firstValueFrom(service.runAfterConnect$());
+    await firstValueFrom(service.runAfterConnect$());
+
+    expect(readUntilPrompt).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
+  });
+
+  it('re-runs pipeline when connection epoch changes', async () => {
+    let epoch = 1;
+    const readUntilPrompt = vi.fn().mockResolvedValue({
+      stdout: `${PI_ZERO_PROMPT} `,
+    });
+    const exec = vi.fn().mockResolvedValue({ stdout: '' });
+    const serial = {
+      isConnected$: of(true),
+      getConnectionEpoch: () => epoch,
+      readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
+      exec$: (c: string, o: unknown) => from(exec(c, o)),
+    } as unknown as SerialFacadeService;
+
+    const shellReadiness = createShellReadinessMock();
+    const service = createSession(serial, shellReadiness);
+
+    await firstValueFrom(service.runAfterConnect$());
+    epoch = 2;
+    await firstValueFrom(service.runAfterConnect$());
+
+    expect(readUntilPrompt).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledTimes(2);
+  });
+});

--- a/libs/web-serial/data-access/src/lib/pi-zero-session.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-session.service.ts
@@ -1,20 +1,137 @@
 import { Injectable } from '@angular/core';
+import {
+  catchError,
+  defer,
+  finalize,
+  map,
+  type Observable,
+  of,
+  shareReplay,
+  switchMap,
+  take,
+  tap,
+  throwError,
+} from 'rxjs';
+import type { PiZeroBootstrapStatusHandler } from './pi-zero-serial-bootstrap.service';
 import { PiZeroSerialBootstrapService } from './pi-zero-serial-bootstrap.service';
 import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
+import type { SerialFacadeConnectResult } from './serial-facade.service';
+import { SerialFacadeService } from './serial-facade.service';
 
 /**
- * Pi Zero / CHIRIMEN 固有のシリアルセッション境界（issue #557）。
+ * Pi Zero / CHIRIMEN 固有シリアルセッションの単一エントリ（issue #562）。
  *
- * UI や feature 層は、汎用の送受信に {@link SerialFacadeService}、接続後のログイン・初期化に
- * {@link PiZeroSerialBootstrapService}、シェル準備フラグに {@link PiZeroShellReadinessService} を利用する。
- * 本サービスはそれらへの単一エントリとして DI を整理する。
+ * 汎用の送受信は {@link SerialFacadeService}。本サービスは接続・切断・接続後パイプラインを束ねる。
  */
 @Injectable({
   providedIn: 'root',
 })
 export class PiZeroSessionService {
+  private lastBootstrappedEpoch = -1;
+  private activeBootstrap$: Observable<void> | null = null;
+  private activeBootstrapEpoch: number | null = null;
+
   constructor(
-    readonly bootstrap: PiZeroSerialBootstrapService,
+    private readonly serial: SerialFacadeService,
+    private readonly bootstrap: PiZeroSerialBootstrapService,
     readonly shellReadiness: PiZeroShellReadinessService,
   ) {}
+
+  connect$(baudRate = 115200): Observable<SerialFacadeConnectResult> {
+    return this.serial.connect$(baudRate);
+  }
+
+  disconnect$(): Observable<void> {
+    return this.serial.disconnect$();
+  }
+
+  loginIfNeeded$(
+    onStatus?: PiZeroBootstrapStatusHandler,
+  ): Observable<void> {
+    return this.bootstrap.loginIfNeeded$(onStatus);
+  }
+
+  setupEnvironment$(
+    onStatus?: PiZeroBootstrapStatusHandler,
+  ): Observable<void> {
+    return this.bootstrap.setupEnvironment$(onStatus);
+  }
+
+  /**
+   * 接続セッションごとに 1 回、初期化パイプラインを走らせるか。
+   */
+  shouldRunAfterConnect$(): Observable<boolean> {
+    return this.serial.isConnected$.pipe(
+      take(1),
+      map((connected) => {
+        if (!connected) {
+          return false;
+        }
+        const epoch = this.serial.getConnectionEpoch();
+        if (epoch === this.lastBootstrappedEpoch) {
+          return false;
+        }
+        return true;
+      }),
+    );
+  }
+
+  /**
+   * 接続セッション内で未初期化の場合のみ login + 環境セットアップを実行する。
+   */
+  runAfterConnect$(
+    onStatus?: PiZeroBootstrapStatusHandler,
+  ): Observable<void> {
+    const log = onStatus ?? (() => undefined);
+
+    return this.shouldRunAfterConnect$().pipe(
+      switchMap((shouldRun) => {
+        if (!shouldRun) {
+          return of(undefined);
+        }
+        const epoch = this.serial.getConnectionEpoch();
+
+        if (
+          this.activeBootstrap$ !== null &&
+          this.activeBootstrapEpoch === epoch
+        ) {
+          return this.activeBootstrap$;
+        }
+
+        this.activeBootstrapEpoch = epoch;
+
+        this.activeBootstrap$ = defer(() =>
+          this.bootstrap.runPostConnectPipeline$(onStatus),
+        ).pipe(
+          switchMap(() =>
+            this.serial.isConnected$.pipe(
+              take(1),
+              tap((connected) => {
+                if (connected) {
+                  this.lastBootstrappedEpoch = epoch;
+                  this.shellReadiness.setReady(true);
+                }
+              }),
+              map(() => undefined),
+            ),
+          ),
+          catchError((error: unknown) => {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            log(`[コンソール] 接続後の初期化に失敗しました: ${message}`);
+            return throwError(() => error);
+          }),
+          finalize(() => {
+            if (this.activeBootstrapEpoch === epoch) {
+              this.activeBootstrap$ = null;
+              this.activeBootstrapEpoch = null;
+            }
+          }),
+          shareReplay({ bufferSize: 1, refCount: true }),
+        );
+
+        return this.activeBootstrap$;
+      }),
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Pi Zero 向けの接続後処理を `PiZeroSessionService` に集約し、`connect$` / `disconnect$` / `loginIfNeeded$` / `setupEnvironment$` / `runAfterConnect$` を単一エントリとして提供する。ブートストラップはログイン・環境セットアップのパイプライン実装に専念し、接続エポックごとの重複実行制御はセッション側に移す。ターミナルは `PiZeroSessionService` の公開 API のみを利用する。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #557
- Fixes #562

## What changed?

- `PiZeroSerialBootstrapService` を `loginIfNeeded$` / `setupEnvironment$` / `runPostConnectPipeline$` に分割し、`PiZeroShellReadinessService` 依存を削除した。
- `PiZeroSessionService` に `connect$` / `disconnect$` / 上記パイプラインのラップ、`shouldRunAfterConnect$` / `runAfterConnect$`（エポック管理・`setReady`）を実装した。
- `TerminalViewComponent` は `piZeroSession.bootstrap` ではなくセッションのメソッドのみを呼ぶようにした。
- `PiZeroSessionService` の単体テストを追加した。

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - `PiZeroSessionService`: これまでの `readonly bootstrap` がなくなり、メソッドベースの API になった。直接 `bootstrap` を参照していたコードは `PiZeroSessionService` または `PiZeroSerialBootstrapService` の利用に置き換える。
- [x] This change is backward compatible（アプリ内の利用箇所はターミナルのみで、そこは追従済み）
- [ ] This change introduces a breaking change

## How to test

1. Web Serial で Pi Zero に接続し、コンソールにログイン・タイムゾーン初期化のメッセージが従来どおり出ること。
2. 切断・再接続後も同様に初期化またはスキップメッセージが妥当であること。
3. `pnpm nx run libs-web-serial-data-access:test` と `pnpm nx run libs-terminal-ui:test` が成功すること。

## Environment (if relevant)

- Browser: Chrome（Web Serial）
- OS: （確認環境を記載）
- Node version: （`node -v`）
- pnpm version: （`pnpm -v`）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the public surface and control flow for serial connection bootstrapping (epoch gating, readiness signaling), which could cause missed or repeated initialization if behavior diverges from the prior implementation.
> 
> **Overview**
> Refactors Pi Zero serial post-connect initialization so **connection-epoch orchestration and “run once” behavior** lives in `PiZeroSessionService`, while `PiZeroSerialBootstrapService` is reduced to a pure pipeline (`loginIfNeeded$`, `setupEnvironment$`, `runPostConnectPipeline$`) with its `PiZeroShellReadinessService` dependency removed.
> 
> Updates `TerminalViewComponent` (and its test) to call `PiZeroSessionService.shouldRunAfterConnect$`/`runAfterConnect$` directly (no `piZeroSession.bootstrap.*` access), adds new unit tests for the session-level epoch gating behavior, and trims equivalent epoch-related tests from the bootstrap service spec.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78c08c411511484434ce05452772a0de7d2b73ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->