### PR TITLE
build(workspace): @gurezo/web-serial-rxjs を v2.3.1 に移行

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@angular/platform-browser": "21.2.10",
     "@angular/platform-browser-dynamic": "21.2.10",
     "@angular/router": "21.2.10",
-    "@gurezo/web-serial-rxjs": "2.2.0",
+    "@gurezo/web-serial-rxjs": "2.3.1",
     "@ngrx/component-store": "21.0.1",
     "@ngrx/effects": "21.0.1",
     "@ngrx/operators": "21.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 21.2.10
         version: 21.2.10(@angular/common@21.2.10(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1))(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0))(@angular/platform-browser@21.2.10(@angular/animations@21.2.10(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0)))(@angular/common@21.2.10(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1))(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0)))(rxjs@7.8.1)
       '@gurezo/web-serial-rxjs':
-        specifier: 2.2.0
-        version: 2.2.0(rxjs@7.8.1)
+        specifier: 2.3.1
+        version: 2.3.1(rxjs@7.8.1)
       '@ngrx/component-store':
         specifier: 21.0.1
         version: 21.0.1(@angular/core@21.2.10(@angular/compiler@21.2.10)(rxjs@7.8.1)(zone.js@0.16.0))(rxjs@7.8.1)
@@ -2145,8 +2145,8 @@ packages:
       '@noble/hashes':
         optional: true
 
-  '@gurezo/web-serial-rxjs@2.2.0':
-    resolution: {integrity: sha512-9SBLLiFHuH55pQ2paN357Qd6m7BuMJXZcasjwA4EEohqh1iJaxvUaNHLrG2JrVWc8/9U7a5jOe+Tyx7m4CT0DQ==}
+  '@gurezo/web-serial-rxjs@2.3.1':
+    resolution: {integrity: sha512-z8Ut+o4zJKLTdaMmbezkWrLvSjW38qAk4N0lq3APZ2hIvMhEHT/2OKNyEImt6JKsqAa4cG6aFmL329zMq0+CfA==}
     peerDependencies:
       rxjs: ^7.8.0
 
@@ -13131,7 +13131,7 @@ snapshots:
 
   '@exodus/bytes@1.15.0': {}
 
-  '@gurezo/web-serial-rxjs@2.2.0(rxjs@7.8.1)':
+  '@gurezo/web-serial-rxjs@2.3.1(rxjs@7.8.1)':
     dependencies:
       rxjs: 7.8.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,4 +10,4 @@ onlyBuiltDependencies:
 
 # Malicious releases are often detected and removed within a week.
 # 7 days x 24h x 60 min
-# minimumReleaseAge: 10080
+minimumReleaseAge: 10080

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,4 +10,4 @@ onlyBuiltDependencies:
 
 # Malicious releases are often detected and removed within a week.
 # 7 days x 24h x 60 min
-minimumReleaseAge: 10080
+# minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary
Issue #596 に対応し、`@gurezo/web-serial-rxjs` を `v2.3.1` へ移行しました。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #596

## What changed?

- `pnpm-workspace.yaml` の `minimumReleaseAge` を一時コメント化
- `package.json` の `@gurezo/web-serial-rxjs` を `2.2.0` から `2.3.1` に更新
- `pnpm i` 実行結果を `pnpm-lock.yaml` に反映
- `pnpm-workspace.yaml` の `minimumReleaseAge` を元に戻して復元

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm i` を実行して依存解決が成功することを確認
2. `package.json` の `@gurezo/web-serial-rxjs` が `2.3.1` であることを確認
3. `pnpm-lock.yaml` に `@gurezo/web-serial-rxjs@2.3.1` の解決結果が反映されていることを確認

## Environment (if relevant)

- Browser: N/A
- OS: macOS
- Node version: N/A
- pnpm version: N/A

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant