### PR TITLE
refactor(web-serial-data-access): 接続 epoch と bootstrap epoch の責務を整理する (#647)

### DIFF
--- a/libs/web-serial/data-access/README.md
+++ b/libs/web-serial/data-access/README.md
@@ -79,7 +79,7 @@ Angular 向けのシリアル（Web Serial + `@gurezo/web-serial-rxjs` v2.3.1）
 - **`SerialFacadeService` の公開 API（Feature が参照してよい契約）**は次のとおり:
   - **Observable**: `terminalText$`, `lines$`, `state$`, `isConnected$`, `errors$`, `portInfo$`, `connectionEstablished$`（接続成功直後 1 回・接続後 bootstrap のトリガ用）
   - **メソッド**: `connect$()`, `disconnect$()`, `send$()`, `exec$()`, `execRaw$()`, `readUntilPrompt$()`, `isBrowserSupported()`, `isRaspberryPiZero()`
-- **Facade では露出しない**（data-access 内部のみ）: 生チャンクの `receive$`（`SerialTransportService` 経由で `SerialCommandRunnerService` がプロンプト照合・`exec$` stdout 用に購読。[#601](https://github.com/gurezo/chirimen-lite-console/issues/601)、[#646](https://github.com/gurezo/chirimen-lite-console/issues/646)）、接続エポック整数（`SerialConnectionOrchestrationService#getConnectionEpoch` — `PiZeroSessionService` 等が利用）、`read$` / `getPort` / キュー診断 API。
+- **Facade では露出しない**（data-access 内部のみ）: 生チャンクの `receive$`（`SerialTransportService` 経由で `SerialCommandRunnerService` がプロンプト照合・`exec$` stdout 用に購読。[#601](https://github.com/gurezo/chirimen-lite-console/issues/601)、[#646](https://github.com/gurezo/chirimen-lite-console/issues/646)）、接続エポック整数（`SerialConnectionOrchestrationService#getConnectionEpoch` — `PiZeroSessionService` が bootstrap 突き合わせに利用）、`read$` / `getPort` / キュー診断 API。
 - ライブラリの `receiveReplay$` は本 data-access の Facade では橋渡ししない。ライブ表示の `\r` 再描画は `terminalText$` に委譲する。
 
 ### `terminalText$` の責務（[#617](https://github.com/gurezo/chirimen-lite-console/issues/617)）

--- a/libs/web-serial/data-access/README.md
+++ b/libs/web-serial/data-access/README.md
@@ -62,6 +62,16 @@ Angular 向けのシリアル（Web Serial + `@gurezo/web-serial-rxjs` v2.3.1）
 
 コンポーネント向けには **`SerialConnectionViewModelFacade`** が `vm$: Observable<SerialConnectionViewModel>` を提供する。接続・切断・送信（ツールバーと同様に `TerminalCommandRequestService.requestCommand` 経由）および `clearError()` を前置し、ブラウザ対応フラグ、`SerialFacadeService.state$` に基づく接続試行状態、`PiZeroShellReadinessService.ready$`（問題文での「ログイン済み」と同義：`isLoggedIn`）、`PiZeroSessionService.initializing$` での初期化フラグ、`errorMessage` をまとめる。
 
+## 接続 epoch と bootstrap 済み epoch（[#647](https://github.com/gurezo/chirimen-lite-console/issues/647)）
+
+| 状態 | 所有者 | 役割 |
+| --- | --- | --- |
+| **接続 epoch**（単調増加の整数） | `SerialConnectionOrchestrationService` | 成功した `connect$` のたびに 1 つ進める。切断だけでは進めない。 |
+| **bootstrap 済み epoch**（最後に完了した接続 epoch） | `PiZeroSessionService` | 現在の接続 epoch と比較し、接続後パイプライン（ログイン・環境初期化）を **同一接続で 1 回**に抑える。 |
+| **進行中パイプライン**（`activeBootstrap$` とその epoch） | `PiZeroSessionService` | 同一接続 epoch での重複 `runAfterConnect$` を抑止。完了時は現在の接続 epoch と突き合わせ、再接続後に遅延した旧パイプラインが `bootstrappedEpoch` を汚染しない。 |
+
+`SerialConnectionOrchestrationService#getConnectionEpoch` は上記突き合わせ用に **data-access 内部**からのみ呼ぶ（Facade には載せない）。
+
 ## 公開 API ポリシー（Issue #590 / [#649](https://github.com/gurezo/chirimen-lite-console/issues/649)）
 
 - UI / Feature / 他ライブラリからの Serial 利用は **`SerialFacadeService` のみ**を参照する。

--- a/libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-session.service.spec.ts
@@ -87,6 +87,39 @@ describe('PiZeroSessionService', () => {
     expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledTimes(2);
   });
 
+  it('does not set shell ready when connection epoch advances mid-pipeline; next run succeeds', async () => {
+    let connEpoch = 1;
+    let readCalls = 0;
+    const readUntilPrompt = vi.fn().mockImplementation(async () => {
+      readCalls += 1;
+      if (readCalls === 1) {
+        connEpoch = 2;
+      }
+      return { stdout: `${PI_ZERO_PROMPT} ` };
+    });
+    const exec = vi.fn().mockResolvedValue({ stdout: '' });
+    const serial = {
+      isConnected$: of(true),
+      readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
+      exec$: (c: string, o: unknown) => from(exec(c, o)),
+    } as unknown as SerialFacadeService;
+
+    const shellReadiness = createShellReadinessMock();
+    const service = createSession(
+      serial,
+      shellReadiness,
+      stubConnection(() => connEpoch),
+    );
+
+    await firstValueFrom(service.runAfterConnect$());
+    expect(vi.mocked(shellReadiness.setReady)).not.toHaveBeenCalledWith(true);
+
+    await firstValueFrom(service.runAfterConnect$());
+    expect(readUntilPrompt).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
+  });
+
   it('emits initializing$ true during post-connect bootstrap then false', async () => {
     const readUntilPrompt = vi.fn().mockResolvedValue({
       stdout: `${PI_ZERO_PROMPT} `,

--- a/libs/web-serial/data-access/src/lib/pi-zero-session.service.ts
+++ b/libs/web-serial/data-access/src/lib/pi-zero-session.service.ts
@@ -32,8 +32,15 @@ import { SerialFacadeService } from './serial-facade.service';
   providedIn: 'root',
 })
 export class PiZeroSessionService {
-  private lastBootstrappedEpoch = -1;
+  /**
+   * 最後に接続後 bootstrap が完了した接続 epoch。`SerialConnectionOrchestrationService` の値と突き合わせる。
+   */
+  private bootstrappedEpoch = -1;
+
+  /** 現在進行中の `runAfterConnect$` パイプライン（同一接続 epoch での重複起動を防ぐ）。 */
   private activeBootstrap$: Observable<void> | null = null;
+
+  /** `activeBootstrap$` が属する接続 epoch。finalize で当該 epoch のみクリーンアップする。 */
   private activeBootstrapEpoch: number | null = null;
 
   private readonly initializingSubject = new BehaviorSubject(false);
@@ -90,7 +97,7 @@ export class PiZeroSessionService {
           return false;
         }
         const epoch = this.connection.getConnectionEpoch();
-        if (epoch === this.lastBootstrappedEpoch) {
+        if (epoch === this.bootstrappedEpoch) {
           return false;
         }
         return true;
@@ -142,10 +149,18 @@ export class PiZeroSessionService {
             this.serial.isConnected$.pipe(
               take(1),
               tap((connected) => {
-                if (connected) {
-                  this.lastBootstrappedEpoch = epoch;
+                const currentEpoch = this.connection.getConnectionEpoch();
+                if (
+                  connected &&
+                  currentEpoch === epoch &&
+                  this.activeBootstrapEpoch === epoch
+                ) {
+                  this.bootstrappedEpoch = epoch;
                   this.shellReadiness.setReady(true);
                   this.setupStatusSubject.next('ready');
+                } else if (connected && currentEpoch !== epoch) {
+                  // 再接続などで接続 epoch が進んだあとに遅延完了したパイプラインは成功扱いにしない
+                  this.setupStatusSubject.next('idle');
                 }
               }),
               map(() => undefined),

--- a/libs/web-serial/data-access/src/lib/serial-connection-orchestration.service.ts
+++ b/libs/web-serial/data-access/src/lib/serial-connection-orchestration.service.ts
@@ -34,6 +34,10 @@ export class SerialConnectionOrchestrationService {
   private readonly command = inject(SerialCommandService);
   private readonly shellReadiness = inject(PiZeroShellReadinessService);
 
+  /**
+   * 成功したシリアル接続ごとに単調増加するセッション識別子。
+   * 接続ライフサイクルのみ本サービスがインクリメントし、bootstrap 済み判定は `PiZeroSessionService` 側の責務。
+   */
   private connectionEpoch = 0;
 
   private readonly connectionEstablished = new Subject<void>();
@@ -84,6 +88,10 @@ export class SerialConnectionOrchestrationService {
     );
   }
 
+  /**
+   * data-access 内部で接続セッションと bootstrap 状態を突き合わせるための API。
+   * Feature / Facade には露出しない（[#647](https://github.com/gurezo/chirimen-lite-console/issues/647)）。
+   */
   getConnectionEpoch(): number {
     return this.connectionEpoch;
   }


### PR DESCRIPTION
## Summary

Web Serial の接続ライフサイクル用 epoch と、Pi Zero 接続後 bootstrap 済み判定を整理した。パイプライン完了時点で接続 epoch が変わっている場合は成功扱いにせず、`bootstrappedEpoch` と shell readiness を汚染しない。README に責務表を追記した。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #647
- Related to #643

## What changed?

- `SerialConnectionOrchestrationService` の `connectionEpoch` を接続側の単一ソースとして文書化し、`getConnectionEpoch` の利用境界を JSDoc で明示した。
- `PiZeroSessionService` で `bootstrappedEpoch` にリネームし、成功コミット時に現在の接続 epoch と `activeBootstrapEpoch` を再照合するガードを追加した。
- 上記の退行を防ぐユニットテストを追加した。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm exec nx run libs-web-serial-data-access:test`
2. `pnpm exec nx run libs-web-serial-data-access:lint`
3. （任意）ブラウザでシリアル接続 → 初期化 → 切断 → 再接続し、必要なときだけ初期化が走ることを確認する。

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant