### PR TITLE
docs(web-serial): exec$ の責務を文書化しターミナル外利用を明確化 (#616)

### DIFF
--- a/docs/serial-architecture.md
+++ b/docs/serial-architecture.md
@@ -33,6 +33,12 @@ chirimen-lite-console（本リポジトリ）
 
 Issue #590 / [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) 以降は、外部公開 API を `SerialFacadeService` に集約し、利用側は `terminalText$` / `lines$` / `state$` / `isConnected$` / `errors$` / `portInfo$` と `connect$()` / `disconnect$()` / `send$()` / `exec$()` / `execRaw$()` / `readUntilPrompt$()` を基本導線とする。Pi Zero のログイン〜タイムゾーン初期化の期待シーケンスは [Issue #606](https://github.com/gurezo/chirimen-lite-console/issues/606) を参照。
 
+### `exec$` 系 API の責務（[#616](https://github.com/gurezo/chirimen-lite-console/issues/616)）
+
+- **ターミナル（xterm）経路**では `send$()` と `terminalText$` のみを使い、`exec$()` / `execRaw$()` / `readUntilPrompt$()` は **呼ばない**（親 [#609](https://github.com/gurezo/chirimen-lite-console/issues/609)）。
+- **`exec$` 系**は、プロンプトまで待って **キャプチャした stdout 等をアプリが解釈する**内部処理向け。i2cdetect・setup・ログイン後初期化はその代表例であり、Wi-Fi・ファイル・リモートなど同種の同期コマンドも同じ原則に含める。
+- 詳細は [`SerialFacadeService` の JSDoc](../libs/web-serial/data-access/src/lib/serial-facade.service.ts) および [libs/web-serial/data-access/README.md](../libs/web-serial/data-access/README.md) の「`exec$` の利用方針」を参照。
+
 ## 受信ストリーム（ライブラリ vs 本アプリの公開面）
 
 ライブラリの `SerialSession` は `receive$` / `receiveReplay$` / `lines$` / `terminalText$` 等を提供する。本アプリの **`SerialFacadeService` では `terminalText$` と `lines$` のみ**を公開し、ライブ表示の `\r` 再描画やバッファ正規化は **ライブラリの `terminalText$`** に委譲する（[#601](https://github.com/gurezo/chirimen-lite-console/issues/601)）。
@@ -73,3 +79,4 @@ Issue #590 / [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) 
 - [#568](https://github.com/gurezo/chirimen-lite-console/issues/568) — 本ドキュメントの追加
 - [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) — `terminalText$` への表示委譲と facade 公開面の整理
 - [#613](https://github.com/gurezo/chirimen-lite-console/issues/613) — ターミナル UI から stdout 整形（`sanitizeSerialStdout`）を排除し、表示は `terminalText$` の生データに統一
+- [#616](https://github.com/gurezo/chirimen-lite-console/issues/616) — `exec$` の責務整理（ターミナル外の内部同期コマンド用と文書化）

--- a/libs/web-serial/data-access/README.md
+++ b/libs/web-serial/data-access/README.md
@@ -39,6 +39,13 @@ Angular 向けのシリアル（Web Serial + `@gurezo/web-serial-rxjs` v2.3.1）
   - methods: `connect$()`, `disconnect$()`, `send$()`, `exec$()`, `execRaw$()`, `readUntilPrompt$()`, `read$()`, `getPort()`, `isRaspberryPiZero()`, `getConnectionEpoch()`, `isReading()`, `getPendingCommandCount()`
 - 生 `receive$` / `receiveReplay$` は facade では公開しない（[#601](https://github.com/gurezo/chirimen-lite-console/issues/601)）。ライブ表示の `\r` 再描画は `terminalText$` に委譲する。
 
+### `exec$` / `execRaw$` / `readUntilPrompt$` の利用方針（[#616](https://github.com/gurezo/chirimen-lite-console/issues/616)）
+
+- **役割**: プロンプト同期でコマンドを送り、**stdout 等のキャプチャ結果**が欲しい **アプリ内部**フロー向け。キュー・リトライ・プロンプト検出は `SerialCommandService` 側。
+- **ターミナル UI（xterm の対話・ツールバー）では使わない。** 送信は `send$()`、ライブ表示は `terminalText$` のみ（親 [#609](https://github.com/gurezo/chirimen-lite-console/issues/609)）。
+- **代表例**（Issue 本文の列挙に沿った説明）: ログイン後の bootstrap / タイムゾーン初期化、i2cdetect、Chirimen setup。これに限らず、**同様にプロンプト待ちと stdout が必要な機能**（Wi-Fi、ファイルマネージャ、リモート等）も `exec$` を用いる。
+- 契約の一次情報は `SerialFacadeService`（`serial-facade.service.ts`）の各メソッド JSDoc を参照する。
+
 ## Pi Zero 接続直後の期待フロー（Issue [#606](https://github.com/gurezo/chirimen-lite-console/issues/606)）
 
 `PiZeroSerialBootstrapService` は `@gurezo/web-serial-rxjs` の `SerialSession` を {@link SerialFacadeService} 経由で利用し、次のコンソール遷移を自動処理する。

--- a/libs/web-serial/data-access/src/lib/serial-command/serial-command-facade.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/serial-command-facade.service.ts
@@ -37,6 +37,11 @@ export class SerialCommandService {
     return this.runner.isReading();
   }
 
+  /**
+   * キュー経由で exec パイプラインを実行する実装入口。
+   *
+   * 呼び出し側の方針・ターミナル UI での禁止事項は {@link SerialFacadeService#exec$} の JSDoc を参照（#616）。
+   */
   exec$(
     cmd: string,
     options: SerialExecOptions,
@@ -45,6 +50,7 @@ export class SerialCommandService {
     return this.enqueueExec$(cmd + '\n', options, onAttemptStart);
   }
 
+  /** @see {@link SerialFacadeService#execRaw$} */
   execRaw$(
     cmdRaw: string,
     options: SerialExecOptions,
@@ -53,6 +59,7 @@ export class SerialCommandService {
     return this.enqueueExec$(cmdRaw, options, onAttemptStart);
   }
 
+  /** @see {@link SerialFacadeService#readUntilPrompt$} */
   readUntilPrompt$(
     options: SerialExecOptions,
     onAttemptStart?: () => void,

--- a/libs/web-serial/data-access/src/lib/serial-facade.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-facade.service.ts
@@ -66,6 +66,15 @@ export class SerialFacadeService {
     return this.lines$.pipe(take(1));
   }
 
+  /**
+   * プロンプト同期でコマンドを送り、シェルが戻るまでの **stdout 等のキャプチャ結果** を返す。
+   *
+   * **利用境界（[#616](https://github.com/gurezo/chirimen-lite-console/issues/616)）**
+   * - **ターミナル UI（xterm の対話・ツールバー送信）では呼ばない。** 表示は {@link #terminalText$}、送信は {@link #send$} に統一する（親 [#609](https://github.com/gurezo/chirimen-lite-console/issues/609)）。
+   * - **アプリ内部**で「コマンド完了まで待ち、stdout を取りたい」フロー向け。代表例はログイン後 bootstrap、i2cdetect、Chirimen setup など。Wi-Fi・ファイルマネージャ・リモート等、プロンプト待ちが必要な機能も同じ層に含める。
+   *
+   * {@link SerialCommandService#exec$} に委譲する。
+   */
   exec$(
     cmd: string,
     options: SerialExecOptions,
@@ -73,6 +82,11 @@ export class SerialFacadeService {
     return this.command.exec$(cmd, options);
   }
 
+  /**
+   * {@link #exec$} と同様の責務で、ペイロード末尾に改行を付けない Raw 送信が必要な場合に用いる。
+   *
+   * @see {@link #exec$} 利用境界（ターミナル UI 禁止）
+   */
   execRaw$(
     cmdRaw: string,
     options: SerialExecOptions,
@@ -80,6 +94,11 @@ export class SerialFacadeService {
     return this.command.execRaw$(cmdRaw, options);
   }
 
+  /**
+   * コマンド送信なしでプロンプト出現まで待ち、それまでのバッファを {@link CommandResult} として返す。
+   *
+   * @see {@link #exec$} 利用境界（ターミナル UI 禁止・アプリ内部のプロンプト同期用）
+   */
   readUntilPrompt$(options: SerialExecOptions): Observable<CommandResult> {
     return this.command.readUntilPrompt$(options);
   }


### PR DESCRIPTION
## Summary

Issue #616 に対し、`SerialFacadeService` の `exec$` / `execRaw$` / `readUntilPrompt$` の責務を JSDoc と README / serial-architecture で明文化した。ターミナル（xterm）は `send$` と `terminalText$` のみとし、`exec$` はプロンプト同期と stdout キャプチャが必要なアプリ内部向けであることを記載した。i2cdetect・setup・ログイン後初期化は代表例とし、Wi-Fi・ファイル・リモート等の既存利用も同じ原則に含める。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #616
- Refs #609

## What changed?

- `SerialFacadeService` および `SerialCommandService` の JSDocで `exec$` 系の利用境界を定義（ターミナル UI では使わない）。
- `libs/web-serial/data-access/README.md` に「exec$ の利用方針」セクションを追加。
- `docs/serial-architecture.md` に同趣旨の段落と関連 Issue #616 を追加。
- 監査: `libs/terminal` 配下に `exec$()` の本番呼び出しはなく、コメントとテスト用モックのみであることを確認済み。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm exec nx run libs-web-serial-data-access:test` を実行する。
2.（任意）IDE で `SerialFacadeService#exec$` の JSDocが意図どおり表示されることを確認する。

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [ ] I considered error handling where relevant