### PR TITLE
feat(web-serial): 初期化状態を state として明示化する (#624)

### DIFF
--- a/libs/web-serial/data-access/src/index.ts
+++ b/libs/web-serial/data-access/src/index.ts
@@ -8,6 +8,7 @@ export * from './lib/pi-zero-session.service';
 export * from './lib/pi-zero-serial-bootstrap.service';
 export * from './lib/pi-zero-shell-readiness.service';
 export * from './lib/serial-setup.service';
+export * from './lib/serial-setup-status';
 export * from './lib/serial-command/serial-command-facade.service';
 export * from './lib/serial-facade.service';
 export * from './lib/serial-notification.service';

--- a/libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts
@@ -102,6 +102,30 @@ describe('PiZeroSessionService', () => {
     expect(seen.at(-1)).toBe(false);
   });
 
+  it('emits setupStatus$ transitions and ends in ready on success', async () => {
+    const readUntilPrompt = vi.fn().mockResolvedValue({
+      stdout: `${PI_ZERO_PROMPT} `,
+    });
+    const exec = vi.fn().mockResolvedValue({ stdout: '' });
+    const serial = {
+      isConnected$: of(true),
+      getConnectionEpoch: () => 1,
+      readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
+      exec$: (c: string, o: unknown) => from(exec(c, o)),
+    } as unknown as SerialFacadeService;
+
+    const shellReadiness = createShellReadinessMock();
+    const service = createSession(serial, shellReadiness);
+    const seen: string[] = [];
+    const sub = service.setupStatus$.subscribe((v) => seen.push(v));
+    await firstValueFrom(service.runAfterConnect$());
+    sub.unsubscribe();
+
+    expect(seen).toContain('waiting-login');
+    expect(seen).toContain('setting-timezone');
+    expect(seen.at(-1)).toBe('ready');
+  });
+
   describe('login flow (loginIfNeeded$)', () => {
     it('completes without exec when shell prompt is already present', async () => {
       const readUntilPrompt = vi.fn().mockReturnValue(
@@ -209,6 +233,36 @@ describe('PiZeroSessionService', () => {
 
       expect(vi.mocked(shellReadiness.setReady)).not.toHaveBeenCalledWith(true);
       expect(seen.at(-1)).toBe(false);
+    });
+
+    it('sets setupStatus$ to failed on pipeline failure', async () => {
+      const readUntilPrompt = vi
+        .fn()
+        .mockImplementationOnce(() =>
+          throwError(() => new Error('shell probe timeout')),
+        )
+        .mockImplementationOnce(() => of({ stdout: 'stale buffer' }))
+        .mockImplementationOnce(() =>
+          throwError(() => new Error('login prompt timeout')),
+        )
+        .mockImplementationOnce(() =>
+          throwError(() => new Error('login prompt timeout')),
+        );
+      const serial = {
+        isConnected$: of(true),
+        getConnectionEpoch: () => 1,
+        readUntilPrompt$: (o: unknown) => readUntilPrompt(o),
+        exec$: () => from(Promise.resolve({ stdout: '' })),
+        send$: () => of(undefined),
+      } as unknown as SerialFacadeService;
+
+      const service = createSession(serial, createShellReadinessMock());
+      const seen: string[] = [];
+      const sub = service.setupStatus$.subscribe((v) => seen.push(v));
+      await expect(firstValueFrom(service.runAfterConnect$())).rejects.toThrow();
+      sub.unsubscribe();
+
+      expect(seen.at(-1)).toBe('failed');
     });
 
     it('notifies status handler on pipeline failure', async () => {

--- a/libs/web-serial/data-access/src/lib/pi-zero-session.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-session.service.ts
@@ -17,6 +17,7 @@ import {
 } from 'rxjs';
 import type { PiZeroBootstrapStatusHandler } from './pi-zero-serial-bootstrap.service';
 import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
+import type { SerialSetupStatus } from './serial-setup-status';
 import type { SerialFacadeConnectResult } from './serial-facade.service';
 import { SerialFacadeService } from './serial-facade.service';
 import { SerialSetupService } from './serial-setup.service';
@@ -35,17 +36,26 @@ export class PiZeroSessionService {
   private activeBootstrapEpoch: number | null = null;
 
   private readonly initializingSubject = new BehaviorSubject(false);
+  private readonly setupStatusSubject =
+    new BehaviorSubject<SerialSetupStatus>('idle');
 
   /**
    * 接続後の Pi Zero 初期化パイプライン（ログイン・環境セットアップ等）実行中。
    */
   readonly initializing$ = this.initializingSubject.pipe(distinctUntilChanged());
+  readonly setupStatus$ = this.setupStatusSubject.pipe(distinctUntilChanged());
 
   constructor(
     private readonly serial: SerialFacadeService,
     private readonly setup: SerialSetupService,
     readonly shellReadiness: PiZeroShellReadinessService,
-  ) {}
+  ) {
+    this.setupStatus$.subscribe((status) => {
+      const isInitializing =
+        status !== 'idle' && status !== 'ready' && status !== 'failed';
+      this.initializingSubject.next(isInitializing);
+    });
+  }
 
   connect$(baudRate = 115200): Observable<SerialFacadeConnectResult> {
     return this.serial.connect$(baudRate);
@@ -93,6 +103,14 @@ export class PiZeroSessionService {
     onStatus?: PiZeroBootstrapStatusHandler,
   ): Observable<void> {
     const log = onStatus ?? (() => undefined);
+    const onBootstrapStatus = (line: string): void => {
+      if (line.includes('ログインユーザー')) {
+        this.setupStatusSubject.next('sending-username');
+      } else if (line.includes('パスワードを送信中')) {
+        this.setupStatusSubject.next('sending-password');
+      }
+      log(line);
+    };
 
     return this.shouldRunAfterConnect$().pipe(
       switchMap((shouldRun) => {
@@ -111,9 +129,13 @@ export class PiZeroSessionService {
         this.activeBootstrapEpoch = epoch;
 
         this.activeBootstrap$ = defer(() => {
-          this.initializingSubject.next(true);
-          return this.setup.setupAfterConnect$(onStatus).pipe(map(() => undefined));
+          this.setupStatusSubject.next('waiting-login');
+          return of(undefined);
         }).pipe(
+          switchMap(() => this.setup.loginIfNeeded$(onBootstrapStatus)),
+          tap(() => this.setupStatusSubject.next('waiting-shell')),
+          tap(() => this.setupStatusSubject.next('setting-timezone')),
+          switchMap(() => this.setup.setupEnvironment$(onBootstrapStatus)),
           switchMap(() =>
             this.serial.isConnected$.pipe(
               take(1),
@@ -121,6 +143,7 @@ export class PiZeroSessionService {
                 if (connected) {
                   this.lastBootstrappedEpoch = epoch;
                   this.shellReadiness.setReady(true);
+                  this.setupStatusSubject.next('ready');
                 }
               }),
               map(() => undefined),
@@ -129,11 +152,11 @@ export class PiZeroSessionService {
           catchError((error: unknown) => {
             const message =
               error instanceof Error ? error.message : String(error);
+            this.setupStatusSubject.next('failed');
             log(`[コンソール] 接続後の初期化に失敗しました: ${message}`);
             return throwError(() => error);
           }),
           finalize(() => {
-            this.initializingSubject.next(false);
             if (this.activeBootstrapEpoch === epoch) {
               this.activeBootstrap$ = null;
               this.activeBootstrapEpoch = null;

--- a/libs/web-serial/data-access/src/lib/serial-connection-view-model.facade.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-connection-view-model.facade.spec.ts
@@ -9,19 +9,22 @@ import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
 import { SerialFacadeService } from './serial-facade.service';
 import { SerialNotificationService } from './serial-notification.service';
 import { SerialConnectionViewModelFacade } from './serial-connection-view-model.facade';
+import type { SerialSetupStatus } from './serial-setup-status';
 
 describe('SerialConnectionViewModelFacade', () => {
   it('combines state into vm$', async () => {
-    const state$ = new BehaviorSubject(SerialSessionState.Idle);
+    const state$ = new BehaviorSubject<SerialSessionState>(
+      SerialSessionState.Idle,
+    );
     const connected$ = new BehaviorSubject(false);
-    const initializing$ = new BehaviorSubject(false);
+    const setupStatus$ = new BehaviorSubject<SerialSetupStatus>('idle');
     const ready$ = new BehaviorSubject(false);
 
     const serial: Partial<SerialFacadeService> = {
       state$: state$.asObservable(),
       isConnected$: connected$.asObservable(),
       isBrowserSupported: vi.fn(() => true),
-      connect$: vi.fn(() => of({ ok: true })),
+      connect$: vi.fn(() => of({ ok: true as const })),
       disconnect$: vi.fn(() => of(undefined)),
     };
 
@@ -31,7 +34,7 @@ describe('SerialConnectionViewModelFacade', () => {
         { provide: SerialFacadeService, useValue: serial },
         {
           provide: PiZeroSessionService,
-          useValue: { initializing$: initializing$.asObservable() },
+          useValue: { setupStatus$: setupStatus$.asObservable() },
         },
         {
           provide: PiZeroShellReadinessService,
@@ -68,9 +71,10 @@ describe('SerialConnectionViewModelFacade', () => {
     expect(vm.isConnecting).toBe(false);
     expect(vm.isLoggedIn).toBe(true);
 
-    initializing$.next(true);
+    setupStatus$.next('setting-timezone');
     vm = await firstValueFrom(facade.vm$);
     expect(vm.isInitializing).toBe(true);
+    expect(vm.setupStatus).toBe('setting-timezone');
   });
 
   it('clearError resets errorMessage in vm$', async () => {
@@ -88,7 +92,7 @@ describe('SerialConnectionViewModelFacade', () => {
         { provide: SerialFacadeService, useValue: serial },
         {
           provide: PiZeroSessionService,
-          useValue: { initializing$: of(false) },
+          useValue: { setupStatus$: of('idle') },
         },
         {
           provide: PiZeroShellReadinessService,
@@ -138,7 +142,7 @@ describe('SerialConnectionViewModelFacade', () => {
         },
         {
           provide: PiZeroSessionService,
-          useValue: { initializing$: of(false) },
+          useValue: { setupStatus$: of('idle') },
         },
         {
           provide: PiZeroShellReadinessService,

--- a/libs/web-serial/data-access/src/lib/serial-connection-view-model.facade.ts
+++ b/libs/web-serial/data-access/src/lib/serial-connection-view-model.facade.ts
@@ -14,6 +14,7 @@ import {
 } from 'rxjs';
 import { PiZeroSessionService } from './pi-zero-session.service';
 import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
+import type { SerialSetupStatus } from './serial-setup-status';
 import { SerialFacadeService } from './serial-facade.service';
 import { SerialNotificationService } from './serial-notification.service';
 
@@ -29,6 +30,7 @@ export interface SerialConnectionViewModel {
   isConnecting: boolean;
   isLoggedIn: boolean;
   isInitializing: boolean;
+  setupStatus: SerialSetupStatus;
   errorMessage: string | null;
 }
 
@@ -54,16 +56,17 @@ export class SerialConnectionViewModelFacade {
   readonly vm$: Observable<SerialConnectionViewModel> = combineLatest([
     this.serial.state$,
     this.serial.isConnected$,
-    this.piZero.initializing$,
+    this.piZero.setupStatus$,
     this.shellReadiness.ready$,
     this.errorSubject.asObservable(),
   ]).pipe(
-    map(([state, connected, initializing, loggedInReady, errorMessage]) => ({
+    map(([state, connected, setupStatus, loggedInReady, errorMessage]) => ({
       isBrowserSupported: this.serial.isBrowserSupported(),
       isConnected: connected,
       isConnecting: state === SerialSessionState.Connecting,
       isLoggedIn: loggedInReady,
-      isInitializing: initializing,
+      isInitializing: !['idle', 'ready', 'failed'].includes(setupStatus),
+      setupStatus,
       errorMessage,
     })),
     shareReplay({ bufferSize: 1, refCount: true }),

--- a/libs/web-serial/data-access/src/lib/serial-setup-status.ts
+++ b/libs/web-serial/data-access/src/lib/serial-setup-status.ts
@@ -1,0 +1,9 @@
+export type SerialSetupStatus =
+  | 'idle'
+  | 'waiting-login'
+  | 'sending-username'
+  | 'sending-password'
+  | 'waiting-shell'
+  | 'setting-timezone'
+  | 'ready'
+  | 'failed';


### PR DESCRIPTION
## Summary
接続後セットアップの進行を boolean ではなく状態 (`SerialSetupStatus`) で管理し、UI が状態を表示するだけで済む構成に変更しました。Issue #618 の子 Issue #624 に対応します。

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #624
- Parent #618

## What changed?
- `SerialSetupStatus` 型を追加し、`idle` / `waiting-login` / `sending-username` / `sending-password` / `waiting-shell` / `setting-timezone` / `ready` / `failed` を定義
- `PiZeroSessionService` に `setupStatus$` を追加し、接続後フロー内で状態遷移を管理
- 既存 `initializing$` は `setupStatus$` から導出する互換レイヤーとして維持
- `SerialConnectionViewModelFacade` が `setupStatus` を公開するよう変更（`isInitializing` は状態から算出）
- `PiZeroSessionService` / `SerialConnectionViewModelFacade` の spec を更新し、成功・失敗時の状態遷移を検証

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
 - Details:
   - `libs-web-serial-data-access` の公開 API に `SerialSetupStatus` と `setupStatus$` 利用前提の ViewModel フィールド（`setupStatus`）を追加
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test
1. `pnpm nx test libs-web-serial-data-access` を実行する
2. `PiZeroSessionService` のテストで `setupStatus$` が `ready` / `failed` に遷移することを確認する
3. `SerialConnectionViewModelFacade` のテストで `setupStatus` と `isInitializing` が整合していることを確認する

## Environment (if relevant)
- Browser:
- OS: macOS
- Node version:
- pnpm version:

## Checklist
- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)