### PR TITLE
test(web-serial): Pi Zero セッションの login/setup/error の単体テストを追加 (#567)

### DIFF
--- a/libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { firstValueFrom, from, of } from 'rxjs';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import { firstValueFrom, from, of, throwError } from 'rxjs';
+import {
+  PI_ZERO_LOGIN_USER,
+  PI_ZERO_PROMPT,
+} from '@libs-web-serial-util';
 import { PiZeroSerialBootstrapService } from './pi-zero-serial-bootstrap.service';
 import type { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
 import { PiZeroSessionService } from './pi-zero-session.service';
@@ -95,5 +98,127 @@ describe('PiZeroSessionService', () => {
 
     expect(seen).toContain(true);
     expect(seen.at(-1)).toBe(false);
+  });
+
+  describe('login flow (loginIfNeeded$)', () => {
+    it('completes without exec when shell prompt is already present', async () => {
+      const readUntilPrompt = vi.fn().mockReturnValue(
+        of({ stdout: `${PI_ZERO_PROMPT} ` }),
+      );
+      const exec = vi.fn();
+      const serial = {
+        readUntilPrompt$: (o: unknown) => readUntilPrompt(o),
+        exec$: (c: string, o: unknown) => from(exec(c, o)),
+      } as unknown as SerialFacadeService;
+
+      const service = createSession(serial, createShellReadinessMock());
+      await firstValueFrom(service.loginIfNeeded$());
+
+      expect(readUntilPrompt).toHaveBeenCalledTimes(1);
+      expect(exec).not.toHaveBeenCalled();
+    });
+
+    it('runs user and password exec after login prompts when shell probe fails', async () => {
+      const readUntilPrompt = vi
+        .fn()
+        .mockImplementationOnce(() =>
+          throwError(() => new Error('shell prompt timeout')),
+        )
+        .mockImplementationOnce(() =>
+          of({ stdout: 'raspberrypi login: ' }),
+        );
+      const exec = vi
+        .fn()
+        .mockReturnValueOnce(of({ stdout: 'Password: ' }))
+        .mockReturnValueOnce(of({ stdout: `${PI_ZERO_PROMPT} ` }));
+
+      const serial = {
+        readUntilPrompt$: (o: unknown) => readUntilPrompt(o),
+        exec$: (c: string, o: unknown) => exec(c, o),
+      } as unknown as SerialFacadeService;
+
+      const service = createSession(serial, createShellReadinessMock());
+      await firstValueFrom(service.loginIfNeeded$());
+
+      expect(readUntilPrompt).toHaveBeenCalledTimes(2);
+      expect(exec).toHaveBeenCalledTimes(2);
+      expect(exec.mock.calls[0]?.[0]).toBe(PI_ZERO_LOGIN_USER);
+    });
+  });
+
+  describe('setup flow (setupEnvironment$)', () => {
+    it('runs each timezone init command over serial exec$', async () => {
+      const exec = vi.fn().mockReturnValue(of({ stdout: `${PI_ZERO_PROMPT} ` }));
+      const serial = {
+        exec$: (c: string, o: unknown) => exec(c, o),
+      } as unknown as SerialFacadeService;
+
+      const service = createSession(serial, createShellReadinessMock());
+      await firstValueFrom(service.setupEnvironment$());
+
+      expect(exec).toHaveBeenCalledTimes(2);
+      expect(exec.mock.calls[0]?.[0]).toContain('timedatectl set-timezone');
+      expect(exec.mock.calls[1]?.[0]).toBe('timedatectl status');
+    });
+  });
+
+  describe('error flow (runAfterConnect$)', () => {
+    it('propagates errors, skips setReady(true), and ends initializing$', async () => {
+      const readUntilPrompt = vi
+        .fn()
+        .mockImplementationOnce(() =>
+          throwError(() => new Error('shell probe timeout')),
+        )
+        .mockImplementationOnce(() =>
+          throwError(() => new Error('login prompt timeout')),
+        );
+      const exec = vi.fn();
+      const serial = {
+        isConnected$: of(true),
+        getConnectionEpoch: () => 1,
+        readUntilPrompt$: (o: unknown) => readUntilPrompt(o),
+        exec$: (c: string, o: unknown) => from(exec(c, o)),
+      } as unknown as SerialFacadeService;
+
+      const shellReadiness = createShellReadinessMock();
+      const service = createSession(serial, shellReadiness);
+      const seen: boolean[] = [];
+      const sub = service.initializing$.subscribe((v) => seen.push(v));
+
+      await expect(firstValueFrom(service.runAfterConnect$())).rejects.toThrow(
+        'login prompt timeout',
+      );
+      sub.unsubscribe();
+
+      expect(vi.mocked(shellReadiness.setReady)).not.toHaveBeenCalledWith(true);
+      expect(seen.at(-1)).toBe(false);
+    });
+
+    it('notifies status handler on pipeline failure', async () => {
+      const readUntilPrompt = vi
+        .fn()
+        .mockImplementationOnce(() =>
+          throwError(() => new Error('shell probe timeout')),
+        )
+        .mockImplementationOnce(() =>
+          throwError(() => new Error('login prompt timeout')),
+        );
+      const onStatus = vi.fn();
+      const serial = {
+        isConnected$: of(true),
+        getConnectionEpoch: () => 1,
+        readUntilPrompt$: (o: unknown) => readUntilPrompt(o),
+        exec$: (c: string, o: unknown) => from(Promise.resolve({ stdout: '' })),
+      } as unknown as SerialFacadeService;
+
+      const service = createSession(serial, createShellReadinessMock());
+      await expect(
+        firstValueFrom(service.runAfterConnect$(onStatus)),
+      ).rejects.toThrow();
+
+      expect(onStatus).toHaveBeenCalledWith(
+        expect.stringContaining('接続後の初期化に失敗'),
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary  
Issue #567 に沿い、`PiZeroSessionService` についてモックのシリアルで login 経路・環境セットアップ・接続後パイプライン失敗時の挙動を検証するテストを追加しました。

## Type of change  
- [ ] Bug fix  
- [ ] New feature  
- [ ] Refactor  
- [ ] Documentation  
- [x] Chore (build/test/ci)  
- [ ] Breaking change  

## Related issues  
- Fixes https://github.com/gurezo/chirimen-lite-console/issues/567  

## What changed?  
- `loginIfNeeded$`: シェル既存時は `exec` なしで完了すること、プローブ失敗後にログインシーケンス（ユーザー送信・パスワード送信）が走ることを検証  
- `setupEnvironment$`: タイムゾーン初期化の各コマンドが `serial.exec$` で実行されることを検証  
- `runAfterConnect$`: パイプライン失敗時にエラー伝播、`setReady(true)` されないこと、`initializing$` の終了、ステータス通知を検証  

## API / Compatibility  
- [ ] Public API changes (export / function signature / behavior)  
- [x] This change is backward compatible  
- [ ] This change introduces a breaking change  

## How to test  
1. `pnpm exec nx run libs-web-serial-data-access:test`  

## Environment (if relevant)  
- Browser: （該当なし）  
- OS: macOS / Windows / Linux  
- Node version: （ローカルに合わせて記載）  
- pnpm version: （ローカルに合わせて記載）  

## Checklist  
- [x] I ran tests locally (if available)  
- [ ] I updated docs/README if needed  
- [x] I considered error handling where relevant