### PR TITLE
refactor(terminal): Terminal UI から exec$ 依存を削除する (#612)

### DIFF
--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
@@ -13,19 +13,14 @@ import {
   PiZeroSessionService,
   SerialFacadeService,
 } from '@libs-web-serial-data-access';
-import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
+import { coerceLsForSerialListing } from '@libs-terminal-util';
+import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
 import { TerminalConsoleOrchestrationService } from './terminal-console-orchestration.service';
 
 describe('TerminalConsoleOrchestrationService', () => {
-  let execMock: ReturnType<typeof vi.fn>;
   let sendMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    execMock = vi.fn().mockReturnValue(
-      of({
-        stdout: 'ok\n',
-      }),
-    );
     sendMock = vi.fn().mockReturnValue(of(undefined));
     TestBed.configureTestingModule({
       providers: [
@@ -33,7 +28,6 @@ describe('TerminalConsoleOrchestrationService', () => {
         {
           provide: SerialFacadeService,
           useValue: {
-            exec$: execMock,
             send$: sendMock,
             isConnected$: of(true),
             connectionEstablished$: of(undefined),
@@ -61,7 +55,6 @@ describe('TerminalConsoleOrchestrationService', () => {
     const svc = TestBed.inject(TerminalConsoleOrchestrationService);
     await svc.runInteractiveCommand('uname', PI_ZERO_PROMPT);
     expect(sendMock).toHaveBeenCalledWith('uname\n');
-    expect(execMock).not.toHaveBeenCalled();
   });
 
   it('coerces ls to dumb TERM and single-column for serial send', async () => {
@@ -70,13 +63,11 @@ describe('TerminalConsoleOrchestrationService', () => {
     expect(sendMock).toHaveBeenCalledWith(
       "LC_ALL=C LANG=C TERM=dumb LS_COLORS= ls -1 -la </dev/null 2>&1 | sed 's/^[[:blank:]]*//' | cat\n",
     );
-    expect(execMock).not.toHaveBeenCalled();
   });
 
   it('runToolbarCommand reports not_connected when serial is down', async () => {
     TestBed.overrideProvider(SerialFacadeService, {
       useValue: {
-        exec$: execMock,
         send$: sendMock,
         isConnected$: of(false),
         connectionEstablished$: of(undefined),
@@ -88,7 +79,16 @@ describe('TerminalConsoleOrchestrationService', () => {
     const svc = TestBed.inject(TerminalConsoleOrchestrationService);
     const result = await svc.runToolbarCommand('ls', PI_ZERO_PROMPT);
     expect(result).toEqual({ status: 'not_connected' });
-    expect(execMock).not.toHaveBeenCalled();
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it('runToolbarCommand sends coerced command via send$ when connected', async () => {
+    const svc = TestBed.inject(TerminalConsoleOrchestrationService);
+    const result = await svc.runToolbarCommand('ls', PI_ZERO_PROMPT);
+    expect(result).toEqual({ status: 'success', output: '' });
+    expect(sendMock).toHaveBeenCalledWith(
+      `${coerceLsForSerialListing('ls')}\n`,
+    );
   });
 
   it('bootstrapAfterConnect$ emits skip sink messages when shouldRun is false', async () => {
@@ -145,7 +145,6 @@ describe('TerminalConsoleOrchestrationService', () => {
     const chunks = new Subject<string>();
     TestBed.overrideProvider(SerialFacadeService, {
       useValue: {
-        exec$: execMock,
         send$: sendMock,
         isConnected$: of(true),
         connectionEstablished$: of(undefined),
@@ -179,7 +178,6 @@ describe('TerminalConsoleOrchestrationService', () => {
     const deferredSend = vi.fn(() => from(sendDone));
     TestBed.overrideProvider(SerialFacadeService, {
       useValue: {
-        exec$: execMock,
         send$: deferredSend,
         isConnected$: of(true),
         connectionEstablished$: of(undefined),
@@ -217,7 +215,6 @@ describe('TerminalConsoleOrchestrationService', () => {
     const bootstrapDone$ = new Subject<void>();
     TestBed.overrideProvider(SerialFacadeService, {
       useValue: {
-        exec$: execMock,
         send$: sendMock,
         isConnected$: of(true),
         connectionEstablished$: of(undefined),

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
@@ -3,8 +3,7 @@ import {
   PiZeroSessionService,
   SerialFacadeService,
 } from '@libs-web-serial-data-access';
-import { SERIAL_TIMEOUT } from '@libs-web-serial-util';
-import { coerceLsForSerialListing, sanitizeSerialStdout } from '@libs-terminal-util';
+import { coerceLsForSerialListing } from '@libs-terminal-util';
 import {
   EMPTY,
   Observable,
@@ -24,8 +23,9 @@ export interface TerminalConsoleSink {
 }
 
 /**
- * ターミナル画面向けにシリアル接続・Pi Zero bootstrap・exec を束ねる（issue #563）。
- * prompt / timeout / sanitize はここに集約し、component は表示用 sink と購読のみに寄せる。
+ * ターミナル画面向けにシリアル接続・Pi Zero bootstrap・送信を束ねる（issue #563）。
+ * 対話・ツールバーとも {@link SerialFacadeService#send$} で送信し、表示は
+ * {@link SerialFacadeService#terminalText$} に任せる（issue #610 / #611 / #612）。
  *
  * ### ライブ表示の経路（issue #610 / 親 #609）
  *
@@ -41,12 +41,11 @@ export interface TerminalConsoleSink {
  * Issue #610 で UI 側購読を停止し、シグネチャと spec のみ温存している
  * （親 #609 配下の後続サブ issue で本メソッド自体を削除予定）。
  *
- * ### 対話コンソール表示
+ * ### 対話・ツールバー（issue #611 / #612）
  *
- * キーボード入力は issue #611 以降 {@link SerialFacadeService#send$} で生送信し、
- * 表示は {@link SerialFacadeService#terminalText$} に任せる。
- * ツールバー経由の {@link SerialFacadeService#exec$} ではライブミラーを抑止し、完了後の
- * {@link sanitizeSerialStdout} 結果だけを xterm に出して二重表示を避ける。
+ * キーボード入力もツールバー経由のコマンドも {@link SerialFacadeService#send$} で
+ * 送信する。完了待ちや stdout の切り出しは行わず、シェル出力は
+ * {@link SerialFacadeService#terminalText$} 側のストリームに任せる。
  */
 @Injectable({
   providedIn: 'root',
@@ -56,23 +55,11 @@ export class TerminalConsoleOrchestrationService {
   private readonly piZeroSession = inject(PiZeroSessionService);
   private activeBootstrap$: Observable<void> | null = null;
   private activeBootstrapEpoch: number | null = null;
-  /** bootstrap / exec 中は 0 より大きくし、{@link #pipeTerminalOutputToSink$} を止める */
+  /** bootstrap 中は 0 より大きくし、{@link #pipeTerminalOutputToSink$} を止める */
   private terminalMirrorSuppressDepth = 0;
-
-  /** 対話入力とツールバー経由の exec を直列化する */
-  private execTail: Promise<void> = Promise.resolve();
 
   readonly connectionEstablished$ = this.serial.connectionEstablished$;
   readonly isConnected$ = this.serial.isConnected$;
-
-  private enqueueExec<T>(job: () => Promise<T>): Promise<T> {
-    const run = this.execTail.then(() => job());
-    this.execTail = run.then(
-      () => undefined,
-      () => undefined,
-    );
-    return run;
-  }
 
   /**
    * キーボードから入力されたコマンドをシリアルへ送る（issue #611）。
@@ -81,51 +68,44 @@ export class TerminalConsoleOrchestrationService {
    *
    * @param _remotePrompt 互換のため残す（プロンプト待ちは行わない）
    */
-  runInteractiveCommand(command: string, _remotePrompt: string): Promise<string> {
-    return this.enqueueExec(async () => {
-      const payload = `${coerceLsForSerialListing(command)}\n`;
-      await firstValueFrom(this.serial.send$(payload));
-      return '';
-    });
+  async runInteractiveCommand(
+    command: string,
+    _remotePrompt: string,
+  ): Promise<string> {
+    const payload = `${coerceLsForSerialListing(command)}\n`;
+    await firstValueFrom(this.serial.send$(payload));
+    return '';
   }
 
   /**
-   * ツールバー等から要求されたコマンドを実行する。
+   * ツールバー等から要求されたコマンドを {@link SerialFacadeService#send$} で送る（issue #612）。
+   * シェル側の完了や stdout の取得は行わず、表示は {@link SerialFacadeService#terminalText$} に任せる。
+   *
+   * @param _remotePrompt 互換のため残す（プロンプト待ちは行わない）
    */
   async runToolbarCommand(
     cmd: string,
-    remotePrompt: string,
+    _remotePrompt: string,
   ): Promise<
     | { status: 'success'; output: string }
     | { status: 'not_connected' }
     | { status: 'error'; message: string }
   > {
-    return this.enqueueExec(async () => {
-      const connected = await firstValueFrom(
-        this.serial.isConnected$.pipe(take(1)),
-      );
-      if (!connected) {
-        return { status: 'not_connected' };
-      }
-      this.terminalMirrorSuppressDepth++;
-      try {
-        const send = coerceLsForSerialListing(cmd);
-        const { stdout } = await firstValueFrom(
-          this.serial.exec$(send, {
-            prompt: remotePrompt,
-            timeout: SERIAL_TIMEOUT.DEFAULT,
-          }),
-        );
-        const output = sanitizeSerialStdout(stdout, send, remotePrompt);
-        return { status: 'success', output };
-      } catch (error: unknown) {
-        const message =
-          error instanceof Error ? error.message : String(error);
-        return { status: 'error', message };
-      } finally {
-        this.terminalMirrorSuppressDepth--;
-      }
-    });
+    const connected = await firstValueFrom(
+      this.serial.isConnected$.pipe(take(1)),
+    );
+    if (!connected) {
+      return { status: 'not_connected' };
+    }
+    try {
+      const payload = `${coerceLsForSerialListing(cmd)}\n`;
+      await firstValueFrom(this.serial.send$(payload));
+      return { status: 'success', output: '' };
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : String(error);
+      return { status: 'error', message };
+    }
   }
 
   /**

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { BehaviorSubject, NEVER, Subject, from, of } from 'rxjs';
+import { BehaviorSubject, NEVER, Subject, of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@xterm/xterm', () => {
@@ -24,13 +24,14 @@ import {
   PiZeroSessionService,
   SerialFacadeService,
 } from '@libs-web-serial-data-access';
-import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial-util';
+import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
+import { coerceLsForSerialListing } from '@libs-terminal-util';
 import { TerminalCommandRequestService } from '@libs-terminal-util';
 import { TerminalViewComponent } from './terminal-view.component';
 
 describe('TerminalViewComponent', () => {
   let fixture: ComponentFixture<TerminalViewComponent>;
-  let execMock: ReturnType<typeof vi.fn>;
+  let sendMock: ReturnType<typeof vi.fn>;
   let shouldRunAfterConnectMock: ReturnType<typeof vi.fn>;
   let runAfterConnectMock: ReturnType<typeof vi.fn>;
   let receiveSubject: Subject<string>;
@@ -38,9 +39,7 @@ describe('TerminalViewComponent', () => {
   let isConnectedSubject: BehaviorSubject<boolean>;
 
   beforeEach(async () => {
-    execMock = vi.fn().mockResolvedValue({
-      stdout: `i2cdetect -y 1\n     0  1\n${PI_ZERO_PROMPT} `,
-    });
+    sendMock = vi.fn().mockReturnValue(of(undefined));
     receiveSubject = new Subject<string>();
     terminalTextSubject = new Subject<string>();
     isConnectedSubject = new BehaviorSubject<boolean>(true);
@@ -52,9 +51,8 @@ describe('TerminalViewComponent', () => {
       .overrideProvider(SerialFacadeService, {
         useValue: {
           isConnected$: isConnectedSubject.asObservable(),
-          exec$: (...args: unknown[]) =>
-            from(execMock(...(args as [string, unknown]))),
-          send$: () => of(undefined),
+          send$: (...args: unknown[]) =>
+            sendMock(...(args as [string])),
           connectionEstablished$: NEVER,
           receive$: receiveSubject.asObservable(),
           terminalText$: terminalTextSubject.asObservable(),
@@ -82,15 +80,14 @@ describe('TerminalViewComponent', () => {
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('runs toolbar-requested commands via serial exec', async () => {
+  it('runs toolbar-requested commands via serial send$', async () => {
     const requests = TestBed.inject(TerminalCommandRequestService);
     requests.requestCommand('i2cdetect -y 1');
 
     await vi.waitFor(() => {
-      expect(execMock).toHaveBeenCalledWith('i2cdetect -y 1', {
-        prompt: PI_ZERO_PROMPT,
-        timeout: SERIAL_TIMEOUT.DEFAULT,
-      });
+      expect(sendMock).toHaveBeenCalledWith(
+        `${coerceLsForSerialListing('i2cdetect -y 1')}\n`,
+      );
     });
   });
 

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -146,17 +146,13 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
               this.xterminal.write('$ ');
               return;
             }
-            this.xterminal.writeln(`$ ${cmd}`);
             if (result.status === 'error') {
+              this.xterminal.writeln(`$ ${cmd}`);
               this.xterminal.writeln(`\r\nCommand failed: ${result.message}`);
               this.xterminal.write('$ ');
               return;
             }
-            const out = result.output;
-            if (out) {
-              this.xterminal.write(out);
-            }
-            this.xterminal.write('\r\n$ ');
+            // success: シェル出力とプロンプトは terminalText$ 差分描画に任せる（#612）
           },
         );
       },


### PR DESCRIPTION
## Summary

Terminal UI オーケストレーションから `exec$`・直列キュー（`execTail` / `enqueueExec`）を削除し、ツールバーコマンドも対話入力と同様に `send$` のみで送信する。表示は既存の `terminalText$` 差分描画に統一する（#612 / 親 #609）。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #612
- Related to #609

## What changed?

- `TerminalConsoleOrchestrationService` から `execTail` / `enqueueExec` / `firstValueFrom(exec$)` を削除し、`runToolbarCommand` は接続確認後に `send$` で改行付きペイロードを送るだけに変更した。
- `runInteractiveCommand` もキューなしで `send$` を直接待つようにした。
- ツールバー成功時は xterm へ `$ コマンド` や追加プロンプトを書かず、`terminalText$` との二重表示を避けた。未接続・送信エラー時は従来どおり UI 側メッセージを出す。
- テストから `exec$` モックを除去し、`send$` 呼び出しを検証するようにした。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

`runToolbarCommand` の戻り値型は維持するが、成功時は常に `output: ''` となり、従来の `exec$` にあったプロンプト待ち・タイムアウト・stdout 切り出しは行わない（シェル出力はストリーム側）。

## How to test

1. `pnpm nx test libs-terminal-ui` を実行し、すべて成功することを確認する。
2. 実機またはシミュレーションでシリアル接続後、ツールバーからコマンドを実行し、ターミナルに重複なく出力されることを確認する。

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant
