### PR TITLE
refactor(terminal): terminal表示ロジックをterminalText

### DIFF
--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
@@ -30,10 +30,9 @@ export interface TerminalConsoleSink {
  * シリアルからの **ライブ表示** 専用は {@link SerialFacadeService#terminalText$} のみを購読する。
  * {@link #pipeTerminalOutputToSink$} がその経路。`exec` の stdout 整形表示と二重にならないよう UI 側で使い分けること。
  *
- * ### 対話コンソールの表示モードと [example-angular](https://github.com/gurezo/web-serial-rxjs/tree/main/apps/example-angular)
+ * ### 対話コンソール表示
  *
- * upstream のサンプルは `send$` と組み込み `lines$` のみ。`sanitizeSerialStdout(..., 'lineStreamMirrored')` は並びだけをそれに寄せられるが、
- * `ls -l` 等の論理行内 `\r` やタブによる段状ずれ対策には **`default`**（CR セグメント折り畳み・dedent を含む）を使う。
+ * ライブ表示は `terminalText$` の購読のみで行い、実行結果の表示整形（`exec$` 経路）とは責務を分離する。
  */
 @Injectable({
   providedIn: 'root',

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NEVER, from, of } from 'rxjs';
+import { NEVER, Subject, from, of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@xterm/xterm', () => {
@@ -33,11 +33,13 @@ describe('TerminalViewComponent', () => {
   let execMock: ReturnType<typeof vi.fn>;
   let shouldRunAfterConnectMock: ReturnType<typeof vi.fn>;
   let runAfterConnectMock: ReturnType<typeof vi.fn>;
+  let terminalTextSubject: Subject<string>;
 
   beforeEach(async () => {
     execMock = vi.fn().mockResolvedValue({
       stdout: `i2cdetect -y 1\n     0  1\n${PI_ZERO_PROMPT} `,
     });
+    terminalTextSubject = new Subject<string>();
     shouldRunAfterConnectMock = vi.fn(() => of(true));
     runAfterConnectMock = vi.fn(() => of(undefined));
     await TestBed.configureTestingModule({
@@ -49,6 +51,7 @@ describe('TerminalViewComponent', () => {
           exec$: (...args: unknown[]) =>
             from(execMock(...(args as [string, unknown]))),
           connectionEstablished$: NEVER,
+          terminalText$: terminalTextSubject.asObservable(),
           getConnectionEpoch: () => 1,
         },
       })
@@ -97,5 +100,16 @@ describe('TerminalViewComponent', () => {
       expect(shouldRunAfterConnectMock).toHaveBeenCalled();
     });
     expect(runAfterConnectMock).not.toHaveBeenCalled();
+  });
+
+  it('forwards live terminalText$ chunks to xterm.write', async () => {
+    const writeSpy = vi.spyOn(fixture.componentInstance.xterminal, 'write');
+    terminalTextSubject.next('hello');
+    terminalTextSubject.next('\r\nworld');
+
+    await vi.waitFor(() => {
+      expect(writeSpy).toHaveBeenCalledWith('hello');
+      expect(writeSpy).toHaveBeenCalledWith('\r\nworld');
+    });
   });
 });

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -109,6 +109,11 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
       });
 
     this.xterminal.reset();
+    this.console
+      .pipeTerminalOutputToSink$(this.terminalSink)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe();
+
     this.console.isConnected$
       .pipe(take(1), takeUntilDestroyed(this.destroyRef))
       .subscribe((connected) => {

--- a/libs/web-serial/data-access/src/lib/serial-command/serial-command-runner.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/serial-command-runner.service.ts
@@ -104,16 +104,9 @@ export class SerialCommandRunnerService {
     this.readBuffer = '';
   }
 
-  /**
-   * バッファ正規化: `\\r`・`\\r\\n` を「論理表示」へ収束させる（{@link collapseCarriageRedrawsPerLine}）。
-   */
-  private normalizeInspectionBufferText(s: string): string {
-    return collapseCarriageRedrawsPerLine(s);
-  }
-
   /** プロンプト照合用のバッファ */
   private promptInspectionBuffer(): string {
-    return this.normalizeInspectionBufferText(this.readBuffer);
+    return collapseCarriageRedrawsPerLine(this.readBuffer);
   }
 
   /**


### PR DESCRIPTION
## Summary

Issue #591 の対応として、terminal のライブ表示責務を `terminalText$` 購読へ統一しました。UI 側の表示専用中間ロジックを削減し、表示経路とプロンプト照合責務の境界を明確にしています。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #591
- Refs #588

## What changed?

- `TerminalViewComponent` で `pipeTerminalOutputToSink$` を購読し、`terminalText$` のライブ出力を xterm に直接流すよう変更
- `TerminalConsoleOrchestrationService` のコメントを更新し、ライブ表示と exec 出力整形の責務分離を明確化
- `SerialCommandRunnerService` で `normalizeInspectionBufferText` を削除し、プロンプト照合バッファ正規化を `promptInspectionBuffer` に集約
- `TerminalViewComponent` の spec に `terminalText$` ライブ出力の転送テストを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx test libs-terminal-ui`
2. `pnpm nx test libs-web-serial-data-access`
3. terminal UI で接続後のライブ出力が `terminalText$` 経路で表示されることを確認する

## Environment (if relevant)

- Browser: N/A
- OS: macOS
- Node version: (local env)
- pnpm version: (local env)

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)