### PR TITLE
refactor(terminal): UI 側の stdout 整形を排除し生データ表示を確定 (#613)

### DIFF
--- a/docs/serial-architecture.md
+++ b/docs/serial-architecture.md
@@ -48,7 +48,7 @@ Issue #590 / [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) 
 詳細な対応表は [`libs/web-serial/data-access/README.md`](../libs/web-serial/data-access/README.md) を正とする。要約すると次のとおり。
 
 - **ターミナル表示（xterm 等・TTY 再描画を含むライブ表示）**  
-  - `terminalText$` のみを購読する。
+  - `terminalText$` のみを購読する。受信テキストをそのまま xterm に書き込み、`sanitizeSerialStdout` は **ターミナル UI 経路では使用しない**（[#613](https://github.com/gurezo/chirimen-lite-console/issues/613)）。
 - **コマンド実行・プロンプト待ち・ログイン判定など「行」単位の処理**  
   - `lines$` と同根の **`commandResultLines$` / `getReadStream()`**（複数購読で行が取り合いにならないようマルチキャスト）。**プロンプト検出に `receiveReplay$` 単体は寄せない**（チャンク境界と ANSI・行処理の齟齬を避ける）。
 - **単一購読で `SerialSession.lines$` をそのまま見たい場合**  
@@ -56,7 +56,7 @@ Issue #590 / [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) 
 - **リプレイ不要な生チャンクが必要な場合**  
   - `receive$`。
 - **exec 結果の整形表示（エコー削り・プロンプト削り・ANSI 除去）**  
-  - `@libs-terminal-util` の `sanitizeSerialStdout`（ライブ表示の `\r` 収束は行わず、`terminalText$` に委譲）。
+  - `@libs-terminal-util` の `sanitizeSerialStdout`（ライブ表示の `\r` 収束は行わず、`terminalText$` に委譲）。利用は **exec キャプチャ後の後処理**に限定し、残存例は Pi Zero 初期化コマンドのコンソールログや Remote の一覧パースなど（親 [#609](https://github.com/gurezo/chirimen-lite-console/issues/609) の非対象フロー）。
 
 ## 新規実装をどちらのリポジトリに置くか
 
@@ -72,3 +72,4 @@ Issue #590 / [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) 
 - [#557](https://github.com/gurezo/chirimen-lite-console/issues/557) — `SerialSession` を正としたアプリ側の薄型化（本ドキュメント執筆時点でコード上の受け入れ条件を満たしている旨を PR で確認済みとする想定）
 - [#568](https://github.com/gurezo/chirimen-lite-console/issues/568) — 本ドキュメントの追加
 - [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) — `terminalText$` への表示委譲と facade 公開面の整理
+- [#613](https://github.com/gurezo/chirimen-lite-console/issues/613) — ターミナル UI から stdout 整形（`sanitizeSerialStdout`）を排除し、表示は `terminalText$` の生データに統一

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
@@ -57,6 +57,12 @@ describe('TerminalConsoleOrchestrationService', () => {
     expect(sendMock).toHaveBeenCalledWith('uname\n');
   });
 
+  it('runInteractiveCommand returns empty string (no stdout capture)', async () => {
+    const svc = TestBed.inject(TerminalConsoleOrchestrationService);
+    const out = await svc.runInteractiveCommand('uname -a', PI_ZERO_PROMPT);
+    expect(out).toBe('');
+  });
+
   it('coerces ls to dumb TERM and single-column for serial send', async () => {
     const svc = TestBed.inject(TerminalConsoleOrchestrationService);
     await svc.runInteractiveCommand('ls -la', PI_ZERO_PROMPT);
@@ -89,6 +95,15 @@ describe('TerminalConsoleOrchestrationService', () => {
     expect(sendMock).toHaveBeenCalledWith(
       `${coerceLsForSerialListing('ls')}\n`,
     );
+  });
+
+  it('runToolbarCommand success always has empty output (no stdout path)', async () => {
+    const svc = TestBed.inject(TerminalConsoleOrchestrationService);
+    const result = await svc.runToolbarCommand('echo hello', PI_ZERO_PROMPT);
+    expect(result.status).toBe('success');
+    if (result.status === 'success') {
+      expect(result.output).toBe('');
+    }
   });
 
   it('bootstrapAfterConnect$ emits skip sink messages when shouldRun is false', async () => {

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
@@ -46,6 +46,11 @@ export interface TerminalConsoleSink {
  * キーボード入力もツールバー経由のコマンドも {@link SerialFacadeService#send$} で
  * 送信する。完了待ちや stdout の切り出しは行わず、シェル出力は
  * {@link SerialFacadeService#terminalText$} 側のストリームに任せる。
+ *
+ * ### stdout 整形（issue #613）
+ *
+ * `sanitizeSerialStdout`（@libs-terminal-util）のような exec キャプチャ向けの stdout
+ * 整形は、ターミナル UI 経路では使用しない（送信のみ・表示は `terminalText$`）。
  */
 @Injectable({
   providedIn: 'root',

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
@@ -136,6 +136,16 @@ describe('TerminalViewComponent', () => {
     });
   });
 
+  it('forwards terminalText$ payload to xterm without sanitizing ANSI/CR/TAB', async () => {
+    const writeSpy = vi.spyOn(fixture.componentInstance.xterminal, 'write');
+    writeSpy.mockClear();
+
+    const raw = '\u001b[2K\ra\tb\r\n$ ';
+    terminalTextSubject.next(raw);
+
+    await vi.waitFor(() => expect(writeSpy).toHaveBeenCalledWith(raw));
+  });
+
   it('skips re-emission when terminalText$ value is identical to previous', async () => {
     const writeSpy = vi.spyOn(fixture.componentInstance.xterminal, 'write');
     writeSpy.mockClear();

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -24,6 +24,11 @@ import {
   type TerminalConsoleSink,
 } from './terminal-console-orchestration.service';
 
+/**
+ * ターミナル表示専用コンポーネント。ライブ表示は {@link SerialFacadeService#terminalText$}
+ * の累積テキストを差分だけ xterm に書き込む（issue #610）。
+ * **stdout の整形**（`sanitizeSerialStdout` 等）は本コンポーネントでは行わない（issue #613）。
+ */
 @Component({
   selector: 'choh-terminal-view',
   host: {
@@ -152,7 +157,7 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
               this.xterminal.write('$ ');
               return;
             }
-            // success: シェル出力とプロンプトは terminalText$ 差分描画に任せる（#612）
+            // success: シェル出力とプロンプトは terminalText$ 差分描画に任せる（#612 / #613）
           },
         );
       },


### PR DESCRIPTION
## Summary

ターミナル表示は `terminalText$` の生データを xterm に流す方針（親 #609 / #610–#612）に合わせ、**Terminal UI 経路で `sanitizeSerialStdout` 等の stdout 整形を行わない**ことを spec・JSDoc・`docs/serial-architecture.md` で明文化・回帰防止します。`sanitizeSerialStdout` 自体は login/setup や Remote 等（#609 非対象）で引き続き利用します。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Refs #609
- Closes #613

## What changed?

- `TerminalViewComponent` spec: ANSI / CR / TAB を含む `terminalText$` を加工せず `xterm.write` に渡すことを検証
- `TerminalConsoleOrchestrationService` spec: `runInteractiveCommand` / `runToolbarCommand` が stdout を取得しない（戻りの `output` は常に空）ことを明示
- 上記2ファイルの JSDoc に #613（UI で stdout 整形しない）を追記
- `docs/serial-architecture.md` に、ターミナル UI は `sanitizeSerialStdout` を使わない旨と、残存利用箇所の目安を追記

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm nx test libs-terminal-ui`
2. `pnpm nx lint libs-terminal-ui`

## Environment (if relevant)

- Browser: N/A
- OS: macOS / Windows / Linux
- Node version: （ローカルに合わせる）
- pnpm version: （ローカルに合わせる）

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant
