### PR TITLE
test(web-serial): 初期化フローの timezone 正常系・異常系テストを追加 (#626)

### DIFF
--- a/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts
@@ -264,4 +264,46 @@ describe('PiZeroSerialBootstrapService', () => {
       true,
     );
   });
+
+  it('executes timezone setup and status commands successfully', async () => {
+    const executedCommands: string[] = [];
+    const exec = vi.fn().mockImplementation((command: string) => {
+      executedCommands.push(command);
+      return of(
+        command === 'timedatectl status'
+          ? { stdout: 'Time zone: Asia/Tokyo\n' }
+          : { stdout: '' },
+      );
+    });
+    const serial = {
+      exec$: (c: string, o: unknown) => exec(c, o),
+    } as unknown as SerialFacadeService;
+
+    await expect(
+      firstValueFrom(createBootstrap(serial).setupEnvironment$()),
+    ).resolves.toBeUndefined();
+
+    expect(executedCommands).toContain(
+      'sudo -n timedatectl set-timezone Asia/Tokyo 2>/dev/null',
+    );
+    expect(executedCommands).toContain('timedatectl status');
+  });
+
+  it('fails setupEnvironment$ when timezone setup command fails', async () => {
+    const exec = vi.fn().mockImplementation((command: string) => {
+      if (command.startsWith('sudo -n timedatectl set-timezone')) {
+        return throwError(() => new Error('timedatectl permission denied'));
+      }
+      return of({ stdout: '' });
+    });
+    const serial = {
+      exec$: (c: string, o: unknown) => exec(c, o),
+    } as unknown as SerialFacadeService;
+
+    await expect(
+      firstValueFrom(createBootstrap(serial).setupEnvironment$()),
+    ).rejects.toThrow(
+      'Environment setup failed at "sudo -n timedatectl set-timezone Asia/Tokyo 2>/dev/null"',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Issue #626 の完了条件に合わせて、Pi Zero 初期化フローの timezone 設定に対する service 単体テストを追加しました。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #626
- Refs #618

## What changed?

- `setupEnvironment$` が timezone 設定コマンドを実行し、`timedatectl status` まで到達する正常系を追加
- `sudo -n timedatectl set-timezone ...` が失敗した場合に、適切なエラーで失敗伝播する異常系を追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx test libs-web-serial-data-access` を実行する
2. `libs/web-serial/data-access/src/lib/pi-zero-serial-bootstrap.service.spec.ts` の追加2ケースが成功することを確認する
3. 全89テストが成功し、失敗がないことを確認する

## Environment (if relevant)

- Browser: N/A
- OS: macOS
- Node version: プロジェクト既定
- pnpm version: プロジェクト既定

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)