### PR TITLE
fix(web-serial): タイムゾーン初期化失敗を接続後フローでエラー伝播する

### DIFF
--- a/libs/web-serial/data-access/src/lib/pi-zero-bootstrap.config.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-bootstrap.config.ts
@@ -14,17 +14,17 @@ export interface PiZeroTimezoneStep {
  * prompt 待機・コマンド完了判定の比較用に利用する。
  */
 export const PI_ZERO_PROMPT_TARGET = PI_ZERO_PROMPT;
+export const PI_ZERO_TIMEZONE = 'Asia/Tokyo' as const;
 
 /**
  * 接続直後のタイムゾーン初期化（各ステップの説明とコマンド）。
- * `sudo -n` で対話的パスワード待ちを避け、失敗時も `|| true` で後続へ進める。
+ * `sudo -n` で対話的パスワード待ちを避ける。
  */
 export const PI_ZERO_TIMEZONE_STEPS: readonly PiZeroTimezoneStep[] = [
   {
     statusMessage:
-      '[コンソール] タイムゾーンを Asia/Tokyo に設定しています...',
-    command:
-      'sudo -n timedatectl set-timezone Asia/Tokyo 2>/dev/null || true',
+      `[コンソール] タイムゾーンを ${PI_ZERO_TIMEZONE} に設定しています...`,
+    command: `sudo -n timedatectl set-timezone ${PI_ZERO_TIMEZONE} 2>/dev/null`,
   },
   {
     statusMessage: '[コンソール] タイムゾーンの状態を表示します。',

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { firstValueFrom, from, of } from 'rxjs';
+import { firstValueFrom, from, of, throwError } from 'rxjs';
 import {
   PI_ZERO_LOGIN_PASSWORD,
   PI_ZERO_LOGIN_USER,
@@ -240,5 +240,25 @@ describe('PiZeroSerialBootstrapService', () => {
       createBootstrap(serial).runPostConnectPipeline$((l) => logs.push(l)),
     );
     expect(logs.some((l) => l.includes('Time zone: Asia/Tokyo'))).toBe(true);
+  });
+
+  it('fails setupEnvironment$ when timezone command fails', async () => {
+    const exec = vi
+      .fn()
+      .mockReturnValueOnce(
+        throwError(() => new Error('sudo: a password is required')),
+      );
+    const serial = {
+      exec$: (c: string, o: unknown) => exec(c, o),
+    } as unknown as SerialFacadeService;
+
+    const logs: string[] = [];
+    await expect(
+      firstValueFrom(createBootstrap(serial).setupEnvironment$((l) => logs.push(l))),
+    ).rejects.toThrow('Timezone setup failed');
+
+    expect(logs.some((l) => l.includes('タイムゾーン初期化コマンドに失敗'))).toBe(
+      true,
+    );
   });
 });

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
@@ -19,10 +19,7 @@ import {
   tap,
   timer,
 } from 'rxjs';
-import {
-  PI_ZERO_PROMPT_TARGET,
-  PI_ZERO_TIMEZONE_STEPS,
-} from './pi-zero-bootstrap.config';
+import { PI_ZERO_PROMPT_TARGET, PI_ZERO_TIMEZONE_STEPS } from './pi-zero-bootstrap.config';
 import { PiZeroPromptDetectorService } from './pi-zero-prompt-detector.service';
 import { SerialFacadeService } from './serial-facade.service';
 
@@ -371,9 +368,12 @@ export class PiZeroSerialBootstrapService {
             catchError((error: unknown) => {
               const message =
                 error instanceof Error ? error.message : String(error);
-              log(`[コンソール] コマンドが失敗しました: ${message}`);
-              console.warn(`Initial command failed: ${step.command}`, error);
-              return of(undefined);
+              log(
+                `[コンソール] タイムゾーン初期化コマンドに失敗しました: ${step.command} (${message})`,
+              );
+              throw new Error(
+                `Timezone setup failed at "${step.command}": ${message}`,
+              );
             }),
           );
       }),

--- a/libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts
@@ -240,5 +240,32 @@ describe('PiZeroSessionService', () => {
         expect.stringContaining('接続後の初期化に失敗'),
       );
     });
+
+    it('propagates timezone setup failures to caller', async () => {
+      const readUntilPrompt = vi.fn().mockImplementation(() =>
+        of({
+          stdout: `${PI_ZERO_PROMPT} `,
+        }),
+      );
+      const exec = vi
+        .fn()
+        .mockReturnValueOnce(
+          throwError(() => new Error('sudo: a password is required')),
+        );
+      const serial = {
+        isConnected$: of(true),
+        getConnectionEpoch: () => 1,
+        readUntilPrompt$: (o: unknown) => readUntilPrompt(o),
+        exec$: (c: string, o: unknown) => exec(c, o),
+      } as unknown as SerialFacadeService;
+
+      const shellReadiness = createShellReadinessMock();
+      const service = createSession(serial, shellReadiness);
+
+      await expect(firstValueFrom(service.runAfterConnect$())).rejects.toThrow(
+        'Timezone setup failed',
+      );
+      expect(vi.mocked(shellReadiness.setReady)).not.toHaveBeenCalledWith(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
Issue #621 の対応として、タイムゾーン設定を Serial 初期化フローの責務として明確化し、失敗時に握りつぶさず呼び出し元まで伝播するようにしました。

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #621
- Refs #618

## What changed?

- `pi-zero-bootstrap.config` にタイムゾーン定数を追加し、タイムゾーン設定コマンドを初期化設定として集約
- `PiZeroSerialBootstrapService` の timezone 実行失敗を握りつぶさず、明示的なエラーとして throw するよう修正
- timezone 失敗が `setupEnvironment$` / `runAfterConnect$` で伝播することを検証するテストを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `npx nx test libs-web-serial-data-access`
2. `npx nx test libs-terminal-ui`
3. `setupEnvironment$` 失敗ケースと `runAfterConnect$` 失敗伝播ケースが通ることを確認

## Environment (if relevant)

- Browser: N/A
- OS: macOS
- Node version: 24.0.2
- pnpm version: N/A

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)