### PR TITLE
refactor(terminal): Terminal UI からオートログイン失敗処理を分離

### DIFF
--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
@@ -7,6 +7,7 @@ import {
   from,
   of,
   Subject,
+  throwError,
 } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
@@ -159,6 +160,30 @@ describe('TerminalConsoleOrchestrationService', () => {
     expect(shouldRunAfterConnect$).toHaveBeenCalledTimes(1);
     expect(runAfterConnect$).toHaveBeenCalledTimes(1);
     expect(write).toHaveBeenCalledWith('\r\nprefix 初期化しています...\r\n');
+  });
+
+  it('bootstrapAfterConnect$ rethrows bootstrap errors for caller handling', async () => {
+    const writeln = vi.fn();
+    const write = vi.fn();
+    TestBed.overrideProvider(PiZeroSessionService, {
+      useValue: {
+        shouldRunAfterConnect$: () => of(true),
+        runAfterConnect$: () => throwError(() => new Error('auth failed')),
+      },
+    });
+    const svc = TestBed.inject(TerminalConsoleOrchestrationService);
+
+    await expect(
+      firstValueFrom(
+        svc.bootstrapAfterConnect$('prefix', { writeln, write }).pipe(
+          defaultIfEmpty(undefined),
+        ),
+      ),
+    ).rejects.toThrow('auth failed');
+    expect(write).toHaveBeenCalledWith('\r\nprefix 初期化しています...\r\n');
+    expect(write).toHaveBeenCalledWith(
+      '\r\nprefix 初期化に失敗しました: auth failed\r\n',
+    );
   });
 
   it('pipeTerminalOutputToSink$ forwards receive$ chunks to sink.write', async () => {

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
@@ -15,6 +15,7 @@ import {
   switchMap,
   take,
   tap,
+  throwError,
 } from 'rxjs';
 
 export interface TerminalConsoleSink {
@@ -106,6 +107,7 @@ export class TerminalConsoleOrchestrationService {
 
   /**
    * 接続確立後の Pi Zero 初期化。表示は {@link TerminalConsoleSink} に委譲する。
+   * 初期化失敗時はエラーを握り潰さず呼び出し元へ伝播し、UI 側で扱えるようにする（issue #619）。
    */
   bootstrapAfterConnect$(
     prefixMessage: string,
@@ -128,7 +130,15 @@ export class TerminalConsoleOrchestrationService {
           this.writeConsoleLine(sink, line),
         );
       }),
-      catchError(() => EMPTY),
+      catchError((error: unknown) => {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        this.writeConsoleLine(
+          sink,
+          `${prefixMessage} 初期化に失敗しました: ${message}`,
+        );
+        return throwError(() => error);
+      }),
       finalize(() => {
         this.terminalMirrorSuppressDepth--;
         if (this.activeBootstrapEpoch === epoch) {

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { BehaviorSubject, NEVER, Subject, of } from 'rxjs';
+import { BehaviorSubject, NEVER, Subject, of, throwError } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@xterm/xterm', () => {
@@ -102,6 +102,24 @@ describe('TerminalViewComponent', () => {
       expect(shouldRunAfterConnectMock).toHaveBeenCalled();
     });
     expect(runAfterConnectMock).not.toHaveBeenCalled();
+  });
+
+  it('writes bootstrap failure message when post-connect setup errors', async () => {
+    runAfterConnectMock.mockReturnValue(
+      throwError(() => new Error('auth failed')),
+    );
+
+    fixture.destroy();
+    fixture = TestBed.createComponent(TerminalViewComponent);
+    const writelnSpy = vi.spyOn(fixture.componentInstance.xterminal, 'writeln');
+    writelnSpy.mockClear();
+    fixture.detectChanges();
+
+    await vi.waitFor(() => {
+      expect(writelnSpy).toHaveBeenCalledWith(
+        '[コンソール] 接続後の初期化に失敗しました: auth failed',
+      );
+    });
   });
 
   it('writes only the appended delta when terminalText$ grows by suffix', async () => {

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -116,7 +116,14 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
         ),
         takeUntilDestroyed(this.destroyRef),
       )
-      .subscribe();
+      .subscribe({
+        error: (err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          this.xterminal.writeln(
+            `[コンソール] 接続後の初期化に失敗しました: ${message}`,
+          );
+        },
+      });
 
     attachTerminalInput(
       this.xterminal,


### PR DESCRIPTION
## Summary

Issue #619 に対応し、接続後オートログイン初期化の失敗を Terminal UI で握り潰さず扱えるようにしました。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #619
- Relates #618

## What changed?

- `TerminalConsoleOrchestrationService#bootstrapAfterConnect$` で初期化失敗を `EMPTY` に潰さず、失敗メッセージを出力したうえでエラーを再送出するよう変更
- `TerminalViewComponent` 側で接続後初期化の購読に error ハンドラを追加し、失敗理由を xterm に表示
- 失敗伝播とUI表示の回帰テストを `terminal-console-orchestration.service.spec.ts` / `terminal-view.component.spec.ts` に追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx test libs-terminal-ui`
2. `pnpm nx test libs-web-serial-data-access`
3. シリアル接続後にログインフローを失敗させ、ターミナルに「接続後の初期化に失敗しました」が表示されることを確認

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)