### PR TITLE
docs(web-serial-data-access): README のストリーム説明を実装方針に合わせる

### DIFF
--- a/docs/serial-architecture.md
+++ b/docs/serial-architecture.md
@@ -31,7 +31,7 @@ chirimen-lite-console（本リポジトリ）
 
 本リポジトリでは `SerialSession`（`state$` / `isConnected$` / `errors$` 等）を **接続状態などの唯一のソース** とし、[`SerialTransportService`](../libs/web-serial/data-access/src/lib/serial-transport.service.ts) は `activeSession$` 経由内の **橋渡し（thin adapter）** に留める。Pi Zero 向けの接続・ログイン・初期化は `PiZeroSessionService` やオーケストレーション層に集約し、機能コンポーネントから `SerialTransportService` を直接注入しない方針とする（[`SerialFacadeService`](../libs/web-serial/data-access/src/lib/serial-facade.service.ts) 経由）。
 
-Issue #590 / [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) 以降は、外部公開 API を `SerialFacadeService` に集約し、利用側は `terminalText$` / `lines$` / `state$` / `isConnected$` / `errors$` / `portInfo$` と `connect$()` / `disconnect$()` / `send$()` / `exec$()` / `execRaw$()` / `readUntilPrompt$()` を基本導線とする。Pi Zero のログイン〜タイムゾーン初期化の期待シーケンスは [Issue #606](https://github.com/gurezo/chirimen-lite-console/issues/606) を参照。
+Issue #590 / [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) 以降は、外部公開 API を `SerialFacadeService` に集約し、利用側は `terminalText$` / `lines$` / `state$` / `isConnected$` / `errors$` / `portInfo$` と `connect$()` / `disconnect$()` / `send$()` / `exec$()` / `execRaw$()` / `readUntilPrompt$()` を基本導線とする。`receive$` は Facade に **フィールドとして露出する**が、**Feature からの購読は行わない**（プロンプト照合・`exec$` の stdout 集約は data-access 内部で `receive$` を用いる。[#646](https://github.com/gurezo/chirimen-lite-console/issues/646)）。Pi Zero のログイン〜タイムゾーン初期化の期待シーケンスは [Issue #606](https://github.com/gurezo/chirimen-lite-console/issues/606) を参照。
 
 ### `exec$` 系 API の責務（[#616](https://github.com/gurezo/chirimen-lite-console/issues/616)）
 
@@ -55,13 +55,14 @@ Issue #590 / [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) 
 
 ## 受信ストリーム（ライブラリ vs 本アプリの公開面）
 
-ライブラリの `SerialSession` は `receive$` / `receiveReplay$` / `lines$` / `terminalText$` 等を提供する。本アプリの **`SerialFacadeService` では `terminalText$` と `lines$` のみ**を公開し、ライブ表示の `\r` 再描画やバッファ正規化は **ライブラリの `terminalText$`** に委譲する（[#601](https://github.com/gurezo/chirimen-lite-console/issues/601)）。
+ライブラリの `SerialSession` は `receive$` / `receiveReplay$` / `lines$` / `terminalText$` 等を提供する。本アプリの **`SerialFacadeService`** は `terminalText$` / `lines$` / **`receive$`** を `readonly` で橋渡しする。うち **Feature が購読するのは `terminalText$` と `lines$`** とし、`receive$` は **internal 契約**（`SerialCommandRunnerService` がプロンプト照合・`exec$` stdout 用に購読）とする（[#601](https://github.com/gurezo/chirimen-lite-console/issues/601)、[#646](https://github.com/gurezo/chirimen-lite-console/issues/646)）。ライブ表示の `\r` 再描画や表示用バッファ正規化は **ライブラリの `terminalText$`** に委譲する。
 
 | ストリーム | ライブラリ `SerialSession` | 本アプリ `SerialFacadeService` |
 |------------|---------------------------|--------------------------------|
-| `terminalText$` | terminal helper 相当の表示用テキスト | 公開（xterm ライブ表示） |
-| `lines$` | 行境界で分割された行 | 公開（プロンプト・exec バッファ） |
-| `receive$` / `receiveReplay$` | 生チャンク | **非公開**（高度用途はライブラリを直接利用する別途の設計とする） |
+| `terminalText$` | terminal helper 相当の表示用テキスト | Feature から購読可（xterm ライブ表示） |
+| `lines$` | 行境界で分割された行 | Feature から購読可（行単位の読み取り） |
+| `receive$` | UTF-8 デコード済みの生チャンク | フィールドはあるが **Feature からは購読しない**（data-access 内部のコマンド実行層が利用） |
+| `receiveReplay$` | 生チャンク（リプレイ付き） | Facade では橋渡ししない |
 
 ### 本アプリでの推奨利用
 
@@ -69,12 +70,12 @@ Issue #590 / [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) 
 
 - **ターミナル表示（xterm 等・TTY 再描画を含むライブ表示）**  
   - `terminalText$` のみを購読する。受信テキストをそのまま xterm に書き込み、`sanitizeSerialStdout` は **ターミナル UI 経路では使用しない**（[#613](https://github.com/gurezo/chirimen-lite-console/issues/613)）。
-- **コマンド実行・プロンプト待ち・ログイン判定など「行」単位の処理**  
-  - `lines$` と同根の **`commandResultLines$` / `getReadStream()`**（複数購読で行が取り合いにならないようマルチキャスト）。**プロンプト検出に `receiveReplay$` 単体は寄せない**（チャンク境界と ANSI・行処理の齟齬を避ける）。
+- **コマンド実行・プロンプト待ち・ログイン判定（本リポジトリの Feature）**  
+  - **`exec$` / `execRaw$` / `readUntilPrompt$`** を使う。プロンプト照合バッファは **`SerialCommandRunnerService` が `receive$` から構築**する（getty の lone `\r` 等で `lines$` が空振りしうるため、照合の一次入力を `lines$` のみに寄せない。[#593](https://github.com/gurezo/chirimen-lite-console/issues/593)、[#646](https://github.com/gurezo/chirimen-lite-console/issues/646)）。ライブラリ層では `lines$` と同根の **`commandResultLines$` / `getReadStream()`** 等の設計もあるが、本アプリの利用境界は [README](../libs/web-serial/data-access/README.md) を正とする。
 - **単一購読で `SerialSession.lines$` をそのまま見たい場合**  
   - `lines$` の素の橋渡し。
-- **リプレイ不要な生チャンクが必要な場合**  
-  - `receive$`。
+- **生チャンクを直接扱う必要がある場合（本アプリの Feature）**  
+  - `receive$` を **直接購読しない**。高度用途はライブラリを直接利用する別設計とし、通常は上記 `exec$` 系に任せる。
 - **exec 結果の整形表示（エコー削り・プロンプト削り・ANSI 除去）**  
   - `@libs-terminal-util` の `sanitizeSerialStdout`（ライブ表示の `\r` 収束は行わず、`terminalText$` に委譲）。利用は **exec キャプチャ後の後処理**に限定し、残存例は Pi Zero 初期化コマンドのコンソールログや Remote の一覧パースなど（親 [#609](https://github.com/gurezo/chirimen-lite-console/issues/609) の非対象フロー）。
 
@@ -95,3 +96,4 @@ Issue #590 / [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) 
 - [#613](https://github.com/gurezo/chirimen-lite-console/issues/613) — ターミナル UI から stdout 整形（`sanitizeSerialStdout`）を排除し、表示は `terminalText$` の生データに統一
 - [#616](https://github.com/gurezo/chirimen-lite-console/issues/616) — `exec$` の責務整理（ターミナル外の内部同期コマンド用と文書化）
 - [#617](https://github.com/gurezo/chirimen-lite-console/issues/617) — `terminalText$` の責務明確化（ドキュメント・JSDoc）
+- [#646](https://github.com/gurezo/chirimen-lite-console/issues/646) — README / ドキュメント上の `receive$` / `lines$` / `terminalText$` と Feature 境界の明文化

--- a/libs/web-serial/data-access/README.md
+++ b/libs/web-serial/data-access/README.md
@@ -8,30 +8,41 @@ Angular 向けのシリアル（Web Serial + `@gurezo/web-serial-rxjs` v2.3.1）
 
 アプリでは `@gurezo/web-serial-rxjs` の `SerialSession` が提供する受信 Observable を、用途に応じて次のように使い分ける（[#559](https://github.com/gurezo/chirimen-lite-console/issues/559)）。
 
-| 用途 | 使用する stream |
+### Feature 向け推奨導線（[#646](https://github.com/gurezo/chirimen-lite-console/issues/646)）
+
+- **入口**: `SerialFacadeService` のみ（他サービスに `SerialTransportService` を直接注入しない）。
+- **ターミナル表示**: `terminalText$` を購読する。
+- **ユーザー入力の送信**: `send$()`。
+- **コマンド実行（stdout キャプチャ付き）**: `exec$()` / `execRaw$()`。
+- **送信なしでプロンプト出現まで待つ**: `readUntilPrompt$()`。
+- **生の `receive$` を Feature から購読しない**（プロンプト同期は上記 `exec$` 系に任せる。内部では `receive$` チャンクをバッファして照合する）。
+
+| 用途 | 使用する stream / API |
 | --- | --- |
-| ターミナル表示（terminal helper で整形済みテキスト） | `terminalText$`（= `session.terminalText$`） |
-| コマンド実行・結果取得に使う **行** | `lines$` |
-| 通常の行単位ログ（単一購読の素の橋渡し） | `lines$` |
-| prompt / login / password 判定 | **`lines$`** を購読し、行を `\n` で連結したバッファで判定（[#593](https://github.com/gurezo/chirimen-lite-console/issues/593)） |
+| ターミナル表示（TTY の `\r` 再描画を含むライブ表示） | `terminalText$`（= `session.terminalText$`） |
+| 行境界が確定した **行** の購読（例: `read$()` の単発行） | `lines$` |
+| プロンプト同期・ログイン〜シェル到達・`exec$` の stdout 照合（**Feature から**） | **`readUntilPrompt$` / `exec$` / `execRaw$`**（内部実装がバッファリングと照合を担当） |
+| 上記と同種の照合（**data-access 内部**） | **`SerialCommandRunnerService` が `receive$` を購読**しチャンクを連結。`collapseCarriageRedrawsPerLine` 等で論理表示に収束させてから照合する（getty が行末を lone `\r` のみにすると `lines$` が遅れる／空振りすることがあるため）（[#593](https://github.com/gurezo/chirimen-lite-console/issues/593)） |
 
 ### issue #566（表示用 vs コマンド用）
 
-- **`terminalText$`（facade / transport）** = `session.terminalText$`。xterm など **UI 表示専用**。プロンプト検出に使わない。
-- **`lines$`（facade / transport）** = `SerialSession.lines$`。行単位読み取りはこの stream に統一する。
+- **`terminalText$`（facade / transport）** = `session.terminalText$`。xterm など **UI 表示専用**。プロンプト照合には使わない。
+- **`lines$`（facade / transport）** = `SerialSession.lines$`。行単位の購読・`read$()` 向け。コマンドランナーのプロンプト用バッファの **唯一の入力**ではない（上表のとおり `receive$` を併用する）。
+- **`receive$`（facade / transport）** = `session.receive$` の UTF-8 デコード済み生チャンク。**Feature から直接購読しない**（原則 internal）。プロンプト照合バッファは `SerialCommandRunnerService` が本 stream から構築する。
 
 ### 本プロジェクト内の対応
 
 - **`SerialTransportService`** が上記各ストリームを `activeSession$` 経由で橋渡しする。
-- **`SerialCommandRunnerService`（`serial-command-runner.service.ts`）／`SerialCommandService` facade** が `lines$` を購読し、プロンプト待ち用に行連結バッファを保持する（表示の `\r` 処理は `terminalText$` と `@libs-web-serial-util` の `collapseCarriageRedrawsPerLine` に委譲）。
-- **ターミナル UI** は **`SerialFacadeService#terminalText$` を購読**し、ライブ表示を xterm 等に反映する（例: `TerminalViewComponent`）。`exec$` の戻り値で同じ画面を二重更新しない。
+- **`SerialCommandRunnerService`**（`serial-command-runner.service.ts`）が **`receive$` を購読**し、プロンプト待ち・`exec$` の stdout 集約用の `readBuffer` に追記する（`stripSerialAnsiForPrompt`・チャンク連結・必要に応じた `collapseCarriageRedrawsPerLine` による論理行への収束は実装および [#593](https://github.com/gurezo/chirimen-lite-console/issues/593) を参照）。
+- **`SerialCommandService` facade** はキュー・再試行・上記ランナーへの委譲を担い、**Feature は `exec$` / `readUntilPrompt$` 経由で**プロンプト同期を行う。
+- **ターミナル UI** は **`SerialFacadeService#terminalText$` を購読**し、ライブ表示を xterm 等に反映する（例: `TerminalViewComponent`）。`receive$` を xterm に直結しない（[#613](https://github.com/gurezo/chirimen-lite-console/issues/613)）。`exec$` の戻り値で同じ画面を二重更新しない。
 
 ## 主要 3 API の責務と判断基準（Issue #625）
 
 - **`terminalText$`**
   - ターミナル UI（xterm 等）のライブ表示専用。
   - 受信表示の再描画（`\r`）を含む表示責務は `SerialSession.terminalText$` に委譲する。
-  - プロンプト判定やログイン判定には使わない（判定は `lines$` 側）。
+  - プロンプト判定やログイン判定には使わない。**Feature** が同期待ちする場合は **`readUntilPrompt$` / `exec$` / `execRaw$`** を使う（バッファは data-access 内で `receive$` から構築される）。
 - **`send$()`**
   - ユーザー入力送信専用（対話入力・ツールバー送信）。
   - コマンド完了待ちや結果解析は行わない。
@@ -56,15 +67,16 @@ Angular 向けのシリアル（Web Serial + `@gurezo/web-serial-rxjs` v2.3.1）
 - UI / Feature / 他ライブラリからの Serial 利用は **`SerialFacadeService` のみ**を参照する。
 - `SerialTransportService` は data-access 内部の thin adapter 実装として扱い、外部公開 API として依存しない。
 - Facade の主な利用 API は次のとおり:
-  - stream: `terminalText$`, `lines$`, `state$`, `isConnected$`, `errors$`, `portInfo$`
+  - stream（Feature から購読してよいもの）: `terminalText$`, `lines$`, `state$`, `isConnected$`, `errors$`, `portInfo$`
+  - stream（**フィールドは公開されているが Feature からは購読しない**・internal 契約）: `receive$`（`SerialCommandRunnerService` がプロンプト照合・`exec$` stdout 用に利用。[#601](https://github.com/gurezo/chirimen-lite-console/issues/601)、[#646](https://github.com/gurezo/chirimen-lite-console/issues/646)）
   - methods: `connect$()`, `disconnect$()`, `send$()`, `exec$()`, `execRaw$()`, `readUntilPrompt$()`, `read$()`, `getPort()`, `isRaspberryPiZero()`, `getConnectionEpoch()`, `isReading()`, `getPendingCommandCount()`
-- 生 `receive$` / `receiveReplay$` は facade では公開しない（[#601](https://github.com/gurezo/chirimen-lite-console/issues/601)）。ライブ表示の `\r` 再描画は `terminalText$` に委譲する。
+- ライブラリの `receiveReplay$` は本 data-access の Facade では橋渡ししない。ライブ表示の `\r` 再描画は `terminalText$` に委譲する。
 
 ### `terminalText$` の責務（[#617](https://github.com/gurezo/chirimen-lite-console/issues/617)）
 
 - **ターミナル UI（xterm のライブ表示）は `SerialFacadeService#terminalText$` を購読する**唯一のソースとする。受信テキストの TTY 相当の扱い（累積全文の emit 等）は `@gurezo/web-serial-rxjs` の `SerialSession.terminalText$` に委譲する（[#601](https://github.com/gurezo/chirimen-lite-console/issues/601)、[#613](https://github.com/gurezo/chirimen-lite-console/issues/613)）。
 - **送信**は `send$()` のみ。ライブ表示の更新に **`exec$()` / `execRaw$()` / `readUntilPrompt$()` の戻り値を流用しない**（`exec$` 系は stdout キャプチャ用。使い分けは次節および [#616](https://github.com/gurezo/chirimen-lite-console/issues/616)）。
-- **プロンプト検出・ログイン判定**は **`lines$`** 側のバッファを用い、`terminalText$` をプロンプト照合に使わない（上表・[#593](https://github.com/gurezo/chirimen-lite-console/issues/593)）。
+- **プロンプト検出・ログイン判定**は **`terminalText$` を使わず**、`readUntilPrompt$` / `exec$` 経由で data-access 内部の **`receive$` 由来バッファ**により行う（上表・[#593](https://github.com/gurezo/chirimen-lite-console/issues/593)、[#646](https://github.com/gurezo/chirimen-lite-console/issues/646)）。
 - 契約の一次情報は `SerialFacadeService`（`serial-facade.service.ts`）の **`terminalText$` および `exec$` の JSDoc** を参照する。
 
 ### `exec$` / `execRaw$` / `readUntilPrompt$` の利用方針（[#616](https://github.com/gurezo/chirimen-lite-console/issues/616)）
@@ -82,7 +94,7 @@ Angular 向けのシリアル（Web Serial + `@gurezo/web-serial-rxjs` v2.3.1）
 2. **ユーザー名送信後** — `Password:` プロンプト。
 3. **パスワード送信後** — Debian MOTD と `pi@raspberrypi:~$` 形式のシェルプロンプト。
 
-シェル到達後は **環境設定の初期化**（`PI_ZERO_ENVIRONMENT_STEPS`）を `exec$` で実行する。初期化には timezone に加えて language / locale / `TZ` などを含める。ターミナルへのライブ表示は **`terminalText$`**、プロンプト照合・ログイン判定は **`lines$`** 由来のバッファを用いる。
+シェル到達後は **環境設定の初期化**（`PI_ZERO_ENVIRONMENT_STEPS`）を `exec$` で実行する。初期化には timezone に加えて language / locale / `TZ` などを含める。ターミナルへのライブ表示は **`terminalText$`**。プロンプト照合・ログイン判定は **`exec$` / `readUntilPrompt$` 経路**（内部で `receive$` チャンクをバッファ）により行う。
 
 ## CHIRIMEN / Pi Zero 固有ロジックの集約（Issue [#594](https://github.com/gurezo/chirimen-lite-console/issues/594)）
 

--- a/libs/web-serial/data-access/src/lib/serial-command/serial-command-runner.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-command/serial-command-runner.service.ts
@@ -1,6 +1,6 @@
 /// <reference types="@types/w3c-web-serial" />
 
-/** Full rewrite (#606). Prompt/exec buffer from {@link SerialTransportService#lines$} (`SerialSession`). */
+/** Full rewrite (#606). Prompt/exec buffer from {@link SerialTransportService#receive$} (`SerialSession`). */
 import { Injectable } from '@angular/core';
 import {
   Observable,
@@ -42,7 +42,7 @@ import { SerialTransportService } from '../serial-transport.service';
  * プロンプト照合および exec の `stdout` は {@link SerialTransportService#receive$} の生チャンクを連結し、
  * {@link collapseCarriageRedrawsPerLine} で論理表示に収束させたバッファで行う（getty の lone `\r` 行末で
  * {@link SerialTransportService#lines$} が空振りする問題の回避）。
- * ターミナル上のライブ表示は UI が {@link SerialTransportService#receive$} を xterm に流す。
+ * ターミナル上のライブ表示は UI が {@link SerialTransportService#terminalText$} を購読する（[#617](https://github.com/gurezo/chirimen-lite-console/issues/617)）。
  *
  * 各チャンクに {@link stripSerialAnsiForPrompt} を適用する。
  */

--- a/libs/web-serial/data-access/src/lib/serial-facade.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-facade.service.ts
@@ -54,7 +54,7 @@ export class SerialFacadeService {
    *
    * - **ターミナル UI は本 Observable を購読**し、シェルからの出力を画面に反映する。TTY の `\r` 再描画の畳み込み等はライブラリの `SerialSession.terminalText$` に委譲する。
    * - **送信**は {@link #send$} のみとし、表示の更新に {@link #exec$} / {@link #execRaw$} / {@link #readUntilPrompt$} の戻り値を用いない（二重表示・責務の混乱を避ける。キャプチャ用途は {@link #exec$} 側のドキュメント参照）。
-   * - **プロンプト検出・ログイン判定**には {@link #lines$} 由来のバッファを用い、本ストリームは照合用に寄せない。
+   * - **プロンプト検出・ログイン判定**には本ストリームは使わない。同期は {@link #readUntilPrompt$} / {@link #exec$} 等に任せ、バッファは data-access 内で {@link #receive$} から構築される。
    *
    * @see {@link #exec$} ターミナル UI では exec 系を呼ばない理由と内部向け利用境界
    */


### PR DESCRIPTION
## Summary

Issue #646 に沿い、`receive$` / `lines$` / `terminalText$` の責務と Feature が使うべき API 境界を README・アーキテクチャ文書・JSDoc で実装と一致させた。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #646
- Related to #643

## What changed?

- [libs/web-serial/data-access/README.md](libs/web-serial/data-access/README.md): 受信ストリーム表、Feature 向け推奨導線、`SerialCommandRunnerService` の `receive$` 購読、Facade の `receive$` を internal 契約として明記し、Pi Zero 節・公開 API ポリシーを整合した。
- [docs/serial-architecture.md](docs/serial-architecture.md): Facade の `receive$` 露出と「Feature からは購読しない」旨、ストリーム対応表と推奨利用の説明を更新した。
- `SerialFacadeService` / `SerialCommandRunnerService` の JSDocを上記方針に合わせて修正した。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. README と `serial-command-runner.service.ts` の挙動説明が矛盾しないことを目視で確認する。
2. `npx nx run libs-web-serial-data-access:test` を実行する（ローカルで実施済み）。

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [ ] I considered error handling where relevant