### PR TITLE
refactor(terminal): ターミナル向けシリアル処理を OrchestrationService に集約 (#557 #563)

### DIFF
--- a/libs/terminal/ui/src/index.ts
+++ b/libs/terminal/ui/src/index.ts
@@ -1,2 +1,3 @@
+export * from './lib/terminal-view/terminal-console-orchestration.service';
 export * from './lib/terminal-view/terminal-view.component';
 export * from './lib/terminal-input';

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
@@ -1,0 +1,89 @@
+import { TestBed } from '@angular/core/testing';
+import { defaultIfEmpty, firstValueFrom, of } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  PiZeroSessionService,
+  SerialFacadeService,
+} from '@libs-web-serial-data-access';
+import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
+import { TerminalConsoleOrchestrationService } from './terminal-console-orchestration.service';
+
+describe('TerminalConsoleOrchestrationService', () => {
+  let execMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    execMock = vi.fn().mockReturnValue(
+      of({
+        stdout: 'ok\n',
+      }),
+    );
+    TestBed.configureTestingModule({
+      providers: [
+        TerminalConsoleOrchestrationService,
+        {
+          provide: SerialFacadeService,
+          useValue: {
+            exec$: execMock,
+            isConnected$: of(true),
+            connectionEstablished$: of(undefined),
+          },
+        },
+        {
+          provide: PiZeroSessionService,
+          useValue: {
+            shouldRunAfterConnect$: () => of(true),
+            runAfterConnect$: () => of(undefined),
+          },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('delegates exec with default serial options', async () => {
+    const svc = TestBed.inject(TerminalConsoleOrchestrationService);
+    await svc.runInteractiveCommand('uname', PI_ZERO_PROMPT);
+    expect(execMock).toHaveBeenCalledWith('uname', {
+      prompt: PI_ZERO_PROMPT,
+      timeout: SERIAL_TIMEOUT.DEFAULT,
+    });
+  });
+
+  it('runToolbarCommand reports not_connected when serial is down', async () => {
+    TestBed.overrideProvider(SerialFacadeService, {
+      useValue: {
+        exec$: execMock,
+        isConnected$: of(false),
+        connectionEstablished$: of(undefined),
+      },
+    });
+    const svc = TestBed.inject(TerminalConsoleOrchestrationService);
+    const result = await svc.runToolbarCommand('ls', PI_ZERO_PROMPT);
+    expect(result).toEqual({ status: 'not_connected' });
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
+  it('bootstrapAfterConnect$ emits skip sink messages when shouldRun is false', async () => {
+    const writeln = vi.fn();
+    const write = vi.fn();
+    TestBed.overrideProvider(PiZeroSessionService, {
+      useValue: {
+        shouldRunAfterConnect$: () => of(false),
+        runAfterConnect$: vi.fn(),
+      },
+    });
+    const svc = TestBed.inject(TerminalConsoleOrchestrationService);
+    await firstValueFrom(
+      svc
+        .bootstrapAfterConnect$('prefix', { writeln, write })
+        .pipe(defaultIfEmpty(undefined)),
+    );
+    expect(writeln).toHaveBeenCalledWith(
+      'prefix 初期化済みのためスキップします。',
+    );
+    expect(write).toHaveBeenCalledWith('$ ');
+  });
+});

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
@@ -1,0 +1,120 @@
+import { Injectable, inject } from '@angular/core';
+import {
+  PiZeroSessionService,
+  SerialFacadeService,
+} from '@libs-web-serial-data-access';
+import { SERIAL_TIMEOUT } from '@libs-web-serial-util';
+import { sanitizeSerialStdout } from '@libs-terminal-util';
+import {
+  EMPTY,
+  Observable,
+  catchError,
+  finalize,
+  firstValueFrom,
+  switchMap,
+  take,
+} from 'rxjs';
+
+export interface TerminalConsoleSink {
+  writeln(line: string): void;
+  write(chunk: string): void;
+}
+
+/**
+ * ターミナル画面向けにシリアル接続・Pi Zero bootstrap・exec を束ねる（issue #563）。
+ * prompt / timeout / sanitize はここに集約し、component は表示用 sink と購読のみに寄せる。
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class TerminalConsoleOrchestrationService {
+  private readonly serial = inject(SerialFacadeService);
+  private readonly piZeroSession = inject(PiZeroSessionService);
+
+  /** 対話入力とツールバー経由の exec を直列化する */
+  private execTail: Promise<void> = Promise.resolve();
+
+  readonly connectionEstablished$ = this.serial.connectionEstablished$;
+  readonly isConnected$ = this.serial.isConnected$;
+
+  private enqueueExec<T>(job: () => Promise<T>): Promise<T> {
+    const run = this.execTail.then(() => job());
+    this.execTail = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
+  /**
+   * キーボードから入力されたコマンドを実行し、表示用に整形した stdout を返す。
+   */
+  runInteractiveCommand(command: string, remotePrompt: string): Promise<string> {
+    return this.enqueueExec(async () => {
+      const { stdout } = await firstValueFrom(
+        this.serial.exec$(command, {
+          prompt: remotePrompt,
+          timeout: SERIAL_TIMEOUT.DEFAULT,
+        }),
+      );
+      return sanitizeSerialStdout(stdout, command, remotePrompt);
+    });
+  }
+
+  /**
+   * ツールバー等から要求されたコマンドを実行する。
+   */
+  async runToolbarCommand(
+    cmd: string,
+    remotePrompt: string,
+  ): Promise<
+    | { status: 'success'; output: string }
+    | { status: 'not_connected' }
+    | { status: 'error'; message: string }
+  > {
+    return this.enqueueExec(async () => {
+      const connected = await firstValueFrom(
+        this.serial.isConnected$.pipe(take(1)),
+      );
+      if (!connected) {
+        return { status: 'not_connected' };
+      }
+      try {
+        const { stdout } = await firstValueFrom(
+          this.serial.exec$(cmd, {
+            prompt: remotePrompt,
+            timeout: SERIAL_TIMEOUT.DEFAULT,
+          }),
+        );
+        const output = sanitizeSerialStdout(stdout, cmd, remotePrompt);
+        return { status: 'success', output };
+      } catch (error: unknown) {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return { status: 'error', message };
+      }
+    });
+  }
+
+  /**
+   * 接続確立後の Pi Zero 初期化。表示は {@link TerminalConsoleSink} に委譲する。
+   */
+  bootstrapAfterConnect$(
+    prefixMessage: string,
+    sink: TerminalConsoleSink,
+  ): Observable<void> {
+    return this.piZeroSession.shouldRunAfterConnect$().pipe(
+      switchMap((should) => {
+        if (!should) {
+          sink.writeln(`${prefixMessage} 初期化済みのためスキップします。`);
+          sink.write('$ ');
+          return EMPTY;
+        }
+        sink.writeln(`${prefixMessage} 初期化しています...`);
+        return this.piZeroSession.runAfterConnect$((line) => sink.writeln(line));
+      }),
+      catchError(() => EMPTY),
+      finalize(() => sink.write('$ ')),
+    );
+  }
+}

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -9,28 +9,19 @@ import {
   input,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import {
-  EMPTY,
-  Subscription,
-  catchError,
-  finalize,
-  firstValueFrom,
-  switchMap,
-  take,
-} from 'rxjs';
+import { EMPTY, Subscription, switchMap, take } from 'rxjs';
 import { FitAddon } from '@xterm/addon-fit';
 import { Terminal } from '@xterm/xterm';
 import {
   TerminalCommandRequestService,
-  sanitizeSerialStdout,
   xtermConsoleConfigOptions,
 } from '@libs-terminal-util';
 import { attachTerminalInput } from '../terminal-input';
+import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
 import {
-  PiZeroSessionService,
-  SerialFacadeService,
-} from '@libs-web-serial-data-access';
-import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
+  TerminalConsoleOrchestrationService,
+  type TerminalConsoleSink,
+} from './terminal-console-orchestration.service';
 
 @Component({
   selector: 'choh-terminal-view',
@@ -41,15 +32,14 @@ import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
 })
 export class TerminalViewComponent implements AfterViewInit, OnDestroy {
   /**
-   * シリアル側のシェルプロンプト（CommandService の prompt 待機に利用）
+   * シリアル側のシェルプロンプト（サービス側の prompt 待機に渡す）
    */
   readonly remotePrompt = input<string>(PI_ZERO_PROMPT);
 
   @ViewChild('consoleDom', { read: ElementRef })
   private consoleDomRef?: ElementRef<HTMLElement>;
 
-  private serial = inject(SerialFacadeService);
-  private piZeroSession = inject(PiZeroSessionService);
+  private console = inject(TerminalConsoleOrchestrationService);
   private commandRequests = inject(TerminalCommandRequestService);
   private destroyRef = inject(DestroyRef);
 
@@ -57,28 +47,26 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
 
   private readonly fitAddon = new FitAddon();
 
-  /** Serializes interactive and toolbar-initiated exec so only one runs at a time. */
-  private execTail: Promise<void> = Promise.resolve();
-
   private commandRequestSub?: Subscription;
   private resizeObserver?: ResizeObserver;
 
-  /** {@link SerialFacadeService#isConnected$} の直近値（キー入力可否用） */
+  /** キー入力可否（{@link TerminalConsoleOrchestrationService#isConnected$} のミラー） */
   private serialInputEnabled = false;
 
   ngAfterViewInit(): void {
     this.configTerminal();
-    this.serial.connectionEstablished$
+    this.console.connectionEstablished$
       .pipe(
         switchMap(() =>
-          this.serial.isConnected$.pipe(
+          this.console.isConnected$.pipe(
             take(1),
             switchMap((connected) =>
               connected
-                ? this.bootstrapAfterConnect$(
+                ? this.console.bootstrapAfterConnect$(
                     '[コンソール] シリアルに接続しました。',
+                    this.terminalSink,
                   )
-                : EMPTY
+                : EMPTY,
             ),
           ),
         ),
@@ -93,13 +81,11 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
     this.xterminal.dispose();
   }
 
-  private enqueueExec<T>(job: () => Promise<T>): Promise<T> {
-    const run = this.execTail.then(() => job());
-    this.execTail = run.then(
-      () => undefined,
-      () => undefined,
-    );
-    return run;
+  private get terminalSink(): TerminalConsoleSink {
+    return {
+      writeln: (line: string) => this.xterminal.writeln(line),
+      write: (chunk: string) => this.xterminal.write(chunk),
+    };
   }
 
   private configTerminal(): void {
@@ -112,18 +98,22 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
     this.resizeObserver = new ResizeObserver(() => this.fitTerminal());
     this.resizeObserver.observe(el);
 
-    this.serial.isConnected$
+    this.console.isConnected$
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((c) => {
         this.serialInputEnabled = c;
       });
 
     this.xterminal.reset();
-    this.serial.isConnected$
+    this.console.isConnected$
       .pipe(take(1), takeUntilDestroyed(this.destroyRef))
       .subscribe((connected) => {
         if (connected) {
-          this.bootstrapAfterConnect$('[コンソール] シリアル接続済み。')
+          this.console
+            .bootstrapAfterConnect$(
+              '[コンソール] シリアル接続済み。',
+              this.terminalSink,
+            )
             .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe();
         } else {
@@ -134,51 +124,34 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
     attachTerminalInput(
       this.xterminal,
       async (command) => {
-        return this.enqueueExec(async () => {
-          const { stdout } = await firstValueFrom(this.serial.exec$(command, {
-            prompt: this.remotePrompt(),
-            timeout: SERIAL_TIMEOUT.DEFAULT,
-          }));
-          return sanitizeSerialStdout(stdout, command, this.remotePrompt());
-        });
+        return this.console.runInteractiveCommand(command, this.remotePrompt());
       },
       () => this.serialInputEnabled,
     );
 
     this.commandRequestSub = this.commandRequests.commandRequests$.subscribe(
       (cmd) => {
-        void this.enqueueExec(async () => {
-          const connected = await firstValueFrom(
-            this.serial.isConnected$.pipe(take(1)),
-          );
-          if (!connected) {
+        void this.console.runToolbarCommand(cmd, this.remotePrompt()).then(
+          (result) => {
+            if (result.status === 'not_connected') {
+              this.xterminal.writeln(`$ ${cmd}`);
+              this.xterminal.writeln('Command failed: Serial port not connected');
+              this.xterminal.write('$ ');
+              return;
+            }
             this.xterminal.writeln(`$ ${cmd}`);
-            this.xterminal.writeln('Command failed: Serial port not connected');
-            this.xterminal.write('$ ');
-            return;
-          }
-          this.xterminal.writeln(`$ ${cmd}`);
-          try {
-            const { stdout } = await firstValueFrom(this.serial.exec$(cmd, {
-              prompt: this.remotePrompt(),
-              timeout: SERIAL_TIMEOUT.DEFAULT,
-            }));
-            const out = sanitizeSerialStdout(
-              stdout,
-              cmd,
-              this.remotePrompt(),
-            );
+            if (result.status === 'error') {
+              this.xterminal.writeln(`\r\nCommand failed: ${result.message}`);
+              this.xterminal.write('$ ');
+              return;
+            }
+            const out = result.output;
             if (out) {
               this.xterminal.write(out);
             }
             this.xterminal.write('\r\n$ ');
-          } catch (error: unknown) {
-            const message =
-              error instanceof Error ? error.message : String(error);
-            this.xterminal.writeln(`\r\nCommand failed: ${message}`);
-            this.xterminal.write('$ ');
-          }
-        });
+          },
+        );
       },
     );
   }
@@ -189,25 +162,5 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
     } catch {
       // Dimensions may be zero before layout stabilizes
     }
-  }
-
-  private bootstrapAfterConnect$(prefixMessage: string) {
-    return this.piZeroSession.shouldRunAfterConnect$().pipe(
-      switchMap((should) => {
-        if (!should) {
-          this.xterminal.writeln(
-            `${prefixMessage} 初期化済みのためスキップします。`,
-          );
-          this.xterminal.write('$ ');
-          return EMPTY;
-        }
-        this.xterminal.writeln(`${prefixMessage} 初期化しています...`);
-        return this.piZeroSession.runAfterConnect$((line) =>
-          this.xterminal.writeln(line),
-        );
-      }),
-      catchError(() => EMPTY),
-      finalize(() => this.xterminal.write('$ ')),
-    );
   }
 }


### PR DESCRIPTION
## Summary

`@gurezo/web-serial-rxjs` v2.1 前提の整理に沿い、データアクセス層は現状の thin adapter のままとし、Issue #563 で指摘されていたターミナル UI 側のシリアル詳細（prompt・タイムアウト・sanitize・exec キュー・bootstrap）を `TerminalConsoleOrchestrationService` に移しました。`TerminalViewComponent` は表示とイベントの配線に限定しています。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #557
- Fixes #563

## What changed?

- `libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts` を新規追加（`SerialFacadeService` / `PiZeroSessionService` を束ね、prompt・timeout・sanitize を一元化）
- `terminal-view.component.ts` から上記ロジックを除去し、xterm と sink・購読のみに整理
- `terminal-console-orchestration.service.spec.ts` で exec 委譲・未接続時ツールバー・bootstrap スキップをテスト
- `libs/terminal/ui/src/index.ts` に orchestration サービスを export

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

新規 export `TerminalConsoleOrchestrationService` / `TerminalConsoleSink` はターミナルライブラリの公開 API です。コンソールアプリの外部契約の変更はありません。

## How to test

1. `pnpm nx run libs-terminal-ui:test` でユニットテストが通ることを確認する。
2. ブラウザで Pi Zero に接続し、コンソールタブで接続メッセージ・初期化ログ・プロンプト表示が従来どおりであることを確認する。
3. ターミナルにコマンドを入力し、実行結果が表示されることを確認する。
4. ツールバー等からターミナルへコマンドを送る経路があれば、未接続時・エラー時の表示が従来どおりであることを確認する。

## Environment (if relevant)

- Browser: （確認したブラウザ）
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant