### PR TITLE
refactor(web-serial): pi zero の初期環境設定フローを整理する

### DIFF
--- a/libs/web-serial/data-access/README.md
+++ b/libs/web-serial/data-access/README.md
@@ -61,13 +61,13 @@ Angular 向けのシリアル（Web Serial + `@gurezo/web-serial-rxjs` v2.3.1）
 2. **ユーザー名送信後** — `Password:` プロンプト。
 3. **パスワード送信後** — Debian MOTD と `pi@raspberrypi:~$` 形式のシェルプロンプト。
 
-シェル到達後は **タイムゾーン等の初期化**（`PI_ZERO_TIMEZONE_STEPS`）を `exec$` で実行する。ターミナルへのライブ表示は **`terminalText$`**、プロンプト照合・ログイン判定は **`lines$`** 由来のバッファを用いる。
+シェル到達後は **環境設定の初期化**（`PI_ZERO_ENVIRONMENT_STEPS`）を `exec$` で実行する。初期化には timezone に加えて language / locale / `TZ` などを含める。ターミナルへのライブ表示は **`terminalText$`**、プロンプト照合・ログイン判定は **`lines$`** 由来のバッファを用いる。
 
 ## CHIRIMEN / Pi Zero 固有ロジックの集約（Issue [#594](https://github.com/gurezo/chirimen-lite-console/issues/594)）
 
-- Pi Zero 向けの **login / password / シェルプロンプト到達確認 / timezone 初期化** は **`PiZeroSerialBootstrapService` に集約**する（[`pi-zero-serial-bootstrap.service.ts`](src/lib/pi-zero-serial-bootstrap.service.ts)）。
+- Pi Zero 向けの **login / password / シェルプロンプト到達確認 / 環境初期化（timezone/language/locale/env）** は **`PiZeroSerialBootstrapService` に集約**する（[`pi-zero-serial-bootstrap.service.ts`](src/lib/pi-zero-serial-bootstrap.service.ts)）。
   - 接続単位の「一度だけ実行」などのオーケストレーションは `PiZeroSessionService`（[`pi-zero-session.service.ts`](src/lib/pi-zero-session.service.ts)）。
-  - timezone ステップ／期待プロンプトの定数は [`pi-zero-bootstrap.config.ts`](src/lib/pi-zero-bootstrap.config.ts) に集約。
+  - 環境初期化ステップ（timezone/language/locale/env）／期待プロンプトの定数は [`pi-zero-bootstrap.config.ts`](src/lib/pi-zero-bootstrap.config.ts) に集約。
 - Pi Zero 固有のプロンプト判定（`pi@…` シェル / `login:` / `Password:` 等）は **`PiZeroPromptDetectorService`** に分離（[`pi-zero-prompt-detector.service.ts`](src/lib/pi-zero-prompt-detector.service.ts)）。
 - `SerialPromptDetectorService` は **汎用 `matchesPrompt` のみ**を提供し、`SerialCommandRunnerService` から共有利用する。
 - 他サービス（`wifi`, `file-manager`, `remote`, `chirimen-setup`, `i2cdetect` など）は Pi Zero 固有ロジックを保持しない。期待プロンプト文字列としての `PI_ZERO_PROMPT` 利用は許容する。

--- a/libs/web-serial/data-access/src/lib/pi-zero-bootstrap.config.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-bootstrap.config.ts
@@ -4,7 +4,7 @@ import { PI_ZERO_PROMPT } from '@libs-web-serial-util';
  * Pi Zero / CHIRIMEN 接続後の初期化で利用する単一ステップの定義（issue #594）。
  * `statusMessage` は機微情報を含めず、ターミナル表示用に使う。
  */
-export interface PiZeroTimezoneStep {
+export interface PiZeroEnvironmentStep {
   statusMessage: string;
   command: string;
 }
@@ -15,12 +15,24 @@ export interface PiZeroTimezoneStep {
  */
 export const PI_ZERO_PROMPT_TARGET = PI_ZERO_PROMPT;
 export const PI_ZERO_TIMEZONE = 'Asia/Tokyo' as const;
+export const PI_ZERO_LANG = 'C.UTF-8' as const;
+export const PI_ZERO_LC_ALL = 'C.UTF-8' as const;
+export const PI_ZERO_TZ_ENV = PI_ZERO_TIMEZONE;
 
 /**
  * 接続直後のタイムゾーン初期化（各ステップの説明とコマンド）。
  * `sudo -n` で対話的パスワード待ちを避ける。
  */
-export const PI_ZERO_TIMEZONE_STEPS: readonly PiZeroTimezoneStep[] = [
+export const PI_ZERO_ENVIRONMENT_STEPS: readonly PiZeroEnvironmentStep[] = [
+  {
+    statusMessage:
+      `[コンソール] 言語環境変数 LANG=${PI_ZERO_LANG} / LC_ALL=${PI_ZERO_LC_ALL} を設定しています...`,
+    command: `export LANG=${PI_ZERO_LANG} LC_ALL=${PI_ZERO_LC_ALL}`,
+  },
+  {
+    statusMessage: '[コンソール] 言語環境変数を確認します。',
+    command: 'locale | sed -n "1,2p"',
+  },
   {
     statusMessage:
       `[コンソール] タイムゾーンを ${PI_ZERO_TIMEZONE} に設定しています...`,
@@ -29,5 +41,13 @@ export const PI_ZERO_TIMEZONE_STEPS: readonly PiZeroTimezoneStep[] = [
   {
     statusMessage: '[コンソール] タイムゾーンの状態を表示します。',
     command: 'timedatectl status',
+  },
+  {
+    statusMessage: `[コンソール] 環境変数 TZ=${PI_ZERO_TZ_ENV} を設定しています...`,
+    command: `export TZ=${PI_ZERO_TZ_ENV}`,
+  },
+  {
+    statusMessage: '[コンソール] 環境変数 TZ を確認します。',
+    command: 'echo "TZ=${TZ:-unset}"',
   },
 ] as const;

--- a/libs/web-serial/data-access/src/lib/pi-zero-bootstrap.config.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-bootstrap.config.ts
@@ -20,8 +20,8 @@ export const PI_ZERO_LC_ALL = 'C.UTF-8' as const;
 export const PI_ZERO_TZ_ENV = PI_ZERO_TIMEZONE;
 
 /**
- * 接続直後のタイムゾーン初期化（各ステップの説明とコマンド）。
- * `sudo -n` で対話的パスワード待ちを避ける。
+ * 接続直後の環境初期化（timezone/language/locale/env 各ステップの説明とコマンド）。
+ * timezone 設定では `sudo -n` を使い、対話的パスワード待ちを避ける。
  */
 export const PI_ZERO_ENVIRONMENT_STEPS: readonly PiZeroEnvironmentStep[] = [
   {

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
@@ -40,7 +40,7 @@ describe('PiZeroSerialBootstrapService', () => {
     expect(send$).toHaveBeenCalledWith('\r\n');
     expect(send$).toHaveBeenCalledWith(`${PI_ZERO_LOGIN_USER}\r\n`);
     expect(send$).toHaveBeenCalledWith(`${PI_ZERO_LOGIN_PASSWORD}\r\n`);
-    expect(exec).toHaveBeenCalledTimes(2); // timezone only
+    expect(exec).toHaveBeenCalledTimes(6); // environment setup steps
   });
 
   it('skips login send when shell already visible after flush', async () => {
@@ -218,16 +218,19 @@ describe('PiZeroSerialBootstrapService', () => {
     expect(send$).toHaveBeenCalledWith(`${PI_ZERO_LOGIN_USER}\r\n`);
   });
 
-  it('keeps timezone status logging', async () => {
+  it('keeps environment status logging', async () => {
     const readUntilPrompt = vi.fn().mockResolvedValue({
       stdout: `ready\r\n${PI_ZERO_PROMPT} `,
     });
-    const exec = vi
-      .fn()
-      .mockResolvedValueOnce({ stdout: '' })
-      .mockResolvedValueOnce({
-        stdout: `timedatectl status\r\n       Time zone: Asia/Tokyo (${PI_ZERO_PROMPT} `,
-      });
+    const exec = vi.fn().mockImplementation((command: string) =>
+      Promise.resolve(
+        command === 'timedatectl status'
+          ? {
+              stdout: `timedatectl status\r\n       Time zone: Asia/Tokyo (${PI_ZERO_PROMPT} `,
+            }
+          : { stdout: '' },
+      ),
+    );
     const send$ = vi.fn().mockReturnValue(of(undefined));
     const serial = {
       readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
@@ -242,7 +245,7 @@ describe('PiZeroSerialBootstrapService', () => {
     expect(logs.some((l) => l.includes('Time zone: Asia/Tokyo'))).toBe(true);
   });
 
-  it('fails setupEnvironment$ when timezone command fails', async () => {
+  it('fails setupEnvironment$ when environment command fails', async () => {
     const exec = vi
       .fn()
       .mockReturnValueOnce(
@@ -255,9 +258,9 @@ describe('PiZeroSerialBootstrapService', () => {
     const logs: string[] = [];
     await expect(
       firstValueFrom(createBootstrap(serial).setupEnvironment$((l) => logs.push(l))),
-    ).rejects.toThrow('Timezone setup failed');
+    ).rejects.toThrow('Environment setup failed');
 
-    expect(logs.some((l) => l.includes('タイムゾーン初期化コマンドに失敗'))).toBe(
+    expect(logs.some((l) => l.includes('環境設定初期化コマンドに失敗'))).toBe(
       true,
     );
   });

--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.ts
@@ -19,7 +19,10 @@ import {
   tap,
   timer,
 } from 'rxjs';
-import { PI_ZERO_PROMPT_TARGET, PI_ZERO_TIMEZONE_STEPS } from './pi-zero-bootstrap.config';
+import {
+  PI_ZERO_ENVIRONMENT_STEPS,
+  PI_ZERO_PROMPT_TARGET,
+} from './pi-zero-bootstrap.config';
 import { PiZeroPromptDetectorService } from './pi-zero-prompt-detector.service';
 import { SerialFacadeService } from './serial-facade.service';
 
@@ -42,7 +45,7 @@ const SHELL_READINESS_TIMEOUT_MESSAGE =
  *   1. **シェルプロンプト到達確認**（{@link probeShellPrompt$}）
  *   2. **ログイン**（{@link loginSequence$}, ID 送信）
  *   3. **パスワード送信**（{@link sendPasswordAndAwaitShell$}）
- *   4. **timezone 初期化**（{@link timezoneSequence$}）
+ *   4. **環境初期化**（{@link environmentSequence$}）
  *
  * シリアル送受信そのものは {@link SerialFacadeService}（`@gurezo/web-serial-rxjs` の
  * `SerialSession` を内包）、接続単位での「一度だけ実行」などのオーケストレーションは
@@ -77,7 +80,7 @@ export class PiZeroSerialBootstrapService {
     onStatus?: PiZeroBootstrapStatusHandler,
   ): Observable<void> {
     const log = onStatus ?? (() => undefined);
-    return this.timezoneSequence$(log);
+    return this.environmentSequence$(log);
   }
 
   /**
@@ -326,13 +329,13 @@ export class PiZeroSerialBootstrapService {
     );
   }
 
-  // --- (4) timezone 初期化 ---------------------------------------------------
+  // --- (4) 環境初期化 ---------------------------------------------------------
 
-  private timezoneSequence$(
+  private environmentSequence$(
     log: PiZeroBootstrapStatusHandler,
   ): Observable<void> {
-    log('[コンソール] タイムゾーン関連の初期化を開始します。');
-    return from(PI_ZERO_TIMEZONE_STEPS).pipe(
+    log('[コンソール] 環境設定の初期化を開始します。');
+    return from(PI_ZERO_ENVIRONMENT_STEPS).pipe(
       concatMap((step) => {
         log(step.statusMessage);
         return this.serial
@@ -350,16 +353,19 @@ export class PiZeroSerialBootstrapService {
                 step.command,
                 PI_ZERO_PROMPT_TARGET,
               );
-              const tzLine = cleaned.match(/Time zone:\s*.+/im)?.[0]?.trim();
-              if (tzLine) {
-                log(`[コンソール] 現在の設定: ${tzLine}`);
+              const highlightedLine = cleaned
+                .split(/\n/)
+                .map((line) => line.trim())
+                .find((line) => /^Time zone:|^(LANG|LC_ALL|TZ)=/i.test(line));
+              if (highlightedLine) {
+                log(`[コンソール] 現在の設定: ${highlightedLine}`);
               }
               for (const line of cleaned.split(/\n/)) {
                 const t = line.trim();
                 if (t.length === 0) {
                   continue;
                 }
-                if (tzLine && /^Time zone:/i.test(t)) {
+                if (highlightedLine && t === highlightedLine) {
                   continue;
                 }
                 log(line);
@@ -369,10 +375,10 @@ export class PiZeroSerialBootstrapService {
               const message =
                 error instanceof Error ? error.message : String(error);
               log(
-                `[コンソール] タイムゾーン初期化コマンドに失敗しました: ${step.command} (${message})`,
+                `[コンソール] 環境設定初期化コマンドに失敗しました: ${step.command} (${message})`,
               );
               throw new Error(
-                `Timezone setup failed at "${step.command}": ${message}`,
+                `Environment setup failed at "${step.command}": ${message}`,
               );
             }),
           );
@@ -380,7 +386,7 @@ export class PiZeroSerialBootstrapService {
       ignoreElements(),
       defaultIfEmpty(undefined),
       tap(() =>
-        log('[コンソール] タイムゾーン関連の初期化が完了しました。'),
+        log('[コンソール] 環境設定の初期化が完了しました。'),
       ),
       map(() => undefined),
     );

--- a/libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts
@@ -153,7 +153,7 @@ describe('PiZeroSessionService', () => {
   });
 
   describe('setup flow (setupEnvironment$)', () => {
-    it('runs each timezone init command over serial exec$', async () => {
+    it('runs each environment init command over serial exec$', async () => {
       const exec = vi.fn().mockReturnValue(of({ stdout: `${PI_ZERO_PROMPT} ` }));
       const serial = {
         exec$: (c: string, o: unknown) => exec(c, o),
@@ -162,9 +162,11 @@ describe('PiZeroSessionService', () => {
       const service = createSession(serial, createShellReadinessMock());
       await firstValueFrom(service.setupEnvironment$());
 
-      expect(exec).toHaveBeenCalledTimes(2);
-      expect(exec.mock.calls[0]?.[0]).toContain('timedatectl set-timezone');
-      expect(exec.mock.calls[1]?.[0]).toBe('timedatectl status');
+      expect(exec).toHaveBeenCalledTimes(6);
+      expect(exec.mock.calls[0]?.[0]).toContain('export LANG=');
+      expect(exec.mock.calls[2]?.[0]).toContain('timedatectl set-timezone');
+      expect(exec.mock.calls[3]?.[0]).toBe('timedatectl status');
+      expect(exec.mock.calls[4]?.[0]).toContain('export TZ=');
     });
   });
 
@@ -241,7 +243,7 @@ describe('PiZeroSessionService', () => {
       );
     });
 
-    it('propagates timezone setup failures to caller', async () => {
+    it('propagates environment setup failures to caller', async () => {
       const readUntilPrompt = vi.fn().mockImplementation(() =>
         of({
           stdout: `${PI_ZERO_PROMPT} `,
@@ -263,7 +265,7 @@ describe('PiZeroSessionService', () => {
       const service = createSession(serial, shellReadiness);
 
       await expect(firstValueFrom(service.runAfterConnect$())).rejects.toThrow(
-        'Timezone setup failed',
+        'Environment setup failed',
       );
       expect(vi.mocked(shellReadiness.setReady)).not.toHaveBeenCalledWith(true);
     });


### PR DESCRIPTION
## Summary

Issue #622 に対応し、Pi Zero 接続後の初期化処理を timezone 専用から language / locale / env を含む環境設定フローへ整理しました。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #622
- Parent: #618

## What changed?

- `PI_ZERO_TIMEZONE_STEPS` を `PI_ZERO_ENVIRONMENT_STEPS` へ拡張し、`LANG` / `LC_ALL` / `TZ` 設定と確認ステップを定数化
- `PiZeroSerialBootstrapService` の setup フローを環境初期化として一般化し、ログ/エラー文言を environment setup に統一
- 関連 spec を新しい実行順・回数・失敗メッセージに合わせて更新し、README の責務説明を環境設定対応へ更新

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `git checkout refactor/web-serial-env-setup-622`
2. `pnpm vitest libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts`
3. Pi Zero 接続後、初期化ログに language / locale / timezone / TZ の順で設定実行が出ることを確認

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [ ] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)