### PR TITLE
docs(web-serial): exec$ の用途と terminal API の使い分けを文書化する (#625)

### DIFF
--- a/docs/serial-architecture.md
+++ b/docs/serial-architecture.md
@@ -39,6 +39,14 @@ Issue #590 / [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) 
 - **`exec$` 系**は、プロンプトまで待って **キャプチャした stdout 等をアプリが解釈する**内部処理向け。i2cdetect・setup・ログイン後初期化はその代表例であり、Wi-Fi・ファイル・リモートなど同種の同期コマンドも同じ原則に含める。
 - 詳細は [`SerialFacadeService` の JSDoc](../libs/web-serial/data-access/src/lib/serial-facade.service.ts) および [libs/web-serial/data-access/README.md](../libs/web-serial/data-access/README.md) の「`exec$` の利用方針」を参照。
 
+### `terminalText$` / `send$` / `exec$` の使い分け（[#625](https://github.com/gurezo/chirimen-lite-console/issues/625)）
+
+- **`terminalText$`**: Terminal UI のライブ表示専用。受信表示の責務に限定し、判定処理には使わない。
+- **`send$`**: ユーザー入力送信専用。結果解析や完了待ちは行わない。
+- **`exec$`**: アプリ制御専用。プロンプト同期で完了まで待ち、stdout 等を解釈する内部フローに使う。
+- **UI で `exec$` を使わない理由**: 表示系（`terminalText$`）と制御系（`exec$`）を分離し、二重表示や責務混在を防ぐため。
+- **初期化で `exec$` を使う理由**: ログイン後の環境設定では完了待ちと成功/失敗判定が必要で、キャプチャ結果を返す API が必要になるため。
+
 ### `terminalText$` の責務（[#617](https://github.com/gurezo/chirimen-lite-console/issues/617)）
 
 - **ターミナル UI は `SerialFacadeService#terminalText$` を購読**して xterm 等にライブ表示する。送信は `send$()` のみとし、`exec$` 系の戻り値で同じ画面を更新しない（上記 `exec$` 節および [#616](https://github.com/gurezo/chirimen-lite-console/issues/616) と対で読む）。

--- a/libs/web-serial/data-access/README.md
+++ b/libs/web-serial/data-access/README.md
@@ -26,6 +26,27 @@ Angular 向けのシリアル（Web Serial + `@gurezo/web-serial-rxjs` v2.3.1）
 - **`SerialCommandRunnerService`（`serial-command-runner.service.ts`）／`SerialCommandService` facade** が `lines$` を購読し、プロンプト待ち用に行連結バッファを保持する（表示の `\r` 処理は `terminalText$` と `@libs-web-serial-util` の `collapseCarriageRedrawsPerLine` に委譲）。
 - **ターミナル UI** は **`SerialFacadeService#terminalText$` を購読**し、ライブ表示を xterm 等に反映する（例: `TerminalViewComponent`）。`exec$` の戻り値で同じ画面を二重更新しない。
 
+## 主要 3 API の責務と判断基準（Issue #625）
+
+- **`terminalText$`**
+  - ターミナル UI（xterm 等）のライブ表示専用。
+  - 受信表示の再描画（`\r`）を含む表示責務は `SerialSession.terminalText$` に委譲する。
+  - プロンプト判定やログイン判定には使わない（判定は `lines$` 側）。
+- **`send$()`**
+  - ユーザー入力送信専用（対話入力・ツールバー送信）。
+  - コマンド完了待ちや結果解析は行わない。
+  - Terminal UI は「送信=`send$` / 表示=`terminalText$`」を基本導線にする。
+- **`exec$()`**
+  - アプリ制御用（ログイン後初期化、i2cdetect、setup、結果解析）。
+  - プロンプト同期で完了を待ち、stdout 等のキャプチャ結果を返す。
+  - Terminal UI で使わない理由は、UI 側の責務を「入力送信とライブ表示」に限定し、結果キャプチャ経路との二重更新・責務混在を防ぐため。
+
+### なぜ初期化処理で `exec$` を使うか（Issue #625）
+
+- 接続直後の bootstrap は、コマンド送信後にプロンプトまで待つ同期制御と結果判定が必要になる。
+- タイムゾーンや環境設定の成功/失敗を呼び出し元へ伝播するため、キャプチャ結果を返す `exec$` が適している。
+- その結果、Terminal UI は表示責務を維持しつつ、初期化フローは制御責務として分離できる。
+
 ## 接続状態の単一ビューモデル（[#564](https://github.com/gurezo/chirimen-lite-console/issues/564)）
 
 コンポーネント向けには **`SerialConnectionViewModelFacade`** が `vm$: Observable<SerialConnectionViewModel>` を提供する。接続・切断・送信（ツールバーと同様に `TerminalCommandRequestService.requestCommand` 経由）および `clearError()` を前置し、ブラウザ対応フラグ、`SerialFacadeService.state$` に基づく接続試行状態、`PiZeroShellReadinessService.ready$`（問題文での「ログイン済み」と同義：`isLoggedIn`）、`PiZeroSessionService.initializing$` での初期化フラグ、`errorMessage` をまとめる。

--- a/libs/web-serial/data-access/src/lib/serial-facade.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-facade.service.ts
@@ -68,6 +68,13 @@ export class SerialFacadeService {
     return this.connection.disconnect$();
   }
 
+  /**
+   * ターミナル対話のユーザー入力をそのまま送るための送信 API（Issue #625）。
+   *
+   * - 主用途はキーボード入力・ツールバー送信などの UI 由来入力。
+   * - 本メソッドは送信のみを担い、コマンド完了待ちや結果解析は行わない。
+   * - 完了待ち・stdout 解析が必要なアプリ制御フローは {@link #exec$} を使う。
+   */
   send$(data: string): Observable<void> {
     return this.transport.send$(data);
   }
@@ -82,6 +89,7 @@ export class SerialFacadeService {
    * **利用境界（[#616](https://github.com/gurezo/chirimen-lite-console/issues/616)）**
    * - **ターミナル UI（xterm の対話・ツールバー送信）では呼ばない。** 表示は {@link #terminalText$}、送信は {@link #send$} に統一する（親 [#609](https://github.com/gurezo/chirimen-lite-console/issues/609)）。
    * - **アプリ内部**で「コマンド完了まで待ち、stdout を取りたい」フロー向け。代表例はログイン後 bootstrap、i2cdetect、Chirimen setup など。Wi-Fi・ファイルマネージャ・リモート等、プロンプト待ちが必要な機能も同じ層に含める。
+   * - とくに接続後初期化（ログイン後の環境設定）は、成功/失敗を判定して呼び出し元へ返す必要があるため `exec$` を使う（Issue #625）。
    *
    * {@link SerialCommandService#exec$} に委譲する。
    */


### PR DESCRIPTION
## Summary

Issue #625 に対応し、`terminalText$` / `send$` / `exec$` の責務と使い分けを README・アーキテクチャ文書・Facade JSDoc で明文化しました。
Terminal UI で `exec$` を使わない理由と、接続後初期化で `exec$` を使う理由を実装判断の基準として統一しています。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #625
- Refs #618

## What changed?

- `libs/web-serial/data-access/README.md` に 3 API の責務と判断基準を追記
- `docs/serial-architecture.md` に `terminalText$` / `send$` / `exec$` の使い分け節を追加
- `libs/web-serial/data-access/src/lib/serial-facade.service.ts` の JSDoc を補強し、`send$` と `exec$` の利用境界を明確化

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `libs/web-serial/data-access/README.md` の「主要 3 API の責務と判断基準」節を確認する
2. `docs/serial-architecture.md` の「terminalText$ / send$ / exec$ の使い分け」節を確認する
3. `serial-facade.service.ts` の `send$` / `exec$` JSDoc が上記文書と整合することを確認する

## Environment (if relevant)

- Browser: N/A
- OS: macOS / Windows / Linux
- Node version: N/A
- pnpm version: N/A

## Checklist

- [ ] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)