### PR TITLE
refactor(web-serial): Feature 境界の Serial 検証を CI に追加 (#650)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Verify Web Serial feature boundary (issue #650)
+        run: pnpm verify:serial-feature-boundary
+
       - name: Run affected tasks
         run: pnpm nx affected -t lint,build,test
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "nx run-many -t build",
     "watch": "nx build --watch --configuration development",
     "test": "nx run-many -t test",
+    "verify:serial-feature-boundary": "node tools/verify-serial-feature-boundary.mjs",
     "prepare": "husky"
   },
   "private": true,

--- a/tools/verify-serial-feature-boundary.mjs
+++ b/tools/verify-serial-feature-boundary.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/**
+ * Issue #650 / parent #643: Web Serial の「アプリ境界」が data-access 内部実装に食い込まないことを検証する。
+ *
+ * - `SerialTransportService`（および `receive$` 橋渡しの低レイヤー）は `libs/web-serial/data-access` のみで import / DI されること。
+ *
+ * 逸脱があれば非ゼロ終了コードで終了する（CI 用）。
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+const EXCLUDED_PREFIX = 'libs/web-serial/data-access';
+
+/** @param {string} relPosix */
+function isExcluded(relPosix) {
+  return (
+    relPosix === EXCLUDED_PREFIX ||
+    relPosix.startsWith(`${EXCLUDED_PREFIX}/`)
+  );
+}
+
+/**
+ * @param {string} relDir
+ * @returns {Generator<string>}
+ */
+function* walkTsFiles(relDir) {
+  const absDir = join(ROOT, relDir);
+  let entries;
+  try {
+    entries = readdirSync(absDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    const name = e.name;
+    const rel = join(relDir, name);
+    if (e.isDirectory()) {
+      if (
+        name === 'node_modules' ||
+        name === 'dist' ||
+        name === '.git' ||
+        name === 'coverage'
+      ) {
+        continue;
+      }
+      yield* walkTsFiles(rel);
+    } else if (name.endsWith('.ts') && !name.endsWith('.d.ts')) {
+      yield join(ROOT, rel);
+    }
+  }
+}
+
+/**
+ * @param {string} absPath
+ * @returns {string}
+ */
+function toPosixRel(absPath) {
+  return relative(ROOT, absPath).split('\\').join('/');
+}
+
+/**
+ * @param {string} text
+ */
+function usesSerialTransportService(text) {
+  const importSerialTransport =
+    /import\s+(?:[\s\S]*?\btype\s+)?(?:\{[\s\S]*?\bSerialTransportService\b[\s\S]*?\}|\bSerialTransportService\b)\s+from/.test(
+      text,
+    );
+  const injectTransport = /inject\s*\(\s*SerialTransportService\s*\)/.test(
+    text,
+  );
+  const provideTransport =
+    /\{\s*provide:\s*SerialTransportService\b/.test(text);
+  return importSerialTransport || injectTransport || provideTransport;
+}
+
+const violations = [];
+
+for (const root of ['libs', 'apps']) {
+  for (const absPath of walkTsFiles(root)) {
+    const rel = toPosixRel(absPath);
+    if (isExcluded(rel)) continue;
+
+    const text = readFileSync(absPath, 'utf8');
+    if (usesSerialTransportService(text)) {
+      violations.push({
+        file: rel,
+        reason:
+          'SerialTransportService は libs/web-serial/data-access 外から参照しない（SerialFacadeService 経由に統一する）',
+      });
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error(
+    'verify-serial-feature-boundary: 次のファイルが Web Serial の境界ルールに違反しています:\n',
+  );
+  for (const v of violations) {
+    console.error(`  - ${v.file}\n    ${v.reason}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  'verify-serial-feature-boundary: OK（libs/web-serial/data-access 外に SerialTransportService の import / provide はありません）',
+);


### PR DESCRIPTION
## Summary

Issue #650（親 #643 Sub-issue 7）に対し、アプリ境界で `SerialTransportService` に食い込まないことを機械的に検証するスクリプトと CI ステップを追加しました。既存コードの監査では Feature 側に `receive$` 直接利用や Transport の不正参照はありませんでした。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #650
- Related to #643

## What changed?

- `libs` / `apps` を対象に、`libs/web-serial/data-access` 以外で `SerialTransportService` を import / `inject` / `provide` していないか検証する Node スクリプトを追加した。
- `pnpm verify:serial-feature-boundary` でローカルでも同じ検証ができるようにした。
- GitHub Actions の CI で `nx affected` の前に上記検証を実行するようにした。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm verify:serial-feature-boundary` が成功することを確認する。
2. 必要に応じて `pnpm nx affected -t lint,test --base=origin/main` または関連プロジェクトの `lint` / `test` を実行する。
3. PR マージ後、GitHub Actions の CI で「Verify Web Serial feature boundary」ステップが成功することを確認する。

## Environment (if relevant)

- Browser: （該当なし / または実施時のブラウザ）
- OS: macOS / Windows / Linux
- Node version: （`node -v` の結果）
- pnpm version: （`pnpm -v` の結果）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant