### PR TITLE
refactor(terminal): ツールバー操作のコマンド実行を send$ に変更（#615）

### DIFF
--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
@@ -18,9 +18,11 @@ import { TerminalConsoleOrchestrationService } from './terminal-console-orchestr
 
 describe('TerminalConsoleOrchestrationService', () => {
   let sendMock: ReturnType<typeof vi.fn>;
+  let execMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     sendMock = vi.fn().mockReturnValue(of(undefined));
+    execMock = vi.fn();
     TestBed.configureTestingModule({
       providers: [
         TerminalConsoleOrchestrationService,
@@ -28,6 +30,7 @@ describe('TerminalConsoleOrchestrationService', () => {
           provide: SerialFacadeService,
           useValue: {
             send$: sendMock,
+            exec$: execMock,
             isConnected$: of(true),
             connectionEstablished$: of(undefined),
             receive$: EMPTY,
@@ -74,6 +77,7 @@ describe('TerminalConsoleOrchestrationService', () => {
     TestBed.overrideProvider(SerialFacadeService, {
       useValue: {
         send$: sendMock,
+        exec$: execMock,
         isConnected$: of(false),
         connectionEstablished$: of(undefined),
         receive$: EMPTY,
@@ -85,6 +89,7 @@ describe('TerminalConsoleOrchestrationService', () => {
     const result = await svc.runToolbarCommand('ls');
     expect(result).toEqual({ status: 'not_connected' });
     expect(sendMock).not.toHaveBeenCalled();
+    expect(execMock).not.toHaveBeenCalled();
   });
 
   it('runToolbarCommand sends coerced command via send$ when connected', async () => {
@@ -94,6 +99,7 @@ describe('TerminalConsoleOrchestrationService', () => {
     expect(sendMock).toHaveBeenCalledWith(
       `${coerceLsForSerialListing('ls')}\n`,
     );
+    expect(execMock).not.toHaveBeenCalled();
   });
 
   it('runToolbarCommand success always has empty output (no stdout path)', async () => {
@@ -103,6 +109,7 @@ describe('TerminalConsoleOrchestrationService', () => {
     if (result.status === 'success') {
       expect(result.output).toBe('');
     }
+    expect(execMock).not.toHaveBeenCalled();
   });
 
   it('bootstrapAfterConnect$ emits skip sink messages when shouldRun is false', async () => {
@@ -159,6 +166,7 @@ describe('TerminalConsoleOrchestrationService', () => {
     TestBed.overrideProvider(SerialFacadeService, {
       useValue: {
         send$: sendMock,
+        exec$: execMock,
         isConnected$: of(true),
         connectionEstablished$: of(undefined),
         receive$: chunks.asObservable(),
@@ -192,6 +200,7 @@ describe('TerminalConsoleOrchestrationService', () => {
     TestBed.overrideProvider(SerialFacadeService, {
       useValue: {
         send$: deferredSend,
+        exec$: execMock,
         isConnected$: of(true),
         connectionEstablished$: of(undefined),
         receive$: chunks.asObservable(),
@@ -229,6 +238,7 @@ describe('TerminalConsoleOrchestrationService', () => {
     TestBed.overrideProvider(SerialFacadeService, {
       useValue: {
         send$: sendMock,
+        exec$: execMock,
         isConnected$: of(true),
         connectionEstablished$: of(undefined),
         receive$: chunks.asObservable(),

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
@@ -41,10 +41,10 @@ export interface TerminalConsoleSink {
  * Issue #610 で UI 側購読を停止し、シグネチャと spec のみ温存している
  * （親 #609 配下の後続サブ issue で本メソッド自体を削除予定）。
  *
- * ### 対話・ツールバー（issue #611 / #612）
+ * ### 対話・ツールバー（issue #611 / #612 / #615）
  *
  * キーボード入力もツールバー経由のコマンドも {@link SerialFacadeService#send$} で
- * 送信する。完了待ちや stdout の切り出しは行わず、シェル出力は
+ * 送信する（ツールバーは #615）。完了待ちや stdout の切り出しは行わず、シェル出力は
  * {@link SerialFacadeService#terminalText$} 側のストリームに任せる。
  *
  * ### stdout 整形（issue #613）
@@ -78,8 +78,9 @@ export class TerminalConsoleOrchestrationService {
   }
 
   /**
-   * ツールバー等から要求されたコマンドを {@link SerialFacadeService#send$} で送る（issue #612）。
-   * シェル側の完了や stdout の取得は行わず、表示は {@link SerialFacadeService#terminalText$} に任せる。
+   * ツールバー等から要求されたコマンドを {@link SerialFacadeService#send$} で送る（#612 / #615）。
+   * {@link SerialFacadeService#exec$} は使用しない。シェル側の完了や stdout の取得は行わず、
+   * 表示は {@link SerialFacadeService#terminalText$} に任せる。
    */
   async runToolbarCommand(cmd: string): Promise<
     | { status: 'success'; output: string }

--- a/libs/terminal/util/src/lib/terminal-command-request.service.ts
+++ b/libs/terminal/util/src/lib/terminal-command-request.service.ts
@@ -3,7 +3,7 @@ import { Observable, Subject } from 'rxjs';
 
 /**
  * Lets other features (e.g. toolbar) ask the terminal to run a shell command
- * using the same serial path as interactive input.
+ * using the same serial path as interactive input (SerialFacadeService `send$`, issue #615).
  */
 @Injectable({
   providedIn: 'root',

--- a/libs/web-serial/data-access/src/lib/serial-connection-view-model.facade.ts
+++ b/libs/web-serial/data-access/src/lib/serial-connection-view-model.facade.ts
@@ -34,7 +34,8 @@ export interface SerialConnectionViewModel {
 
 /**
  * Terminal のツールバー等からの送信と同一パスの {@link TerminalCommandRequestService.requestCommand}
- * でシェル実行をキューする（#564）。
+ * でシェル実行をキューする（#564）。実送信はターミナル側で {@link SerialFacadeService#send$} となり、
+ * {@link SerialFacadeService#exec$} は使わない（親 #609 / #615）。
  */
 @Injectable({
   providedIn: 'root',
@@ -103,7 +104,7 @@ export class SerialConnectionViewModelFacade {
       });
   }
 
-  /** ツールバーと同じキュー経路でコンソール向けコマンドを送信する。 */
+  /** ツールバーと同じキュー経路でコンソール向けコマンドを送信する（#615: send$ 経路）。 */
   sendCommand(command: string): void {
     this.terminalCommandRequests.requestCommand(command);
   }


### PR DESCRIPTION
## Summary

親 issue #609 の子 issue #615 に対し、ツールバー経路が `exec$` に依存しないことをテストで保証し、関連 JSDoc に #615 を明記する。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #615
- Related to #609

## What changed?

- `TerminalConsoleOrchestrationService.runToolbarCommand` のテストで、`SerialFacadeService#exec$` が呼ばれないことを検証する（送信は `send$` のみ）。
- ツールバー／ターミナルキュー経路の JSDocに issue #615（および #609 の文脈）を追記した。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

公開 API の変更はない。挙動は既存の send$ + terminalText$ 設計のまま。

## How to test

1. `pnpm nx run libs-terminal-ui:test`
2. `pnpm nx run libs-console-shell-feature:test`
3. `pnpm nx run libs-web-serial-data-access:test -- libs/web-serial/data-access/src/lib/serial-connection-view-model.facade.spec.ts`
4. （任意）実機でシリアル接続後、I2C ツールバーから `i2cdetect` を送り、xterm にシェル出力が流れることを確認する。

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant