### PR TITLE
refactor(terminal): terminalText$ 購読による xterm 描画への移行 (#610)

### DIFF
--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
@@ -27,16 +27,24 @@ export interface TerminalConsoleSink {
  * ターミナル画面向けにシリアル接続・Pi Zero bootstrap・exec を束ねる（issue #563）。
  * prompt / timeout / sanitize はここに集約し、component は表示用 sink と購読のみに寄せる。
  *
- * ### 生受信ミラー（issue #566）
+ * ### ライブ表示の経路（issue #610 / 親 #609）
  *
- * シリアルからの **ライブ表示** は {@link SerialFacadeService#receive$} の生チャンクを xterm に流す。
- * `terminalText$` はライブラリが畳んだ**累積全文**を出すため、そのまま `write` すると二重表示になる。
- * {@link #pipeTerminalOutputToSink$} が `receive$` 経路。`exec` の stdout 整形表示とは別。
+ * Issue #610 以降、ライブ表示は {@link TerminalViewComponent} 側で
+ * {@link SerialFacadeService#terminalText$} を直接購読し、累積全文との差分のみを
+ * xterm に書き込む方式に移行した。`terminalText$` はライブラリ内で `\r` 再描画を
+ * 畳んだ累積全文を emit するため、そのまま `write` すると二重表示になる点に注意する。
+ *
+ * ### 生受信ミラー（issue #566 / #610 で停止）
+ *
+ * 旧来は本サービスの {@link #pipeTerminalOutputToSink$} が
+ * {@link SerialFacadeService#receive$} の生チャンクを xterm にミラーしていた。
+ * Issue #610 で UI 側購読を停止し、シグネチャと spec のみ温存している
+ * （親 #609 配下の後続サブ issue で本メソッド自体を削除予定）。
  *
  * ### 対話コンソール表示
  *
- * ライブ表示は `receive$` の購読で行う。`exec$` 経路（対話・ツールバー）ではミラーを止め、
- * 完了後の {@link sanitizeSerialStdout} 結果だけを xterm に出して二重表示を避ける。
+ * `exec$` 経路（対話・ツールバー）ではライブミラーを抑止し、完了後の
+ * {@link sanitizeSerialStdout} 結果だけを xterm に出して二重表示を避ける。
  */
 @Injectable({
   providedIn: 'root',
@@ -165,6 +173,9 @@ export class TerminalConsoleOrchestrationService {
   /**
    * {@link SerialFacadeService#receive$} の UTF-8 チャンクを xterm 等へそのまま流す（TTY 相当）。
    * プロンプト判定・コマンド結果の行処理には使わないこと。
+   *
+   * @deprecated Issue #610 でライブ表示は {@link SerialFacadeService#terminalText$} 直購読に
+   * 移行済み。UI 側からは購読されておらず、親 issue #609 配下の後続サブ issue で削除予定。
    */
   pipeTerminalOutputToSink$(
     sink: Pick<TerminalConsoleSink, 'write'>,

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NEVER, Subject, from, of } from 'rxjs';
+import { BehaviorSubject, NEVER, Subject, from, of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@xterm/xterm', () => {
@@ -34,12 +34,16 @@ describe('TerminalViewComponent', () => {
   let shouldRunAfterConnectMock: ReturnType<typeof vi.fn>;
   let runAfterConnectMock: ReturnType<typeof vi.fn>;
   let receiveSubject: Subject<string>;
+  let terminalTextSubject: Subject<string>;
+  let isConnectedSubject: BehaviorSubject<boolean>;
 
   beforeEach(async () => {
     execMock = vi.fn().mockResolvedValue({
       stdout: `i2cdetect -y 1\n     0  1\n${PI_ZERO_PROMPT} `,
     });
     receiveSubject = new Subject<string>();
+    terminalTextSubject = new Subject<string>();
+    isConnectedSubject = new BehaviorSubject<boolean>(true);
     shouldRunAfterConnectMock = vi.fn(() => of(true));
     runAfterConnectMock = vi.fn(() => of(undefined));
     await TestBed.configureTestingModule({
@@ -47,12 +51,12 @@ describe('TerminalViewComponent', () => {
     })
       .overrideProvider(SerialFacadeService, {
         useValue: {
-          isConnected$: of(true),
+          isConnected$: isConnectedSubject.asObservable(),
           exec$: (...args: unknown[]) =>
             from(execMock(...(args as [string, unknown]))),
           connectionEstablished$: NEVER,
           receive$: receiveSubject.asObservable(),
-          terminalText$: NEVER,
+          terminalText$: terminalTextSubject.asObservable(),
           getConnectionEpoch: () => 1,
         },
       })
@@ -103,14 +107,75 @@ describe('TerminalViewComponent', () => {
     expect(runAfterConnectMock).not.toHaveBeenCalled();
   });
 
-  it('forwards live receive$ chunks to xterm.write', async () => {
+  it('writes only the appended delta when terminalText$ grows by suffix', async () => {
     const writeSpy = vi.spyOn(fixture.componentInstance.xterminal, 'write');
-    receiveSubject.next('hello');
-    receiveSubject.next('\r\nworld');
+    writeSpy.mockClear();
+
+    terminalTextSubject.next('hello');
+    terminalTextSubject.next('hello world');
 
     await vi.waitFor(() => {
       expect(writeSpy).toHaveBeenCalledWith('hello');
-      expect(writeSpy).toHaveBeenCalledWith('\r\nworld');
+      expect(writeSpy).toHaveBeenCalledWith(' world');
     });
+    expect(writeSpy).not.toHaveBeenCalledWith('hello world');
+  });
+
+  it('resets xterm and writes full text when terminalText$ prefix changes', async () => {
+    const writeSpy = vi.spyOn(fixture.componentInstance.xterminal, 'write');
+    const resetSpy = vi.spyOn(fixture.componentInstance.xterminal, 'reset');
+    writeSpy.mockClear();
+    resetSpy.mockClear();
+
+    terminalTextSubject.next('abc');
+    await vi.waitFor(() => expect(writeSpy).toHaveBeenCalledWith('abc'));
+
+    terminalTextSubject.next('x');
+
+    await vi.waitFor(() => {
+      expect(resetSpy).toHaveBeenCalled();
+      expect(writeSpy).toHaveBeenCalledWith('x');
+    });
+  });
+
+  it('skips re-emission when terminalText$ value is identical to previous', async () => {
+    const writeSpy = vi.spyOn(fixture.componentInstance.xterminal, 'write');
+    writeSpy.mockClear();
+
+    terminalTextSubject.next('hello');
+    await vi.waitFor(() => expect(writeSpy).toHaveBeenCalledWith('hello'));
+
+    writeSpy.mockClear();
+    terminalTextSubject.next('hello');
+
+    await Promise.resolve();
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it('treats fresh terminalText$ as full write after disconnect resets cache', async () => {
+    const writeSpy = vi.spyOn(fixture.componentInstance.xterminal, 'write');
+    writeSpy.mockClear();
+
+    terminalTextSubject.next('hello');
+    await vi.waitFor(() => expect(writeSpy).toHaveBeenCalledWith('hello'));
+
+    isConnectedSubject.next(false);
+    await Promise.resolve();
+
+    writeSpy.mockClear();
+    isConnectedSubject.next(true);
+    terminalTextSubject.next('hello');
+
+    await vi.waitFor(() => expect(writeSpy).toHaveBeenCalledWith('hello'));
+  });
+
+  it('does not subscribe to receive$ for live mirroring', async () => {
+    const writeSpy = vi.spyOn(fixture.componentInstance.xterminal, 'write');
+    writeSpy.mockClear();
+
+    receiveSubject.next('raw-chunk');
+
+    await Promise.resolve();
+    expect(writeSpy).not.toHaveBeenCalledWith('raw-chunk');
   });
 });

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -99,10 +99,6 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
       });
 
     this.xterminal.reset();
-    this.console
-      .pipeTerminalOutputToSink$(this.terminalSink)
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe();
 
     this.serial.terminalText$
       .pipe(takeUntilDestroyed(this.destroyRef))

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -18,6 +18,7 @@ import {
 } from '@libs-terminal-util';
 import { attachTerminalInput } from '../terminal-input';
 import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import { SerialFacadeService } from '@libs-web-serial-data-access';
 import {
   TerminalConsoleOrchestrationService,
   type TerminalConsoleSink,
@@ -40,6 +41,7 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
   private consoleDomRef?: ElementRef<HTMLElement>;
 
   private console = inject(TerminalConsoleOrchestrationService);
+  private serial = inject(SerialFacadeService);
   private commandRequests = inject(TerminalCommandRequestService);
   private destroyRef = inject(DestroyRef);
 
@@ -52,6 +54,13 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
 
   /** キー入力可否（{@link TerminalConsoleOrchestrationService#isConnected$} のミラー） */
   private serialInputEnabled = false;
+
+  /**
+   * 直前に terminalText$ から受け取った累積全文。差分書き込みの基準として使う（issue #610）。
+   * `terminalText$` はライブラリが `\r` 再描画を畳んで累積で emit するため、
+   * 末尾差分のみを xterm に流し、prefix が一致しない場合は reset + 全文書き込みでフォールバックする。
+   */
+  private lastTerminalText = '';
 
   ngAfterViewInit(): void {
     this.configTerminal();
@@ -84,6 +93,9 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((c) => {
         this.serialInputEnabled = c;
+        if (!c) {
+          this.lastTerminalText = '';
+        }
       });
 
     this.xterminal.reset();
@@ -91,6 +103,10 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
       .pipeTerminalOutputToSink$(this.terminalSink)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe();
+
+    this.serial.terminalText$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((text) => this.writeTerminalDelta(text));
 
     merge(
       this.console.connectionEstablished$,
@@ -157,5 +173,28 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
     } catch {
       // Dimensions may be zero before layout stabilizes
     }
+  }
+
+  /**
+   * `terminalText$` の累積全文を xterm に流す（issue #610）。
+   * 通常は前回 emission の末尾に追加された差分のみを `write` し、
+   * prefix が変化した場合は安全側に寄せて `reset` してから全文を書き戻す。
+   */
+  private writeTerminalDelta(text: string): void {
+    if (text === this.lastTerminalText) {
+      return;
+    }
+    if (text.startsWith(this.lastTerminalText)) {
+      const delta = text.slice(this.lastTerminalText.length);
+      if (delta) {
+        this.xterminal.write(delta);
+      }
+    } else {
+      this.xterminal.reset();
+      if (text) {
+        this.xterminal.write(text);
+      }
+    }
+    this.lastTerminalText = text;
   }
 }


### PR DESCRIPTION
## Summary

- 親 issue [#609](https://github.com/gurezo/chirimen-lite-console/issues/609) の子 issue [#610](https://github.com/gurezo/chirimen-lite-console/issues/610) に対応し、`TerminalViewComponent` のライブ表示を `SerialFacadeService.terminalText$` 直購読へ移行する。
- `terminalText$` は `@gurezo/web-serial-rxjs` 内で `\r` 再描画を畳んだ累積全文を `scan` + `shareReplay` で emit するため、毎回の emission との差分のみを `xterm.write` する `writeTerminalDelta` を導入し、prefix が変化したケースは `xterm.reset()` + 全文書き戻しで安全側に倒す。
- 二重描画を避けるため、既存の `TerminalConsoleOrchestrationService.pipeTerminalOutputToSink$`（`receive$` ミラー）の UI 側購読を停止する。サービス本体・spec は親 #609 配下の後続サブ issue で削除予定のため温存し、`@deprecated` を付与した。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #610
- Refs #609

## What changed?

- `libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts`
  - `SerialFacadeService` を直接 inject し、`terminalText$` を `takeUntilDestroyed` で購読
  - `writeTerminalDelta(text)` を追加し、累積全文との差分のみを `xterm.write` / 不一致時は `xterm.reset()` + 全文書き戻し
  - `isConnected$` が `false` になったタイミングで差分基準キャッシュ `lastTerminalText` をリセット
  - `TerminalConsoleOrchestrationService.pipeTerminalOutputToSink$` の subscribe 呼び出しを削除
- `libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts`
  - クラスコメントを #610 移行後の構成に追記・整理
  - `pipeTerminalOutputToSink$` に `@deprecated` JSDoc を付与（シグネチャは温存）
- `libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts`
  - 旧 "forwards live receive\$ chunks to xterm.write" テストを撤去
  - 追加: 末尾差分のみ write される / prefix 不一致で reset + 全文 write される / 同値再 emission を skip する / 切断後の再接続で全文 write になる / `receive$` push で xterm.write されない

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details: なし（`pipeTerminalOutputToSink$` は `@deprecated` を付けたのみで挙動は不変）
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes: 後続サブ issue で `pipeTerminalOutputToSink$` および `receive$` 経路の整理を予定

## How to test

1. `pnpm nx test libs-terminal-ui`（18 tests / 3 files が green であること）
2. `pnpm nx test libs-terminal-feature`（既存テストにリグレッションがないこと）
3. 手動: 開発サーバ起動後、Pi Zero に接続し、シリアル受信内容が xterm に流れることを確認（`exec$` 経由のツールバー / 対話コマンド表示は本 PR スコープ外で従来挙動のまま）

## Environment (if relevant)

- Browser: Chromium 系
- OS: macOS / Windows / Linux
- Node version: pnpm-lock.yaml に準拠
- pnpm version: pnpm-lock.yaml に準拠

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed（クラスコメント / JSDoc を更新）
- [x] I considered error handling where relevant（prefix 不一致時の `reset` フォールバックを実装）


Made with [Cursor](https://cursor.com)