### PR TITLE
refactor(terminal): deprecated terminal output 経路を削除し terminalText$ に一本化

### DIFF
--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
@@ -4,9 +4,7 @@ import {
   EMPTY,
   firstValueFrom,
   forkJoin,
-  from,
   of,
-  Subject,
   throwError,
 } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -212,112 +210,4 @@ describe('TerminalConsoleOrchestrationService', () => {
     );
   });
 
-  it('pipeTerminalOutputToSink$ forwards receive$ chunks to sink.write', async () => {
-    const chunks = new Subject<string>();
-    TestBed.overrideProvider(SerialFacadeService, {
-      useValue: {
-        send$: sendMock,
-        exec$: execMock,
-        isConnected$: of(true),
-        connectionEstablished$: of(undefined),
-        receive$: chunks.asObservable(),
-        terminalText$: EMPTY,
-        getConnectionEpoch: () => 1,
-      },
-    });
-    TestBed.overrideProvider(PiZeroSessionService, {
-      useValue: {
-        shouldRunAfterConnect$: () => of(true),
-        runAfterConnect$: () => of(undefined),
-      },
-    });
-    const write = vi.fn();
-    const svc = TestBed.inject(TerminalConsoleOrchestrationService);
-    const sub = svc.pipeTerminalOutputToSink$({ write }).subscribe();
-    chunks.next('a');
-    chunks.next('b');
-    expect(write).toHaveBeenNthCalledWith(1, 'a');
-    expect(write).toHaveBeenNthCalledWith(2, 'b');
-    sub.unsubscribe();
-  });
-
-  it('does not suppress receive$ mirror while runInteractiveCommand awaits send$', async () => {
-    const chunks = new Subject<string>();
-    let resolveSend!: () => void;
-    const sendDone = new Promise<void>((r) => {
-      resolveSend = r;
-    });
-    const deferredSend = vi.fn(() => from(sendDone));
-    TestBed.overrideProvider(SerialFacadeService, {
-      useValue: {
-        send$: deferredSend,
-        exec$: execMock,
-        isConnected$: of(true),
-        connectionEstablished$: of(undefined),
-        receive$: chunks.asObservable(),
-        terminalText$: EMPTY,
-        getConnectionEpoch: () => 1,
-      },
-    });
-    TestBed.overrideProvider(PiZeroSessionService, {
-      useValue: {
-        shouldRunAfterConnect$: () => of(true),
-        runAfterConnect$: () => of(undefined),
-      },
-    });
-    const write = vi.fn();
-    const svc = TestBed.inject(TerminalConsoleOrchestrationService);
-    const mirrorSub = svc.pipeTerminalOutputToSink$({ write }).subscribe();
-
-    const cmdPromise = svc.runInteractiveCommand('date');
-    await Promise.resolve();
-    chunks.next('during-send');
-    expect(write).toHaveBeenCalledWith('during-send');
-
-    resolveSend();
-    await cmdPromise;
-
-    chunks.next('after-send');
-    expect(write).toHaveBeenCalledWith('after-send');
-
-    mirrorSub.unsubscribe();
-  });
-
-  it('suppresses receive$ mirror while bootstrap is running', async () => {
-    const chunks = new Subject<string>();
-    const bootstrapDone$ = new Subject<void>();
-    TestBed.overrideProvider(SerialFacadeService, {
-      useValue: {
-        send$: sendMock,
-        exec$: execMock,
-        isConnected$: of(true),
-        connectionEstablished$: of(undefined),
-        receive$: chunks.asObservable(),
-        terminalText$: EMPTY,
-        getConnectionEpoch: () => 1,
-      },
-    });
-    TestBed.overrideProvider(PiZeroSessionService, {
-      useValue: {
-        shouldRunAfterConnect$: () => of(true),
-        runAfterConnect$: () => bootstrapDone$.asObservable(),
-      },
-    });
-    const write = vi.fn();
-    const writeln = vi.fn();
-    const svc = TestBed.inject(TerminalConsoleOrchestrationService);
-    const mirrorSub = svc.pipeTerminalOutputToSink$({ write }).subscribe();
-    const bootSub = svc.bootstrapAfterConnect$('prefix', { write, writeln }).subscribe();
-
-    chunks.next('during-bootstrap');
-    expect(write).not.toHaveBeenCalledWith('during-bootstrap');
-
-    bootstrapDone$.next();
-    bootstrapDone$.complete();
-    chunks.next('after-bootstrap');
-    expect(write).toHaveBeenCalledWith('after-bootstrap');
-
-    bootSub.unsubscribe();
-    mirrorSub.unsubscribe();
-  });
 });

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
@@ -8,13 +8,11 @@ import {
   EMPTY,
   Observable,
   catchError,
-  filter,
   finalize,
   firstValueFrom,
   shareReplay,
   switchMap,
   take,
-  tap,
   throwError,
 } from 'rxjs';
 
@@ -35,13 +33,6 @@ export interface TerminalConsoleSink {
  * xterm に書き込む方式に移行した。`terminalText$` はライブラリ内で `\r` 再描画を
  * 畳んだ累積全文を emit するため、そのまま `write` すると二重表示になる点に注意する。
  *
- * ### 生受信ミラー（issue #566 / #610 で停止）
- *
- * 旧来は本サービスの {@link #pipeTerminalOutputToSink$} が
- * {@link SerialFacadeService#receive$} の生チャンクを xterm にミラーしていた。
- * Issue #610 で UI 側購読を停止し、シグネチャと spec のみ温存している
- * （親 #609 配下の後続サブ issue で本メソッド自体を削除予定）。
- *
  * ### 対話・ツールバー（issue #611 / #612 / #615）
  *
  * キーボード入力もツールバー経由のコマンドも {@link SerialFacadeService#send$} で
@@ -61,8 +52,6 @@ export class TerminalConsoleOrchestrationService {
   private readonly piZeroSession = inject(PiZeroSessionService);
   private activeBootstrap$: Observable<void> | null = null;
   private activeBootstrapEpoch: number | null = null;
-  /** bootstrap 中は 0 より大きくし、{@link #pipeTerminalOutputToSink$} を止める */
-  private terminalMirrorSuppressDepth = 0;
 
   readonly connectionEstablished$ = this.serial.connectionEstablished$;
   readonly isConnected$ = this.serial.isConnected$;
@@ -121,7 +110,6 @@ export class TerminalConsoleOrchestrationService {
     this.activeBootstrapEpoch = epoch;
     this.activeBootstrap$ = this.piZeroSession.shouldRunAfterConnect$().pipe(
       switchMap((should) => {
-        this.terminalMirrorSuppressDepth++;
         if (!should) {
           this.writeConsoleLine(sink, `${prefixMessage} 初期化済みのためスキップします。`);
           return EMPTY;
@@ -141,7 +129,6 @@ export class TerminalConsoleOrchestrationService {
         return throwError(() => error);
       }),
       finalize(() => {
-        this.terminalMirrorSuppressDepth--;
         if (this.activeBootstrapEpoch === epoch) {
           this.activeBootstrap$ = null;
           this.activeBootstrapEpoch = null;
@@ -150,22 +137,6 @@ export class TerminalConsoleOrchestrationService {
       shareReplay({ bufferSize: 1, refCount: true }),
     );
     return this.activeBootstrap$;
-  }
-
-  /**
-   * {@link SerialFacadeService#receive$} の UTF-8 チャンクを xterm 等へそのまま流す（TTY 相当）。
-   * プロンプト判定・コマンド結果の行処理には使わないこと。
-   *
-   * @deprecated Issue #610 でライブ表示は {@link SerialFacadeService#terminalText$} 直購読に
-   * 移行済み。UI 側からは購読されておらず、親 issue #609 配下の後続サブ issue で削除予定。
-   */
-  pipeTerminalOutputToSink$(
-    sink: Pick<TerminalConsoleSink, 'write'>,
-  ): Observable<string> {
-    return this.serial.receive$.pipe(
-      filter(() => this.terminalMirrorSuppressDepth === 0),
-      tap((chunk) => sink.write(chunk)),
-    );
   }
 
   private writeConsoleLine(sink: TerminalConsoleSink, line: string): void {


### PR DESCRIPTION
## Summary

deprecated 扱いだった terminal output ミラー経路を削除し、ターミナル表示経路を `terminalText$` に統一しました。
Issue #645 の完了条件（deprecated 経路削除・既存表示非破壊）を満たすため、関連テストも更新しています。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #645
- Parent #643

## What changed?

- `TerminalConsoleOrchestrationService` から deprecated API `pipeTerminalOutputToSink$` を削除
- `receive$` ミラー抑止のためだけに存在していた内部状態（`terminalMirrorSuppressDepth`）と関連処理を削除
- 削除した deprecated 経路に依存する spec を整理し、現行の `terminalText$` 導線に沿うテストのみ維持

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details: `TerminalConsoleOrchestrationService#pipeTerminalOutputToSink$` を削除（deprecated API の除去）
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes: 既存UIはすでに `SerialFacadeService#terminalText$` を購読しているため、通常運用での移行作業は不要

## How to test

1. `pnpm nx test libs-terminal-ui`
2. `pnpm nx lint libs-terminal-ui`
3. `terminal-console-orchestration.service.spec.ts` / `terminal-view.component.spec.ts` が通過することを確認

## Environment (if relevant)

- Browser: N/A
- OS: macOS
- Node version: N/A
- pnpm version: N/A

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)