### PR TITLE
refactor(terminal): 対話入力を send$ に変更（#611）

### DIFF
--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
@@ -18,6 +18,7 @@ import { TerminalConsoleOrchestrationService } from './terminal-console-orchestr
 
 describe('TerminalConsoleOrchestrationService', () => {
   let execMock: ReturnType<typeof vi.fn>;
+  let sendMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     execMock = vi.fn().mockReturnValue(
@@ -25,6 +26,7 @@ describe('TerminalConsoleOrchestrationService', () => {
         stdout: 'ok\n',
       }),
     );
+    sendMock = vi.fn().mockReturnValue(of(undefined));
     TestBed.configureTestingModule({
       providers: [
         TerminalConsoleOrchestrationService,
@@ -32,6 +34,7 @@ describe('TerminalConsoleOrchestrationService', () => {
           provide: SerialFacadeService,
           useValue: {
             exec$: execMock,
+            send$: sendMock,
             isConnected$: of(true),
             connectionEstablished$: of(undefined),
             receive$: EMPTY,
@@ -54,31 +57,27 @@ describe('TerminalConsoleOrchestrationService', () => {
     TestBed.resetTestingModule();
   });
 
-  it('delegates exec with default serial options', async () => {
+  it('delegates interactive input to send$ with newline', async () => {
     const svc = TestBed.inject(TerminalConsoleOrchestrationService);
     await svc.runInteractiveCommand('uname', PI_ZERO_PROMPT);
-    expect(execMock).toHaveBeenCalledWith('uname', {
-      prompt: PI_ZERO_PROMPT,
-      timeout: SERIAL_TIMEOUT.DEFAULT,
-    });
+    expect(sendMock).toHaveBeenCalledWith('uname\n');
+    expect(execMock).not.toHaveBeenCalled();
   });
 
-  it('coerces ls to dumb TERM and single-column for serial exec', async () => {
+  it('coerces ls to dumb TERM and single-column for serial send', async () => {
     const svc = TestBed.inject(TerminalConsoleOrchestrationService);
     await svc.runInteractiveCommand('ls -la', PI_ZERO_PROMPT);
-    expect(execMock).toHaveBeenCalledWith(
-      "LC_ALL=C LANG=C TERM=dumb LS_COLORS= ls -1 -la </dev/null 2>&1 | sed 's/^[[:blank:]]*//' | cat",
-      {
-        prompt: PI_ZERO_PROMPT,
-        timeout: SERIAL_TIMEOUT.DEFAULT,
-      },
+    expect(sendMock).toHaveBeenCalledWith(
+      "LC_ALL=C LANG=C TERM=dumb LS_COLORS= ls -1 -la </dev/null 2>&1 | sed 's/^[[:blank:]]*//' | cat\n",
     );
+    expect(execMock).not.toHaveBeenCalled();
   });
 
   it('runToolbarCommand reports not_connected when serial is down', async () => {
     TestBed.overrideProvider(SerialFacadeService, {
       useValue: {
         exec$: execMock,
+        send$: sendMock,
         isConnected$: of(false),
         connectionEstablished$: of(undefined),
         receive$: EMPTY,
@@ -147,6 +146,7 @@ describe('TerminalConsoleOrchestrationService', () => {
     TestBed.overrideProvider(SerialFacadeService, {
       useValue: {
         exec$: execMock,
+        send$: sendMock,
         isConnected$: of(true),
         connectionEstablished$: of(undefined),
         receive$: chunks.asObservable(),
@@ -170,16 +170,17 @@ describe('TerminalConsoleOrchestrationService', () => {
     sub.unsubscribe();
   });
 
-  it('suppresses receive$ mirror while runInteractiveCommand executes', async () => {
+  it('does not suppress receive$ mirror while runInteractiveCommand awaits send$', async () => {
     const chunks = new Subject<string>();
-    let resolveExec!: (v: { stdout: string }) => void;
-    const execDone = new Promise<{ stdout: string }>((r) => {
-      resolveExec = r;
+    let resolveSend!: () => void;
+    const sendDone = new Promise<void>((r) => {
+      resolveSend = r;
     });
-    const deferredExec = vi.fn(() => from(execDone));
+    const deferredSend = vi.fn(() => from(sendDone));
     TestBed.overrideProvider(SerialFacadeService, {
       useValue: {
-        exec$: deferredExec,
+        exec$: execMock,
+        send$: deferredSend,
         isConnected$: of(true),
         connectionEstablished$: of(undefined),
         receive$: chunks.asObservable(),
@@ -199,14 +200,14 @@ describe('TerminalConsoleOrchestrationService', () => {
 
     const cmdPromise = svc.runInteractiveCommand('date', PI_ZERO_PROMPT);
     await Promise.resolve();
-    chunks.next('during-exec');
-    expect(write).not.toHaveBeenCalledWith('during-exec');
+    chunks.next('during-send');
+    expect(write).toHaveBeenCalledWith('during-send');
 
-    resolveExec({ stdout: `Sat Jan  1 12:00:00 UTC 2026\r\n${PI_ZERO_PROMPT} ` });
+    resolveSend();
     await cmdPromise;
 
-    chunks.next('after-exec');
-    expect(write).toHaveBeenCalledWith('after-exec');
+    chunks.next('after-send');
+    expect(write).toHaveBeenCalledWith('after-send');
 
     mirrorSub.unsubscribe();
   });
@@ -217,6 +218,7 @@ describe('TerminalConsoleOrchestrationService', () => {
     TestBed.overrideProvider(SerialFacadeService, {
       useValue: {
         exec$: execMock,
+        send$: sendMock,
         isConnected$: of(true),
         connectionEstablished$: of(undefined),
         receive$: chunks.asObservable(),

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
@@ -43,7 +43,9 @@ export interface TerminalConsoleSink {
  *
  * ### 対話コンソール表示
  *
- * `exec$` 経路（対話・ツールバー）ではライブミラーを抑止し、完了後の
+ * キーボード入力は issue #611 以降 {@link SerialFacadeService#send$} で生送信し、
+ * 表示は {@link SerialFacadeService#terminalText$} に任せる。
+ * ツールバー経由の {@link SerialFacadeService#exec$} ではライブミラーを抑止し、完了後の
  * {@link sanitizeSerialStdout} 結果だけを xterm に出して二重表示を避ける。
  */
 @Injectable({
@@ -73,23 +75,17 @@ export class TerminalConsoleOrchestrationService {
   }
 
   /**
-   * キーボードから入力されたコマンドを実行し、表示用に整形した stdout を返す。
+   * キーボードから入力されたコマンドをシリアルへ送る（issue #611）。
+   * 改行は {@link SerialFacadeService#send$} 用ペイロードに `\n` を付与する。
+   * 表示は {@link SerialFacadeService#terminalText$} 側のため、戻り値は空文字。
+   *
+   * @param _remotePrompt 互換のため残す（プロンプト待ちは行わない）
    */
-  runInteractiveCommand(command: string, remotePrompt: string): Promise<string> {
+  runInteractiveCommand(command: string, _remotePrompt: string): Promise<string> {
     return this.enqueueExec(async () => {
-      this.terminalMirrorSuppressDepth++;
-      try {
-        const send = coerceLsForSerialListing(command);
-        const { stdout } = await firstValueFrom(
-          this.serial.exec$(send, {
-            prompt: remotePrompt,
-            timeout: SERIAL_TIMEOUT.DEFAULT,
-          }),
-        );
-        return sanitizeSerialStdout(stdout, send, remotePrompt);
-      } finally {
-        this.terminalMirrorSuppressDepth--;
-      }
+      const payload = `${coerceLsForSerialListing(command)}\n`;
+      await firstValueFrom(this.serial.send$(payload));
+      return '';
     });
   }
 

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
@@ -54,6 +54,7 @@ describe('TerminalViewComponent', () => {
           isConnected$: isConnectedSubject.asObservable(),
           exec$: (...args: unknown[]) =>
             from(execMock(...(args as [string, unknown]))),
+          send$: () => of(undefined),
           connectionEstablished$: NEVER,
           receive$: receiveSubject.asObservable(),
           terminalText$: terminalTextSubject.asObservable(),


### PR DESCRIPTION
## Summary

ターミナルのキーボード入力を `exec$`（プロンプト待ち・stdout 返却）から `send$`（生送信＋改行）へ切り替え、表示は既存の `terminalText$` 購読に一本化する。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #611
- Related to #609

## What changed?

- `TerminalConsoleOrchestrationService#runInteractiveCommand` が `SerialFacadeService#send$` で `coerceLsForSerialListing` 結果に `\n` を付けて送信し、戻り値は空文字（ライブ表示は `terminalText$` 側）
- 対話経路から `terminalMirrorSuppressDepth` の増減を削除（`exec$` を使わないため）
- オーケストレーション／コンポーネントのテストを `send$` 前提に更新。非推奨 `receive$` ミラーは `send$` 待機中も抑止されないことを検証するテストに差し替え

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. シリアル接続後、コンソールでコマンドを入力して Enter → シェルのエコー・結果が `terminalText$` 経由で従来どおり表示されること
2. ツールバーからコマンド実行 → 従来どおり `exec$`（プロンプト待ち）であること

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

## 備考

実機シェルが `\r\n` を厳密に要求する場合は、別途フォローで調整の余地あり。

Made with [Cursor](https://cursor.com)