### PR TITLE
refactor(web-serial): 接続後初期化フローを SerialSetupService に集約

### DIFF
--- a/libs/web-serial/data-access/src/index.ts
+++ b/libs/web-serial/data-access/src/index.ts
@@ -7,6 +7,7 @@ export * from './lib/pi-zero-prompt-detector.service';
 export * from './lib/pi-zero-session.service';
 export * from './lib/pi-zero-serial-bootstrap.service';
 export * from './lib/pi-zero-shell-readiness.service';
+export * from './lib/serial-setup.service';
 export * from './lib/serial-command/serial-command-facade.service';
 export * from './lib/serial-facade.service';
 export * from './lib/serial-notification.service';

--- a/libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts
@@ -9,6 +9,7 @@ import { PiZeroSerialBootstrapService } from './pi-zero-serial-bootstrap.service
 import type { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
 import { PiZeroSessionService } from './pi-zero-session.service';
 import type { SerialFacadeService } from './serial-facade.service';
+import { SerialSetupService } from './serial-setup.service';
 
 function createShellReadinessMock(): PiZeroShellReadinessService {
   return {
@@ -27,7 +28,8 @@ function createSession(
     serial,
     new PiZeroPromptDetectorService(),
   );
-  return new PiZeroSessionService(serial, bootstrap, shellReadiness);
+  const setup = new SerialSetupService(bootstrap);
+  return new PiZeroSessionService(serial, setup, shellReadiness);
 }
 
 describe('PiZeroSessionService', () => {

--- a/libs/web-serial/data-access/src/lib/pi-zero-session.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-session.service.ts
@@ -16,10 +16,10 @@ import {
   throwError,
 } from 'rxjs';
 import type { PiZeroBootstrapStatusHandler } from './pi-zero-serial-bootstrap.service';
-import { PiZeroSerialBootstrapService } from './pi-zero-serial-bootstrap.service';
 import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
 import type { SerialFacadeConnectResult } from './serial-facade.service';
 import { SerialFacadeService } from './serial-facade.service';
+import { SerialSetupService } from './serial-setup.service';
 
 /**
  * Pi Zero / CHIRIMEN 固有シリアルセッションの単一エントリ（issue #562）。
@@ -43,7 +43,7 @@ export class PiZeroSessionService {
 
   constructor(
     private readonly serial: SerialFacadeService,
-    private readonly bootstrap: PiZeroSerialBootstrapService,
+    private readonly setup: SerialSetupService,
     readonly shellReadiness: PiZeroShellReadinessService,
   ) {}
 
@@ -58,13 +58,13 @@ export class PiZeroSessionService {
   loginIfNeeded$(
     onStatus?: PiZeroBootstrapStatusHandler,
   ): Observable<void> {
-    return this.bootstrap.loginIfNeeded$(onStatus);
+    return this.setup.loginIfNeeded$(onStatus);
   }
 
   setupEnvironment$(
     onStatus?: PiZeroBootstrapStatusHandler,
   ): Observable<void> {
-    return this.bootstrap.setupEnvironment$(onStatus);
+    return this.setup.setupEnvironment$(onStatus);
   }
 
   /**
@@ -112,7 +112,7 @@ export class PiZeroSessionService {
 
         this.activeBootstrap$ = defer(() => {
           this.initializingSubject.next(true);
-          return this.bootstrap.runPostConnectPipeline$(onStatus);
+          return this.setup.setupAfterConnect$(onStatus).pipe(map(() => undefined));
         }).pipe(
           switchMap(() =>
             this.serial.isConnected$.pipe(

--- a/libs/web-serial/data-access/src/lib/serial-setup.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-setup.service.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { of, throwError, firstValueFrom } from 'rxjs';
+import { SerialSetupService } from './serial-setup.service';
+import type { PiZeroSerialBootstrapService } from './pi-zero-serial-bootstrap.service';
+
+describe('SerialSetupService', () => {
+  it('returns initialized result when setup completes', async () => {
+    const bootstrap = {
+      runPostConnectPipeline$: vi.fn(() => of(undefined)),
+      loginIfNeeded$: vi.fn(() => of(undefined)),
+      setupEnvironment$: vi.fn(() => of(undefined)),
+    } as unknown as PiZeroSerialBootstrapService;
+
+    const service = new SerialSetupService(bootstrap);
+    await expect(firstValueFrom(service.setupAfterConnect$())).resolves.toEqual({
+      initialized: true,
+    });
+    expect(bootstrap.runPostConnectPipeline$).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates setup errors', async () => {
+    const bootstrap = {
+      runPostConnectPipeline$: vi.fn(() =>
+        throwError(() => new Error('setup failed')),
+      ),
+      loginIfNeeded$: vi.fn(() => of(undefined)),
+      setupEnvironment$: vi.fn(() => of(undefined)),
+    } as unknown as PiZeroSerialBootstrapService;
+
+    const service = new SerialSetupService(bootstrap);
+    await expect(firstValueFrom(service.setupAfterConnect$())).rejects.toThrow(
+      'setup failed',
+    );
+  });
+});

--- a/libs/web-serial/data-access/src/lib/serial-setup.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-setup.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@angular/core';
+import { map, type Observable } from 'rxjs';
+import type { PiZeroBootstrapStatusHandler } from './pi-zero-serial-bootstrap.service';
+import { PiZeroSerialBootstrapService } from './pi-zero-serial-bootstrap.service';
+
+export interface SerialSetupResult {
+  initialized: true;
+}
+
+/**
+ * 接続後初期化の単一入口。
+ * login / shell ready / environment setup を順番に実行し、失敗時はエラーを伝播する。
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class SerialSetupService {
+  constructor(private readonly bootstrap: PiZeroSerialBootstrapService) {}
+
+  loginIfNeeded$(onStatus?: PiZeroBootstrapStatusHandler): Observable<void> {
+    return this.bootstrap.loginIfNeeded$(onStatus);
+  }
+
+  setupEnvironment$(onStatus?: PiZeroBootstrapStatusHandler): Observable<void> {
+    return this.bootstrap.setupEnvironment$(onStatus);
+  }
+
+  setupAfterConnect$(
+    onStatus?: PiZeroBootstrapStatusHandler,
+  ): Observable<SerialSetupResult> {
+    return this.bootstrap
+      .runPostConnectPipeline$(onStatus)
+      .pipe(map(() => ({ initialized: true as const })));
+  }
+}


### PR DESCRIPTION
## Summary

Issue #623 の対応として、接続後初期化の単一入口 `SerialSetupService` を導入し、Pi Zero セッションからの呼び出しを一本化しました。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #623
- Refs #618

## What changed?

- `SerialSetupService` を追加し、`setupAfterConnect$()` で login/shell ready/environment setup を順次実行する単一入口を提供
- `PiZeroSessionService` の接続後初期化を `SerialSetupService` 経由へ切り替え
- `serial-setup.service.spec.ts` を新規追加し、成功時 result と失敗時エラー伝播を検証
- `pi-zero-session.service.spec.ts` を新依存構成に追従
- 公開 API に `serial-setup.service` export を追加

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details: `@libs/web-serial/data-access` から `SerialSetupService` / `SerialSetupResult` が参照可能になりました。
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx test libs-web-serial-data-access` を実行する
2. `SerialSetupService` の spec（成功・失敗ケース）が通過することを確認する
3. `PiZeroSessionService` の spec が通過し、接続後初期化の回帰がないことを確認する

## Environment (if relevant)

- Browser: N/A
- OS: macOS
- Node version: (local)
- pnpm version: (local)

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)