### PR TITLE
refactor(terminal): シェル準備待ち処理を専用フローに分離する

### DIFF
--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
@@ -186,6 +186,32 @@ describe('TerminalConsoleOrchestrationService', () => {
     );
   });
 
+  it('bootstrapAfterConnect$ keeps explicit shell readiness timeout errors', async () => {
+    const writeln = vi.fn();
+    const write = vi.fn();
+    TestBed.overrideProvider(PiZeroSessionService, {
+      useValue: {
+        shouldRunAfterConnect$: () => of(true),
+        runAfterConnect$: () =>
+          throwError(
+            () => new Error('Shell readiness timeout while waiting for prompt'),
+          ),
+      },
+    });
+    const svc = TestBed.inject(TerminalConsoleOrchestrationService);
+
+    await expect(
+      firstValueFrom(
+        svc.bootstrapAfterConnect$('prefix', { writeln, write }).pipe(
+          defaultIfEmpty(undefined),
+        ),
+      ),
+    ).rejects.toThrow('Shell readiness timeout while waiting for prompt');
+    expect(write).toHaveBeenCalledWith(
+      '\r\nprefix 初期化に失敗しました: Shell readiness timeout while waiting for prompt\r\n',
+    );
+  });
+
   it('pipeTerminalOutputToSink$ forwards receive$ chunks to sink.write', async () => {
     const chunks = new Subject<string>();
     TestBed.overrideProvider(SerialFacadeService, {

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
@@ -108,6 +108,7 @@ export class TerminalConsoleOrchestrationService {
   /**
    * 接続確立後の Pi Zero 初期化。表示は {@link TerminalConsoleSink} に委譲する。
    * 初期化失敗時はエラーを握り潰さず呼び出し元へ伝播し、UI 側で扱えるようにする（issue #619）。
+   * shell readiness 判定・待機の詳細は web-serial 側フローが担い、UI 側では扱わない（issue #620）。
    */
   bootstrapAfterConnect$(
     prefixMessage: string,

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
@@ -122,6 +122,26 @@ describe('TerminalViewComponent', () => {
     });
   });
 
+  it('shows explicit shell readiness timeout message from bootstrap flow', async () => {
+    runAfterConnectMock.mockReturnValue(
+      throwError(
+        () => new Error('Shell readiness timeout while waiting for prompt'),
+      ),
+    );
+
+    fixture.destroy();
+    fixture = TestBed.createComponent(TerminalViewComponent);
+    const writelnSpy = vi.spyOn(fixture.componentInstance.xterminal, 'writeln');
+    writelnSpy.mockClear();
+    fixture.detectChanges();
+
+    await vi.waitFor(() => {
+      expect(writelnSpy).toHaveBeenCalledWith(
+        '[コンソール] 接続後の初期化に失敗しました: Shell readiness timeout while waiting for prompt',
+      );
+    });
+  });
+
   it('writes only the appended delta when terminalText$ grows by suffix', async () => {
     const writeSpy = vi.spyOn(fixture.componentInstance.xterminal, 'write');
     writeSpy.mockClear();

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -108,12 +108,7 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
     )
       .pipe(
         take(1),
-        switchMap(() =>
-          this.console.bootstrapAfterConnect$(
-            '[コンソール] シリアル接続済み。',
-            this.terminalSink,
-          ),
-        ),
+        switchMap(() => this.runPostConnectInitialization$()),
         takeUntilDestroyed(this.destroyRef),
       )
       .subscribe({
@@ -162,6 +157,16 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
     } catch {
       // Dimensions may be zero before layout stabilizes
     }
+  }
+
+  /**
+   * 接続後の初期化実行は orchestration service に委譲し、UI は結果表示のみ行う。
+   */
+  private runPostConnectInitialization$() {
+    return this.console.bootstrapAfterConnect$(
+      '[コンソール] シリアル接続済み。',
+      this.terminalSink,
+    );
   }
 
   /**

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
@@ -194,6 +194,30 @@ describe('PiZeroSerialBootstrapService', () => {
     expect(send$).toHaveBeenCalledWith(`${PI_ZERO_LOGIN_PASSWORD}\r\n`);
   });
 
+  it('throws explicit shell readiness timeout when auth wait times out twice', async () => {
+    const readUntilPrompt = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('probe timeout'))
+      .mockResolvedValueOnce({ stdout: 'stale' })
+      .mockResolvedValueOnce({ stdout: 'raspberrypi login: ' })
+      .mockRejectedValueOnce(new Error('Command execution timeout'))
+      .mockRejectedValueOnce(new Error('Command execution timeout'));
+    const exec = vi.fn().mockResolvedValue({ stdout: '' });
+    const send$ = vi.fn().mockReturnValue(of(undefined));
+    const serial = {
+      readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
+      exec$: (c: string, o: unknown) => from(exec(c, o)),
+      send$,
+    } as unknown as SerialFacadeService;
+
+    await expect(
+      firstValueFrom(createBootstrap(serial).loginIfNeeded$()),
+    ).rejects.toThrow('Shell readiness timeout while waiting for prompt');
+
+    expect(send$).toHaveBeenCalledWith('\r\n');
+    expect(send$).toHaveBeenCalledWith(`${PI_ZERO_LOGIN_USER}\r\n`);
+  });
+
   it('keeps timezone status logging', async () => {
     const readUntilPrompt = vi.fn().mockResolvedValue({
       stdout: `ready\r\n${PI_ZERO_PROMPT} `,

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
@@ -34,6 +34,8 @@ interface AuthLoopState {
   loginSendCount: number;
   passwordSendCount: number;
 }
+const SHELL_READINESS_TIMEOUT_MESSAGE =
+  'Shell readiness timeout while waiting for prompt';
 
 /**
  * Pi Zero / CHIRIMEN 固有のシリアル初期化を集約する単一サービス（issue #594）。
@@ -175,18 +177,29 @@ export class PiZeroSerialBootstrapService {
    * getty が lone `\r` でプロンプトを更新した直後は lines$ に載るまで遅れることがあるため、
    * 1 回だけ改行を再送して認証状態待ちを再試行する。
    */
-  private awaitAuthStateWithRetry$(): Observable<AuthState> {
+  private waitForAuthState$(): Observable<AuthState> {
     return this.awaitAuthState$().pipe(
       catchError((error) => {
-        const message = error instanceof Error ? error.message : String(error);
-        if (!/timeout/i.test(message)) {
+        if (!this.isTimeoutError(error)) {
           throw error;
         }
+        // getty の lone CR で行イベントが未確定な場合に 1 度だけ改行を打って再判定する。
         return this.serial.send$('\r\n').pipe(
           switchMap(() => this.awaitAuthState$()),
+          catchError((retryError) => {
+            if (!this.isTimeoutError(retryError)) {
+              throw retryError;
+            }
+            throw new Error(SHELL_READINESS_TIMEOUT_MESSAGE);
+          }),
         );
       }),
     );
+  }
+
+  private isTimeoutError(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error);
+    return /timeout/i.test(message);
   }
 
   /**
@@ -252,7 +265,7 @@ export class PiZeroSerialBootstrapService {
     if (state.stepCount >= 8) {
       throw new Error('Authentication flow exceeded retry budget');
     }
-    return this.awaitAuthStateWithRetry$().pipe(
+    return this.waitForAuthState$().pipe(
       switchMap((authState) => {
         if (authState === 'pending') {
           return timer(250).pipe(

--- a/libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts
@@ -199,7 +199,7 @@ describe('PiZeroSessionService', () => {
       const sub = service.initializing$.subscribe((v) => seen.push(v));
 
       await expect(firstValueFrom(service.runAfterConnect$())).rejects.toThrow(
-        'login prompt timeout',
+        'Shell readiness timeout while waiting for prompt',
       );
       sub.unsubscribe();
 


### PR DESCRIPTION
## Summary
- Issue #620 の要件に合わせ、shell readiness 待機の timeout を専用エラーとして明示化しました
- Terminal UI 側は shell readiness の判定を持たず、接続後初期化フローの実行結果表示に責務を限定しました
- timeout の伝播と表示を web-serial / terminal-ui のテストで固定化しました

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #620
- Related #618

## What changed?

- `PiZeroSerialBootstrapService` の認証状態待機で timeout が再発した場合に `Shell readiness timeout while waiting for prompt` を返すように変更
- `TerminalViewComponent` の接続後初期化呼び出しを専用メソッド化し、UI が readiness 判定を持たない構造を明示
- orchestration / component / bootstrap / session の spec を更新し、timeout の明示エラー伝播と表示を検証

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx test libs-web-serial-data-access`
2. `pnpm nx test libs-terminal-ui`
3. すべてのテストが成功し、shell readiness timeout 関連の追加ケースが通ることを確認する

## Environment (if relevant)

- Browser: N/A
- OS: macOS
- Node version: v24.13.1
- pnpm version: 10.18.3

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)