### PR TITLE
docs(web-serial): terminalText$ の責務を README と JSDoc で明確化 (#617)

### DIFF
--- a/docs/serial-architecture.md
+++ b/docs/serial-architecture.md
@@ -39,6 +39,12 @@ Issue #590 / [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) 
 - **`exec$` 系**は、プロンプトまで待って **キャプチャした stdout 等をアプリが解釈する**内部処理向け。i2cdetect・setup・ログイン後初期化はその代表例であり、Wi-Fi・ファイル・リモートなど同種の同期コマンドも同じ原則に含める。
 - 詳細は [`SerialFacadeService` の JSDoc](../libs/web-serial/data-access/src/lib/serial-facade.service.ts) および [libs/web-serial/data-access/README.md](../libs/web-serial/data-access/README.md) の「`exec$` の利用方針」を参照。
 
+### `terminalText$` の責務（[#617](https://github.com/gurezo/chirimen-lite-console/issues/617)）
+
+- **ターミナル UI は `SerialFacadeService#terminalText$` を購読**して xterm 等にライブ表示する。送信は `send$()` のみとし、`exec$` 系の戻り値で同じ画面を更新しない（上記 `exec$` 節および [#616](https://github.com/gurezo/chirimen-lite-console/issues/616) と対で読む）。
+- 表示の TTY 相当処理・`\r` の扱いはライブラリの `terminalText$` に委譲する（[#601](https://github.com/gurezo/chirimen-lite-console/issues/601)）。
+- **契約の一次情報**は [`SerialFacadeService` の JSDoc](../libs/web-serial/data-access/src/lib/serial-facade.service.ts) および [README の `terminalText$` / `exec$` 節](../libs/web-serial/data-access/README.md) を正とする。
+
 ## 受信ストリーム（ライブラリ vs 本アプリの公開面）
 
 ライブラリの `SerialSession` は `receive$` / `receiveReplay$` / `lines$` / `terminalText$` 等を提供する。本アプリの **`SerialFacadeService` では `terminalText$` と `lines$` のみ**を公開し、ライブ表示の `\r` 再描画やバッファ正規化は **ライブラリの `terminalText$`** に委譲する（[#601](https://github.com/gurezo/chirimen-lite-console/issues/601)）。
@@ -80,3 +86,4 @@ Issue #590 / [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) 
 - [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) — `terminalText$` への表示委譲と facade 公開面の整理
 - [#613](https://github.com/gurezo/chirimen-lite-console/issues/613) — ターミナル UI から stdout 整形（`sanitizeSerialStdout`）を排除し、表示は `terminalText$` の生データに統一
 - [#616](https://github.com/gurezo/chirimen-lite-console/issues/616) — `exec$` の責務整理（ターミナル外の内部同期コマンド用と文書化）
+- [#617](https://github.com/gurezo/chirimen-lite-console/issues/617) — `terminalText$` の責務明確化（ドキュメント・JSDoc）

--- a/libs/web-serial/data-access/README.md
+++ b/libs/web-serial/data-access/README.md
@@ -24,7 +24,7 @@ Angular 向けのシリアル（Web Serial + `@gurezo/web-serial-rxjs` v2.3.1）
 
 - **`SerialTransportService`** が上記各ストリームを `activeSession$` 経由で橋渡しする。
 - **`SerialCommandRunnerService`（`serial-command-runner.service.ts`）／`SerialCommandService` facade** が `lines$` を購読し、プロンプト待ち用に行連結バッファを保持する（表示の `\r` 処理は `terminalText$` と `@libs-web-serial-util` の `collapseCarriageRedrawsPerLine` に委譲）。
-- **ターミナル UI** は `TerminalConsoleOrchestrationService#pipeTerminalOutputToSink$` で **`terminalText$` のみ** をライブミラーに接続できる。`exec` の stdout 整形表示と二重にならないよう使い分けること。
+- **ターミナル UI** は **`SerialFacadeService#terminalText$` を購読**し、ライブ表示を xterm 等に反映する（例: `TerminalViewComponent`）。`exec$` の戻り値で同じ画面を二重更新しない。
 
 ## 接続状態の単一ビューモデル（[#564](https://github.com/gurezo/chirimen-lite-console/issues/564)）
 
@@ -38,6 +38,13 @@ Angular 向けのシリアル（Web Serial + `@gurezo/web-serial-rxjs` v2.3.1）
   - stream: `terminalText$`, `lines$`, `state$`, `isConnected$`, `errors$`, `portInfo$`
   - methods: `connect$()`, `disconnect$()`, `send$()`, `exec$()`, `execRaw$()`, `readUntilPrompt$()`, `read$()`, `getPort()`, `isRaspberryPiZero()`, `getConnectionEpoch()`, `isReading()`, `getPendingCommandCount()`
 - 生 `receive$` / `receiveReplay$` は facade では公開しない（[#601](https://github.com/gurezo/chirimen-lite-console/issues/601)）。ライブ表示の `\r` 再描画は `terminalText$` に委譲する。
+
+### `terminalText$` の責務（[#617](https://github.com/gurezo/chirimen-lite-console/issues/617)）
+
+- **ターミナル UI（xterm のライブ表示）は `SerialFacadeService#terminalText$` を購読する**唯一のソースとする。受信テキストの TTY 相当の扱い（累積全文の emit 等）は `@gurezo/web-serial-rxjs` の `SerialSession.terminalText$` に委譲する（[#601](https://github.com/gurezo/chirimen-lite-console/issues/601)、[#613](https://github.com/gurezo/chirimen-lite-console/issues/613)）。
+- **送信**は `send$()` のみ。ライブ表示の更新に **`exec$()` / `execRaw$()` / `readUntilPrompt$()` の戻り値を流用しない**（`exec$` 系は stdout キャプチャ用。使い分けは次節および [#616](https://github.com/gurezo/chirimen-lite-console/issues/616)）。
+- **プロンプト検出・ログイン判定**は **`lines$`** 側のバッファを用い、`terminalText$` をプロンプト照合に使わない（上表・[#593](https://github.com/gurezo/chirimen-lite-console/issues/593)）。
+- 契約の一次情報は `SerialFacadeService`（`serial-facade.service.ts`）の **`terminalText$` および `exec$` の JSDoc** を参照する。
 
 ### `exec$` / `execRaw$` / `readUntilPrompt$` の利用方針（[#616](https://github.com/gurezo/chirimen-lite-console/issues/616)）
 

--- a/libs/web-serial/data-access/src/lib/serial-facade.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-facade.service.ts
@@ -48,6 +48,16 @@ export class SerialFacadeService {
   readonly portInfo$ = this.transport.portInfo$;
   readonly lines$ = this.transport.lines$;
   readonly receive$ = this.transport.receive$;
+
+  /**
+   * ターミナル（xterm 等）の **ライブ表示専用** テキストストリーム（[#617](https://github.com/gurezo/chirimen-lite-console/issues/617)）。
+   *
+   * - **ターミナル UI は本 Observable を購読**し、シェルからの出力を画面に反映する。TTY の `\r` 再描画の畳み込み等はライブラリの `SerialSession.terminalText$` に委譲する。
+   * - **送信**は {@link #send$} のみとし、表示の更新に {@link #exec$} / {@link #execRaw$} / {@link #readUntilPrompt$} の戻り値を用いない（二重表示・責務の混乱を避ける。キャプチャ用途は {@link #exec$} 側のドキュメント参照）。
+   * - **プロンプト検出・ログイン判定**には {@link #lines$} 由来のバッファを用い、本ストリームは照合用に寄せない。
+   *
+   * @see {@link #exec$} ターミナル UI では exec 系を呼ばない理由と内部向け利用境界
+   */
   readonly terminalText$ = this.transport.terminalText$;
 
   connect$(baudRate = 115200): Observable<SerialFacadeConnectResult> {

--- a/libs/web-serial/data-access/src/lib/serial-transport.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-transport.service.ts
@@ -91,7 +91,10 @@ export class SerialTransportService {
    */
   readonly receive$ = this.fromSession((s) => s.receive$, NEVER);
 
-  /** {@link SerialSession.terminalText$} */
+  /**
+   * {@link SerialSession.terminalText$}。ターミナル UI のライブ表示用（TTY 再描画の畳み込みはライブラリ側）。
+   * 利用境界は {@link SerialFacadeService#terminalText$} の JSDoc および data-access README（[#617](https://github.com/gurezo/chirimen-lite-console/issues/617)）を参照。
+   */
   readonly terminalText$ = this.fromSession((s) => s.terminalText$, NEVER);
 
   /** {@link SerialSession.errors$} */


### PR DESCRIPTION
## Summary

Issue #617 に対し、`terminalText$` の責務（ターミナル UI は購読のみ・`exec$` との境界）を README・アーキテクチャ文書・ソース JSDoc で明確化しました。親 Issue #609 の方針と整合します。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #617
- Related #609

## What changed?

- `SerialFacadeService` の `terminalText$` に JSDoc を追加（ターミナル UI の購読・`send$` / `exec$` との使い分け・`lines$` との役割分担、`@see exec$`）。
- `libs/web-serial/data-access/README.md` に「`terminalText$` の責務」節を追加し、`exec$` 節と対称に記述。ターミナル UI の説明を `terminalText$` 直購読に合わせて修正。
- `docs/serial-architecture.md` に同趣旨の小見出しと関連 Issue #617 を追記。
- `SerialTransportService` の `terminalText$` に簡潔な JSDoc を拡張。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `libs/web-serial/data-access/README.md` と `docs/serial-architecture.md` を開き、`terminalText$` / `exec$` の説明が一貫していることを確認する。
2. IDE で `SerialFacadeService.terminalText$` にホバーし、JSDoc が表示されることを確認する。

## Environment (if relevant)

- Browser: 該当なし
- OS: macOS / Windows / Linux
- Node version: 該当なし
- pnpm version: 該当なし

## Checklist

- [ ] I ran tests locally (if available) — ドキュメントのみのため未実施
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant — 該当なし（文書のみ）

Made with [Cursor](https://cursor.com)