### PR TITLE
refactor(terminal): アプリ側のプロンプト描画を削除 (#614)

### DIFF
--- a/libs/terminal/feature/src/lib/terminal-page/terminal-page.component.html
+++ b/libs/terminal/feature/src/lib/terminal-page/terminal-page.component.html
@@ -1,5 +1,5 @@
 <div
   class="box-border h-full min-h-0 min-w-0 bg-black pt-1 pr-1 pb-1 pl-1"
 >
-  <choh-terminal-view [remotePrompt]="remotePrompt" />
+  <choh-terminal-view />
 </div>

--- a/libs/terminal/feature/src/lib/terminal-page/terminal-page.component.ts
+++ b/libs/terminal/feature/src/lib/terminal-page/terminal-page.component.ts
@@ -1,12 +1,9 @@
 import { Component } from '@angular/core';
 import { TerminalViewComponent } from '@libs-terminal-ui';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
 
 @Component({
   selector: 'choh-terminal',
   imports: [TerminalViewComponent],
   templateUrl: './terminal-page.component.html',
 })
-export default class TerminalPageComponent {
-  readonly remotePrompt = PI_ZERO_PROMPT;
-}
+export default class TerminalPageComponent {}

--- a/libs/terminal/ui/src/lib/terminal-input.ts
+++ b/libs/terminal/ui/src/lib/terminal-input.ts
@@ -31,12 +31,11 @@ export function attachTerminalInput(
       inputBuffer = '';
 
       if (!command) {
-        terminal.write('$ ');
         return;
       }
 
       if (!onCommand) {
-        terminal.write(`(No command handler)\r\n$ `);
+        terminal.writeln('(No command handler)');
         return;
       }
 
@@ -45,13 +44,11 @@ export function attachTerminalInput(
           if (stdout) {
             terminal.write(stdout);
           }
-          terminal.write('\r\n$ ');
         })
         .catch((error) => {
           const message =
             error instanceof Error ? error.message : String(error);
           terminal.writeln(`\r\nCommand failed: ${message}`);
-          terminal.write('$ ');
         });
     } else if (ev.code === 'Backspace') {
       if (inputBuffer.length > 0) {

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
@@ -125,7 +125,6 @@ describe('TerminalConsoleOrchestrationService', () => {
     expect(write).toHaveBeenCalledWith(
       '\r\nprefix 初期化済みのためスキップします。\r\n',
     );
-    expect(write).toHaveBeenCalledWith('\r\n$ ');
   });
 
   it('bootstrapAfterConnect$ deduplicates concurrent bootstrap calls in same epoch', async () => {

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
@@ -14,7 +14,6 @@ import {
   SerialFacadeService,
 } from '@libs-web-serial-data-access';
 import { coerceLsForSerialListing } from '@libs-terminal-util';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
 import { TerminalConsoleOrchestrationService } from './terminal-console-orchestration.service';
 
 describe('TerminalConsoleOrchestrationService', () => {
@@ -53,19 +52,19 @@ describe('TerminalConsoleOrchestrationService', () => {
 
   it('delegates interactive input to send$ with newline', async () => {
     const svc = TestBed.inject(TerminalConsoleOrchestrationService);
-    await svc.runInteractiveCommand('uname', PI_ZERO_PROMPT);
+    await svc.runInteractiveCommand('uname');
     expect(sendMock).toHaveBeenCalledWith('uname\n');
   });
 
   it('runInteractiveCommand returns empty string (no stdout capture)', async () => {
     const svc = TestBed.inject(TerminalConsoleOrchestrationService);
-    const out = await svc.runInteractiveCommand('uname -a', PI_ZERO_PROMPT);
+    const out = await svc.runInteractiveCommand('uname -a');
     expect(out).toBe('');
   });
 
   it('coerces ls to dumb TERM and single-column for serial send', async () => {
     const svc = TestBed.inject(TerminalConsoleOrchestrationService);
-    await svc.runInteractiveCommand('ls -la', PI_ZERO_PROMPT);
+    await svc.runInteractiveCommand('ls -la');
     expect(sendMock).toHaveBeenCalledWith(
       "LC_ALL=C LANG=C TERM=dumb LS_COLORS= ls -1 -la </dev/null 2>&1 | sed 's/^[[:blank:]]*//' | cat\n",
     );
@@ -83,14 +82,14 @@ describe('TerminalConsoleOrchestrationService', () => {
       },
     });
     const svc = TestBed.inject(TerminalConsoleOrchestrationService);
-    const result = await svc.runToolbarCommand('ls', PI_ZERO_PROMPT);
+    const result = await svc.runToolbarCommand('ls');
     expect(result).toEqual({ status: 'not_connected' });
     expect(sendMock).not.toHaveBeenCalled();
   });
 
   it('runToolbarCommand sends coerced command via send$ when connected', async () => {
     const svc = TestBed.inject(TerminalConsoleOrchestrationService);
-    const result = await svc.runToolbarCommand('ls', PI_ZERO_PROMPT);
+    const result = await svc.runToolbarCommand('ls');
     expect(result).toEqual({ status: 'success', output: '' });
     expect(sendMock).toHaveBeenCalledWith(
       `${coerceLsForSerialListing('ls')}\n`,
@@ -99,7 +98,7 @@ describe('TerminalConsoleOrchestrationService', () => {
 
   it('runToolbarCommand success always has empty output (no stdout path)', async () => {
     const svc = TestBed.inject(TerminalConsoleOrchestrationService);
-    const result = await svc.runToolbarCommand('echo hello', PI_ZERO_PROMPT);
+    const result = await svc.runToolbarCommand('echo hello');
     expect(result.status).toBe('success');
     if (result.status === 'success') {
       expect(result.output).toBe('');
@@ -210,7 +209,7 @@ describe('TerminalConsoleOrchestrationService', () => {
     const svc = TestBed.inject(TerminalConsoleOrchestrationService);
     const mirrorSub = svc.pipeTerminalOutputToSink$({ write }).subscribe();
 
-    const cmdPromise = svc.runInteractiveCommand('date', PI_ZERO_PROMPT);
+    const cmdPromise = svc.runInteractiveCommand('date');
     await Promise.resolve();
     chunks.next('during-send');
     expect(write).toHaveBeenCalledWith('during-send');

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
@@ -140,7 +140,6 @@ export class TerminalConsoleOrchestrationService {
       catchError(() => EMPTY),
       finalize(() => {
         this.terminalMirrorSuppressDepth--;
-        sink.write('\r\n$ ');
         if (this.activeBootstrapEpoch === epoch) {
           this.activeBootstrap$ = null;
           this.activeBootstrapEpoch = null;

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
@@ -70,13 +70,8 @@ export class TerminalConsoleOrchestrationService {
    * キーボードから入力されたコマンドをシリアルへ送る（issue #611）。
    * 改行は {@link SerialFacadeService#send$} 用ペイロードに `\n` を付与する。
    * 表示は {@link SerialFacadeService#terminalText$} 側のため、戻り値は空文字。
-   *
-   * @param _remotePrompt 互換のため残す（プロンプト待ちは行わない）
    */
-  async runInteractiveCommand(
-    command: string,
-    _remotePrompt: string,
-  ): Promise<string> {
+  async runInteractiveCommand(command: string): Promise<string> {
     const payload = `${coerceLsForSerialListing(command)}\n`;
     await firstValueFrom(this.serial.send$(payload));
     return '';
@@ -85,13 +80,8 @@ export class TerminalConsoleOrchestrationService {
   /**
    * ツールバー等から要求されたコマンドを {@link SerialFacadeService#send$} で送る（issue #612）。
    * シェル側の完了や stdout の取得は行わず、表示は {@link SerialFacadeService#terminalText$} に任せる。
-   *
-   * @param _remotePrompt 互換のため残す（プロンプト待ちは行わない）
    */
-  async runToolbarCommand(
-    cmd: string,
-    _remotePrompt: string,
-  ): Promise<
+  async runToolbarCommand(cmd: string): Promise<
     | { status: 'success'; output: string }
     | { status: 'not_connected' }
     | { status: 'error'; message: string }

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
@@ -24,7 +24,6 @@ import {
   PiZeroSessionService,
   SerialFacadeService,
 } from '@libs-web-serial-data-access';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
 import { coerceLsForSerialListing } from '@libs-terminal-util';
 import { TerminalCommandRequestService } from '@libs-terminal-util';
 import { TerminalViewComponent } from './terminal-view.component';

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -125,14 +125,6 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
       )
       .subscribe();
 
-    this.console.isConnected$
-      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
-      .subscribe((connected) => {
-        if (!connected) {
-          this.xterminal.writeln('$ ');
-        }
-      });
-
     attachTerminalInput(
       this.xterminal,
       async (command) => {
@@ -146,15 +138,15 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
         void this.console.runToolbarCommand(cmd, this.remotePrompt()).then(
           (result) => {
             if (result.status === 'not_connected') {
-              this.xterminal.writeln(`$ ${cmd}`);
-              this.xterminal.writeln('Command failed: Serial port not connected');
-              this.xterminal.write('$ ');
+              this.xterminal.writeln(
+                `Command failed: Serial port not connected (${cmd})`,
+              );
               return;
             }
             if (result.status === 'error') {
-              this.xterminal.writeln(`$ ${cmd}`);
-              this.xterminal.writeln(`\r\nCommand failed: ${result.message}`);
-              this.xterminal.write('$ ');
+              this.xterminal.writeln(
+                `Command failed: ${result.message} (${cmd})`,
+              );
               return;
             }
             // success: シェル出力とプロンプトは terminalText$ 差分描画に任せる（#612 / #613）

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -6,7 +6,6 @@ import {
   OnDestroy,
   ViewChild,
   inject,
-  input,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subscription, filter, merge, switchMap, take } from 'rxjs';
@@ -17,7 +16,6 @@ import {
   xtermConsoleConfigOptions,
 } from '@libs-terminal-util';
 import { attachTerminalInput } from '../terminal-input';
-import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
 import { SerialFacadeService } from '@libs-web-serial-data-access';
 import {
   TerminalConsoleOrchestrationService,
@@ -37,11 +35,6 @@ import {
   templateUrl: './terminal-view.component.html',
 })
 export class TerminalViewComponent implements AfterViewInit, OnDestroy {
-  /**
-   * シリアル側のシェルプロンプト（サービス側の prompt 待機に渡す）
-   */
-  readonly remotePrompt = input<string>(PI_ZERO_PROMPT);
-
   @ViewChild('consoleDom', { read: ElementRef })
   private consoleDomRef?: ElementRef<HTMLElement>;
 
@@ -128,14 +121,14 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
     attachTerminalInput(
       this.xterminal,
       async (command) => {
-        return this.console.runInteractiveCommand(command, this.remotePrompt());
+        return this.console.runInteractiveCommand(command);
       },
       () => this.serialInputEnabled,
     );
 
     this.commandRequestSub = this.commandRequests.commandRequests$.subscribe(
       (cmd) => {
-        void this.console.runToolbarCommand(cmd, this.remotePrompt()).then(
+        void this.console.runToolbarCommand(cmd).then(
           (result) => {
             if (result.status === 'not_connected') {
               this.xterminal.writeln(


### PR DESCRIPTION
## Summary

親 Issue #609 の Sub Issue #614 に対応し、ターミナル UI でアプリ側が描画していた `$ ` 相当のプロンプトと、それに紐づく入力の引き回しを削除しました。プロンプト表示はシリアルの `terminalText$`（デバイス出力）に任せます。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #614
- Refs #609

## What changed?

- `attachTerminalInput`: Enter 後の `$ ` 再描画、空コマンド／エラー／ハンドラ無し時の `$ ` を削除
- `TerminalViewComponent`: 未接続時の `$ ` 表示を削除。ツールバー失敗時は `$ ` でコマンド行を偽装せず、プレーンメッセージに変更
- `TerminalConsoleOrchestrationService`: `bootstrapAfterConnect$` 完了時の `sink.write('\r\n$ ')` を削除。`runInteractiveCommand` / `runToolbarCommand` から第2引数（旧 `remotePrompt`）を削除
- `TerminalPageComponent`: `[remotePrompt]` バインドと `PI_ZERO_PROMPT` 依存を削除
- 上記に合わせて単体テストを更新

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - Details: `choh-terminal-view` の `remotePrompt` 入力を削除。カスタムプロンプト文字列を渡していた利用者はバインドを外してください（表示はデバイス側に依存）。
- [ ] This change is backward compatible
- [x] This change introduces a breaking change
  - Migration notes: テンプレートから `[remotePrompt]` を削除済み。他リポジトリで `choh-terminal-view` をラップしている場合は同様に入力を外す。

## How to test

1. `pnpm nx run libs-terminal-ui:test`
2. `pnpm nx run libs-terminal-feature:test`
3. 実機またはモックで、対話入力・ツールバー実行後にアプリ独自の `$ ` が付かないこと、およびシェルプロンプトが `terminalText$` 経由で一貫することを確認

## Environment (if relevant)

- Browser: （任意）
- OS: macOS / Windows / Linux
- Node version: （ローカルに合わせて記入）
- pnpm version: （ローカルに合わせて記入）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant
