### PR TITLE
refactor(web-serial): シリアルコマンドの retry / timeout / cancel オプション整理 (#565)

### DIFF
--- a/libs/web-serial/data-access/src/index.ts
+++ b/libs/web-serial/data-access/src/index.ts
@@ -1,4 +1,8 @@
 export type { SerialExecOptions } from '@libs-web-serial-util';
+export {
+  DEFAULT_SERIAL_EXEC_OPTIONS,
+  mergeSerialExecOptions,
+} from '@libs-web-serial-util';
 export * from './lib/pi-zero-session.service';
 export * from './lib/pi-zero-serial-bootstrap.service';
 export * from './lib/pi-zero-shell-readiness.service';

--- a/libs/web-serial/data-access/src/lib/serial-command/serial-command-facade.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/serial-command-facade.service.ts
@@ -2,7 +2,10 @@
 
 import { Injectable } from '@angular/core';
 import type { Observable } from 'rxjs';
-import type { SerialExecOptions } from '@libs-web-serial-util';
+import {
+  mergeSerialExecOptions,
+  type SerialExecOptions,
+} from '@libs-web-serial-util';
 import type { CommandExecutionConfig, CommandResult } from './serial-command-types';
 import { SerialCommandQueueService } from './serial-command-queue.service';
 import { SerialCommandRunnerService } from './serial-command-runner.service';
@@ -43,17 +46,24 @@ export class SerialCommandService {
   }
 
   /**
-   * {@link SerialExecOptions}（timeout / retry の既定あり）でコマンド実行
+   * {@link SerialExecOptions}（既定のタイムアウト・再試行・フラグあり）でコマンド実行
    */
   execWithSerialOptions$(
     cmd: string,
     options: SerialExecOptions,
     onAttemptStart?: () => void,
   ): Observable<CommandResult> {
-    return this.exec$(
-      cmd,
-      this.runner.serialOptionsToConfig(options),
-      onAttemptStart,
+    const merged = mergeSerialExecOptions(options);
+    const config = this.runner.serialOptionsToConfig(merged);
+    return this.commandQueue.enqueueCommand$(
+      (enqueuedGen) =>
+        this.runner.buildExecPipeline$(
+          cmd + '\n',
+          config,
+          enqueuedGen,
+          onAttemptStart,
+        ),
+      { cancelPrevious: merged.cancelPrevious },
     );
   }
 
@@ -62,10 +72,17 @@ export class SerialCommandService {
     options: SerialExecOptions,
     onAttemptStart?: () => void,
   ): Observable<CommandResult> {
-    return this.execRaw$(
-      cmdRaw,
-      this.runner.serialOptionsToConfig(options),
-      onAttemptStart,
+    const merged = mergeSerialExecOptions(options);
+    const config = this.runner.serialOptionsToConfig(merged);
+    return this.commandQueue.enqueueCommand$(
+      (enqueuedGen) =>
+        this.runner.buildExecPipeline$(
+          cmdRaw,
+          config,
+          enqueuedGen,
+          onAttemptStart,
+        ),
+      { cancelPrevious: merged.cancelPrevious },
     );
   }
 
@@ -73,9 +90,16 @@ export class SerialCommandService {
     options: SerialExecOptions,
     onAttemptStart?: () => void,
   ): Observable<CommandResult> {
-    return this.readUntilPrompt$(
-      this.runner.serialOptionsToConfig(options),
-      onAttemptStart,
+    const merged = mergeSerialExecOptions(options);
+    const config = this.runner.serialOptionsToConfig(merged);
+    return this.commandQueue.enqueueCommand$(
+      (enqueuedGen) =>
+        this.runner.buildReadUntilPromptPipeline$(
+          config,
+          enqueuedGen,
+          onAttemptStart,
+        ),
+      { cancelPrevious: merged.cancelPrevious },
     );
   }
 

--- a/libs/web-serial/data-access/src/lib/serial-command/serial-command-queue.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/serial-command-queue.service.spec.ts
@@ -6,6 +6,7 @@ import {
   firstValueFrom,
   map,
   of,
+  switchMap,
   take,
   timer,
 } from 'rxjs';
@@ -107,5 +108,47 @@ describe('SerialCommandQueueService', () => {
     expect(queue.isGenerationActive(genAtEnqueue)).toBe(true);
     queue.cancelAllCommands();
     expect(queue.isGenerationActive(genAtEnqueue)).toBe(false);
+  });
+
+  it('cancelPrevious rejects pending work but not the one currently running', async () => {
+    const queue = new SerialCommandQueueService();
+    const finishFirst = new Subject<void>();
+    const p1 = firstValueFrom(
+      queue.enqueueCommand$(() =>
+        finishFirst.pipe(
+          take(1),
+          map(() => 'first'),
+        ),
+      ),
+    );
+    const p2 = firstValueFrom(queue.enqueueCommand$(() => of('second')));
+    const p3 = firstValueFrom(
+      queue.enqueueCommand$(() => of('third'), { cancelPrevious: true }),
+    );
+    finishFirst.next();
+    finishFirst.complete();
+    expect(await p1).toBe('first');
+    await expect(p2).rejects.toThrow('All commands cancelled');
+    expect(await p3).toBe('third');
+  });
+
+  it('cancelPrevious does not abort work already in defer (same slot bump)', async () => {
+    const queue = new SerialCommandQueueService();
+    const blocker = new Subject<void>();
+    const p1 = firstValueFrom(
+      queue.enqueueCommand$(() =>
+        blocker.pipe(
+          take(1),
+          switchMap(() => of('running')),
+        ),
+      ),
+    );
+    const p2 = firstValueFrom(
+      queue.enqueueCommand$(() => of('x'), { cancelPrevious: true }),
+    );
+    blocker.next();
+    blocker.complete();
+    expect(await p1).toBe('running');
+    expect(await p2).toBe('x');
   });
 });

--- a/libs/web-serial/data-access/src/lib/serial-command/serial-command-queue.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/serial-command-queue.service.ts
@@ -12,6 +12,15 @@ import {
   throwError,
 } from 'rxjs';
 
+/** {@link SerialCommandQueueService#enqueueCommand$} のキュー制御オプション（issue #565） */
+export interface SerialCommandEnqueueOptions {
+  /**
+   * `true` のとき、この enqueue の直前に **まだ実行が始まっていない** 先行ジョブを棄却する。
+   * 実行中のジョブは止めない。{@link SerialCommandQueueService#cancelAllCommands} とは別。
+   */
+  cancelPrevious?: boolean;
+}
+
 /**
  * シリアルコマンド実行を直列化し、世代ベースで一括キャンセルする。
  *
@@ -22,6 +31,7 @@ import {
  *   `cancelAllCommands` 済みなら `All commands cancelled` で打ち切る。
  * - `enqueuedGen` は enqueue 時点の世代。キャンセル後もキューに積まれた古いジョブは
  *   実行開始時に世代不一致で棄却される。
+ * - **スロット**（`assignedSlotId`）は `cancelPrevious` 時に未実行ジョブだけを棄却するために使う。
  */
 @Injectable({
   providedIn: 'root',
@@ -31,6 +41,13 @@ export class SerialCommandQueueService {
   /** `cancelAllCommands` のたびに増加。enqueue 時点の世代と比較して実行可否を決める */
   private generation = 0;
   private pendingCount = 0;
+  /** enqueue ごとに増える単調 ID（実行順と一致しない） */
+  private nextSlotId = 0;
+  /**
+   * 実行開始時、`assignedSlotId` がこの値未満なら棄却（`cancelPrevious` で設定）。
+   * `cancelAllCommands` ではリセットする。
+   */
+  private rejectPendingSlotsBelow: number | null = null;
 
   constructor() {
     this.executionQueue$
@@ -48,6 +65,14 @@ export class SerialCommandQueueService {
   }
 
   /**
+   * キューに載っているがまだ `factory` が起動していないジョブを棄却するしきい値を更新する。
+   * 直後に enqueue されるコマンドは新しいスロット ID を得る。
+   */
+  invalidatePendingEnqueues(): void {
+    this.rejectPendingSlotsBelow = this.nextSlotId + 1;
+  }
+
+  /**
    * enqueue 時点の世代がまだ有効か（cancel されていなければ true）
    */
   isGenerationActive(enqueuedGen: number): boolean {
@@ -56,12 +81,22 @@ export class SerialCommandQueueService {
 
   enqueueCommand$<T>(
     factory: (enqueuedGen: number) => Observable<T>,
+    opts?: SerialCommandEnqueueOptions,
   ): Observable<T> {
     return new Observable<T>((subscriber) => {
+      if (opts?.cancelPrevious) {
+        this.invalidatePendingEnqueues();
+      }
+      const assignedSlotId = ++this.nextSlotId;
       const enqueuedGen = this.generation;
       this.pendingCount++;
       this.executionQueue$.next(
-        this.createQueuedWork$(enqueuedGen, factory, subscriber),
+        this.createQueuedWork$(
+          enqueuedGen,
+          assignedSlotId,
+          factory,
+          subscriber,
+        ),
       );
     });
   }
@@ -71,11 +106,18 @@ export class SerialCommandQueueService {
    */
   private createQueuedWork$<T>(
     enqueuedGen: number,
+    assignedSlotId: number,
     factory: (enqueuedGen: number) => Observable<T>,
     subscriber: Subscriber<T>,
   ): Observable<unknown> {
     return defer(() => {
       if (this.generation !== enqueuedGen) {
+        return throwError(() => new Error('All commands cancelled'));
+      }
+      if (
+        this.rejectPendingSlotsBelow !== null &&
+        assignedSlotId < this.rejectPendingSlotsBelow
+      ) {
         return throwError(() => new Error('All commands cancelled'));
       }
       return factory(enqueuedGen);
@@ -97,6 +139,7 @@ export class SerialCommandQueueService {
 
   cancelAllCommands(): void {
     this.generation++;
+    this.rejectPendingSlotsBelow = null;
   }
 
   getPendingCommandCount(): number {

--- a/libs/web-serial/data-access/src/lib/serial-command/serial-command-runner.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/serial-command-runner.service.ts
@@ -19,7 +19,8 @@ import {
   timeout,
 } from 'rxjs';
 import {
-  SERIAL_TIMEOUT,
+  DEFAULT_SERIAL_EXEC_OPTIONS,
+  mergeSerialExecOptions,
   type SerialExecOptions,
 } from '@libs-web-serial-util';
 import { stripLineForPromptDetection } from './ansi-strip.util';
@@ -153,8 +154,14 @@ export class SerialCommandRunnerService {
       onAttemptStart?.();
       this.clearReadBuffer();
       return this.transport.write(sendData).pipe(
-        mergeMap(() => this.waitForPromptMatch$(config, enqueuedGen)),
-        map((stdout) => ({ stdout })),
+        mergeMap(() => {
+          if (config.waitForPrompt === false) {
+            return of<CommandResult>({ stdout: '' });
+          }
+          return this.waitForPromptMatch$(config, enqueuedGen).pipe(
+            map((stdout) => ({ stdout })),
+          );
+        }),
       );
     });
     return this.withPromptAttemptRetries(attempt$, retryCount);
@@ -171,6 +178,11 @@ export class SerialCommandRunnerService {
         return throwError(() => new Error('All commands cancelled'));
       }
       onAttemptStart?.();
+      if (config.waitForPrompt === false) {
+        const stdout = this.readBuffer;
+        this.readBuffer = '';
+        return of<CommandResult>({ stdout });
+      }
       if (this.bufferMatchesPrompt(this.readBuffer, config)) {
         const stdout = this.readBuffer;
         this.readBuffer = '';
@@ -184,12 +196,14 @@ export class SerialCommandRunnerService {
   }
 
   serialOptionsToConfig(options: SerialExecOptions): CommandExecutionConfig {
-    const {
-      prompt,
-      promptMatch,
-      timeout = SERIAL_TIMEOUT.DEFAULT,
-      retry = 0,
-    } = options;
+    const m = mergeSerialExecOptions(options);
+    const { prompt, promptMatch, waitForPrompt } = m;
+    const timeout =
+      m.timeoutMs ??
+      m.timeout ??
+      DEFAULT_SERIAL_EXEC_OPTIONS.timeoutMs;
+    const retry =
+      m.retryCount ?? m.retry ?? DEFAULT_SERIAL_EXEC_OPTIONS.retryCount;
     if (promptMatch === undefined && prompt === undefined) {
       throw new Error('SerialExecOptions: prompt or promptMatch is required');
     }
@@ -198,6 +212,7 @@ export class SerialCommandRunnerService {
       promptMatch,
       timeout,
       retry,
+      waitForPrompt,
     };
   }
 

--- a/libs/web-serial/data-access/src/lib/serial-command/serial-command-types.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/serial-command-types.ts
@@ -14,6 +14,10 @@ export interface CommandExecutionConfig {
   timeout: number;
   /** タイムアウト等失敗時の再試行回数 */
   retry?: number;
+  /**
+   * 既定相当 `true`。`false` のときプロンプト一致待ちを行わない（Runner 層、issue #565）。
+   */
+  waitForPrompt?: boolean;
 }
 
 /**

--- a/libs/web-serial/data-access/src/lib/serial-command/serial-command.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/serial-command.service.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { Observable, Subject, firstValueFrom } from 'rxjs';
+import { Observable, Subject, firstValueFrom, take } from 'rxjs';
 import {
   PI_ZERO_PROMPT,
 } from '@libs-web-serial-util';
@@ -253,5 +253,105 @@ describe('SerialCommandService', () => {
     });
     expect(outcome).toBeInstanceOf(Error);
     expect((outcome as Error).message).toContain('Command execution timeout');
+  });
+
+  it('respects timeoutMs as alias for timeout', async () => {
+    const { service, transport } = createService();
+    transport.write = vi.fn(
+      () =>
+        new Observable<void>((subscriber) => {
+          subscriber.next();
+          subscriber.complete();
+        }),
+    );
+    const p = firstValueFrom(
+      service.execWithSerialOptions$('ls', {
+        prompt: PI_ZERO_PROMPT,
+        timeoutMs: 40,
+        retryCount: 0,
+      }),
+    );
+    await expect(p).rejects.toThrow('Command execution timeout');
+  });
+
+  it('exec with waitForPrompt false completes without prompt in output', async () => {
+    const { service, transport } = createService();
+
+    let releaseWrite: (() => void) | undefined;
+    transport.write = vi.fn(
+      () =>
+        new Observable<void>((subscriber) => {
+          releaseWrite = () => {
+            subscriber.next();
+            subscriber.complete();
+          };
+        }),
+    );
+
+    const execPromise = firstValueFrom(
+      service.execWithSerialOptions$('ls', {
+        prompt: PI_ZERO_PROMPT,
+        timeout: 5000,
+        waitForPrompt: false,
+      }),
+    );
+
+    releaseWrite?.();
+    const result = await execPromise;
+    expect(result.stdout).toBe('');
+    expect(transport.write).toHaveBeenCalled();
+  });
+
+  it('cancelPrevious drops pending exec but not running', async () => {
+    const { service, lines, transport } = createService();
+    const finishFirst = new Subject<void>();
+    let writeCall = 0;
+    transport.write = vi.fn(
+      () =>
+        new Observable<void>((s) => {
+          writeCall++;
+          if (writeCall === 1) {
+            finishFirst.pipe(take(1)).subscribe(() => {
+              s.next();
+              s.complete();
+            });
+            return;
+          }
+          s.next();
+          s.complete();
+        }),
+    );
+
+    const p1 = firstValueFrom(
+      service.execWithSerialOptions$('a', {
+        prompt: PI_ZERO_PROMPT,
+        timeout: 5000,
+      }),
+    );
+    const p2 = firstValueFrom(
+      service.execWithSerialOptions$('b', {
+        prompt: PI_ZERO_PROMPT,
+        timeout: 5000,
+      }),
+    );
+    const p3 = firstValueFrom(
+      service.execWithSerialOptions$('c', {
+        prompt: PI_ZERO_PROMPT,
+        timeout: 5000,
+        cancelPrevious: true,
+      }),
+    );
+
+    finishFirst.next();
+    finishFirst.complete();
+    emitAsLines(lines, `${PI_ZERO_PROMPT}`);
+
+    await expect(p2).rejects.toThrow('All commands cancelled');
+
+    emitAsLines(lines, `${PI_ZERO_PROMPT}`);
+
+    const [r1, r3] = await Promise.all([p1, p3]);
+    expect(r1.stdout).toContain(PI_ZERO_PROMPT);
+    expect(r3.stdout).toContain(PI_ZERO_PROMPT);
   });
 });

--- a/libs/web-serial/util/src/lib/serial-exec-options.ts
+++ b/libs/web-serial/util/src/lib/serial-exec-options.ts
@@ -1,5 +1,7 @@
+import { SERIAL_TIMEOUT } from './serial-timeout';
+
 /**
- * {@link SerialFacadeService#exec} / execRaw / readUntilPrompt 向けオプション
+ * {@link SerialFacadeService#exec} / execRaw / readUntilPrompt 向けオプション（issue #565）
  */
 export interface SerialExecOptions {
   /**
@@ -10,6 +12,59 @@ export interface SerialExecOptions {
    * {@link promptMatch} 未指定時に必須。指定時はダミーでも可（未使用）。
    */
   prompt?: string | RegExp;
+  /**
+   * タイムアウト（ミリ秒）。{@link timeoutMs} 未指定時の {@link timeout} と同義。
+   * 後方互換のため残す。
+   */
   timeout?: number;
+  /** `timeout` の別名。両方指定時はこちらが優先。 */
+  timeoutMs?: number;
+  /** 失敗試行ごとの再試行回数（初回を除く）。{@link retryCount} 未指定時に使う。 */
   retry?: number;
+  /** `retry` の別名。両方指定時はこちらが優先。 */
+  retryCount?: number;
+  /**
+   * 既定 `true`。`false` のとき送信後（または readUntil 時）はプロンプト待ちをせず完了する。
+   * exec / execRaw では `stdout` は空文字を返す。
+   */
+  waitForPrompt?: boolean;
+  /**
+   * 既定 `false`。`true` のとき、このコマンドをキューに載せる直前に、
+   * **未実行**の先行ジョブだけを破棄する（実行中のジョブは止めない）。
+   * {@link SerialCommandQueueService#cancelAllCommands} とは別。
+   */
+  cancelPrevious?: boolean;
+}
+
+/**
+ * {@link mergeSerialExecOptions} が埋める既定（ミリ秒・回数・フラグ）。
+ */
+export const DEFAULT_SERIAL_EXEC_OPTIONS = {
+  timeoutMs: SERIAL_TIMEOUT.DEFAULT,
+  retryCount: 0,
+  waitForPrompt: true,
+  cancelPrevious: false,
+} as const;
+
+/**
+ * 省略フィールドを {@link DEFAULT_SERIAL_EXEC_OPTIONS} で埋め、`timeout`/`timeoutMs` と `retry`/`retryCount` を正規化する。
+ */
+export function mergeSerialExecOptions(options: SerialExecOptions): SerialExecOptions {
+  const timeout =
+    options.timeoutMs ?? options.timeout ?? DEFAULT_SERIAL_EXEC_OPTIONS.timeoutMs;
+  const retry =
+    options.retryCount ?? options.retry ?? DEFAULT_SERIAL_EXEC_OPTIONS.retryCount;
+  const waitForPrompt =
+    options.waitForPrompt ?? DEFAULT_SERIAL_EXEC_OPTIONS.waitForPrompt;
+  const cancelPrevious =
+    options.cancelPrevious ?? DEFAULT_SERIAL_EXEC_OPTIONS.cancelPrevious;
+  return {
+    ...options,
+    timeout,
+    retry,
+    timeoutMs: timeout,
+    retryCount: retry,
+    waitForPrompt,
+    cancelPrevious,
+  };
 }


### PR DESCRIPTION
## Summary

issue #565 に沿い、シリアルコマンドの `SerialExecOptions` に `timeoutMs` / `retryCount` / `waitForPrompt` / `cancelPrevious` を追加し、`mergeSerialExecOptions` と既定値で正規化するようにしました。`cancelPrevious` は実行中ジョブを止めず、キュー上の未実行ジョブのみをスロット ID で無効化します。`waitForPrompt: false` ではプロンプト待ちをスキップします（exec は空の stdout）。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #565

## What changed?

- `libs-web-serial/util` の `SerialExecOptions` 拡張と `DEFAULT_SERIAL_EXEC_OPTIONS` / `mergeSerialExecOptions`
- `SerialCommandQueueService` の `cancelPrevious`（スロットベース）と `cancelAllCommands` 時のリセット
- `SerialCommandRunnerService` の `waitForPrompt` 分岐とマージ済みオプションの反映
- `SerialCommandService` の SerialExecOptions 経路での `cancelPrevious` 引き渡し
- data-access の `index` からの再エクスポートと Vitest の追加

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - Details: `@libs-web-serial-util` の `SerialExecOptions` に任意フィールドを追加。`@libs-web-serial-data-access` から `mergeSerialExecOptions` と `DEFAULT_SERIAL_EXEC_OPTIONS` をエクスポート。既存の `timeout` / `retry` のみの呼び出しは従来どおり（マージで既定が埋まる）。
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test

1. `pnpm exec nx run libs-web-serial-data-access:test`
2. （任意）実機でシリアル接続後、従来どおり exec / readUntilPrompt が動くこと

## Environment (if relevant)

- Browser: （未確認）
- OS: macOS / Windows / Linux
- Node version: （ローカルに合わせて記載）
- pnpm version: （ローカルに合わせて記載）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant