### PR TITLE
test(web-serial-data-access): Web Serial 簡素化後の回帰テストを整理する (#651)

### DIFF
--- a/libs/web-serial/data-access/README.md
+++ b/libs/web-serial/data-access/README.md
@@ -114,3 +114,45 @@ Angular 向けのシリアル（Web Serial + `@gurezo/web-serial-rxjs` v2.3.1）
 - Pi Zero 固有のプロンプト判定（`pi@…` シェル / `login:` / `Password:` 等）は **`PiZeroPromptDetectorService`** に分離（[`pi-zero-prompt-detector.service.ts`](src/lib/pi-zero-prompt-detector.service.ts)）。
 - `SerialPromptDetectorService` は **汎用 `matchesPrompt` のみ**を提供し、`SerialCommandRunnerService` から共有利用する。
 - 他サービス（`wifi`, `file-manager`, `remote`, `chirimen-setup`, `i2cdetect` など）は Pi Zero 固有ロジックを保持しない。期待プロンプト文字列としての `PI_ZERO_PROMPT` 利用は許容する。
+
+## 回帰テスト（自動 / 手動）（[#651](https://github.com/gurezo/chirimen-lite-console/issues/651) / 親 [#643](https://github.com/gurezo/chirimen-lite-console/issues/643)）
+
+Web Serial 周辺の変更後は、接続・ログイン・timezone・ターミナル・コマンド経路の回帰を必ず確認する。
+
+### 自動テスト（Vitest）のおおよその対応
+
+| 確認観点 | 主な spec |
+| --- | --- |
+| Facade 経由の `connect$` / `disconnect$` / `exec$` / `readUntilPrompt$` / `terminalText$` | `serial-facade.service.spec.ts` |
+| 接続ライフサイクル・再接続時の `disconnect$` → `connect$`・`connectionEpoch`・`connectionEstablished$` | `serial-connection-orchestration.service.spec.ts` |
+| `terminalText$` / `errors$` の橋渡し | `serial-transport.service.spec.ts` |
+| `exec$` / `readUntilPrompt$`・キュー | `serial-command.service.spec.ts`、`serial-command-queue.service.spec.ts` |
+| Pi Zero bootstrap・ログイン・環境初期化 | `pi-zero-serial-bootstrap.service.spec.ts`、`pi-zero-session.service.spec.ts` |
+| 接続 UI の VM（timezone 初期化中など）・接続失敗時の通知 | `serial-connection-view-model.facade.spec.ts` |
+| ターミナルが `terminalText$` の差分のみ反映する挙動 | `libs/terminal/ui` の `terminal-view.component.spec.ts` |
+| Feature が `SerialTransportService` を直接 import しないこと | リポジトリ直下 `tools/verify-serial-feature-boundary.mjs`（CI） |
+
+### 手動確認チェックリスト（実機 / ブラウザ）
+
+実機または対象ブラウザで、必要に応じて記録を残す。
+
+- [ ] ブラウザが Web Serial に対応している（非対応時は `/unsupported-browser` 等の導線）
+- [ ] Web Serial でポート選択・接続ができる
+- [ ] 切断ができる
+- [ ] 再接続（2 回目以降の接続）が問題なく完了する
+- [ ] Pi Zero として認識される（想定デバイスのみ接続する運用の場合はその前提で確認）
+- [ ] ログイン（login / password）〜シェルプロンプトまで到達する
+- [ ] timezone / language（locale）設定が完了し、想定プロンプトに戻る
+- [ ] ターミナルに `terminalText$` 由来のライブ表示が出る（`\r` 再描画含む想定動作）
+- [ ] ユーザー入力（`send$`）がシェルに届く
+- [ ] アプリからのコマンド実行（`exec$`）が期待どおり完了する
+- [ ] `readUntilPrompt$` 相当の「プロンプト待ち」フローが期待どおり完了する
+- [ ] `i2cdetect` 等、シリアル経由の機能コマンドが動作する
+- [ ] 接続失敗・シリアルエラー時にユーザーへ分かる形でエラーが出る
+
+### 変更後に壊れやすい箇所（リグレッション注意）
+
+- **接続 epoch と bootstrap epoch の整合**（`SerialConnectionOrchestrationService` と `PiZeroSessionService` の突き合わせ。再接続直後に旧パイプラインが状態を汚染しないこと）
+- **`receive$` と `terminalText$` の責務分界**（表示は `terminalText$`、プロンプト照合は data-access 内の `receive$` バッファ）
+- **コマンドキューとプロンプト検出**（`SerialCommandQueueService` / `SerialCommandRunnerService`）
+- **Feature 境界**（`SerialFacadeService` 以外への低レイヤー依存を増やさない。CI の feature-boundary 検証に抵触しないこと）

--- a/libs/web-serial/data-access/src/lib/serial-connection-orchestration.service.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-connection-orchestration.service.spec.ts
@@ -1,0 +1,119 @@
+import '@angular/compiler';
+import { Injector } from '@angular/core';
+import { BehaviorSubject, firstValueFrom, of, take } from 'rxjs';
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
+import { SerialCommandService } from './serial-command/serial-command-facade.service';
+import { SerialConnectionOrchestrationService } from './serial-connection-orchestration.service';
+import { SerialTransportService } from './serial-transport.service';
+
+describe('SerialConnectionOrchestrationService', () => {
+  let service: SerialConnectionOrchestrationService;
+  let isConnectedSubj: BehaviorSubject<boolean>;
+  let transport: Partial<SerialTransportService>;
+  let connectMock: Mock;
+  let disconnectMock: Mock;
+  let command: Partial<SerialCommandService>;
+  let shellReadiness: PiZeroShellReadinessService;
+
+  beforeEach(() => {
+    isConnectedSubj = new BehaviorSubject(false);
+    command = {
+      startReadLoop: vi.fn(),
+      stopReadLoop: vi.fn(),
+      cancelAllCommands: vi.fn(),
+    };
+    connectMock = vi.fn(() => of({ port: {} as SerialPort }));
+    disconnectMock = vi.fn(() => of(undefined));
+    transport = {
+      isConnected$: isConnectedSubj.asObservable(),
+      connect$: connectMock,
+      disconnect$: disconnectMock,
+    };
+    shellReadiness = new PiZeroShellReadinessService();
+
+    const injector = Injector.create({
+      providers: [
+        SerialConnectionOrchestrationService,
+        { provide: SerialTransportService, useValue: transport },
+        { provide: SerialCommandService, useValue: command },
+        { provide: PiZeroShellReadinessService, useValue: shellReadiness },
+      ],
+    });
+    service = injector.get(SerialConnectionOrchestrationService);
+  });
+
+  it('getConnectionEpoch starts at 0', () => {
+    expect(service.getConnectionEpoch()).toBe(0);
+  });
+
+  it('on successful connect increments epoch, starts read loop, resets shell readiness, emits connectionEstablished$', async () => {
+    const establishedOnce = firstValueFrom(
+      service.connectionEstablished$.pipe(take(1)),
+    );
+
+    shellReadiness.setReady(true);
+    const result = await firstValueFrom(service.connect$(115200));
+    await establishedOnce;
+
+    expect(result).toEqual({ ok: true });
+    expect(service.getConnectionEpoch()).toBe(1);
+    expect(command.startReadLoop).toHaveBeenCalledTimes(1);
+    expect(shellReadiness.isReady()).toBe(false);
+    expect(connectMock).toHaveBeenCalledWith(115200);
+  });
+
+  it('when already connected, orchestration disconnect runs before transport connect', async () => {
+    isConnectedSubj.next(true);
+
+    await firstValueFrom(service.connect$(9600));
+
+    expect(disconnectMock).toHaveBeenCalled();
+    expect(connectMock).toHaveBeenCalledWith(9600);
+    expect(service.getConnectionEpoch()).toBe(1);
+    const disconnectOrder = disconnectMock.mock.invocationCallOrder[0];
+    const connectOrder = connectMock.mock.invocationCallOrder[0];
+    expect(disconnectOrder).toBeLessThan(connectOrder);
+  });
+
+  it('each successful connect after disconnect increments connectionEpoch', async () => {
+    await firstValueFrom(service.connect$(115200));
+    expect(service.getConnectionEpoch()).toBe(1);
+
+    await firstValueFrom(service.disconnect$());
+    await firstValueFrom(service.connect$(115200));
+
+    expect(service.getConnectionEpoch()).toBe(2);
+  });
+
+  it('disconnect$ resets shell readiness, cancels commands, stops read loop, disconnects transport', async () => {
+    await firstValueFrom(service.connect$(115200));
+    shellReadiness.setReady(true);
+
+    await firstValueFrom(service.disconnect$());
+
+    expect(command.cancelAllCommands).toHaveBeenCalled();
+    expect(command.stopReadLoop).toHaveBeenCalled();
+    expect(disconnectMock).toHaveBeenCalled();
+    expect(shellReadiness.isReady()).toBe(false);
+  });
+
+  it('does not increment epoch or start read loop when transport returns error', async () => {
+    connectMock.mockReturnValue(of({ error: 'permission denied' }));
+
+    let establishedFired = false;
+    const sub = service.connectionEstablished$.subscribe(() => {
+      establishedFired = true;
+    });
+    const result = await firstValueFrom(service.connect$(115200));
+    sub.unsubscribe();
+
+    expect(result).toEqual({
+      ok: false,
+      errorMessage: 'permission denied',
+    });
+    expect(service.getConnectionEpoch()).toBe(0);
+    expect(command.startReadLoop).not.toHaveBeenCalled();
+    expect(establishedFired).toBe(false);
+  });
+});

--- a/libs/web-serial/data-access/src/lib/serial-connection-view-model.facade.spec.ts
+++ b/libs/web-serial/data-access/src/lib/serial-connection-view-model.facade.spec.ts
@@ -77,6 +77,52 @@ describe('SerialConnectionViewModelFacade', () => {
     expect(vm.setupStatus).toBe('setting-timezone');
   });
 
+  it('connect on failure notifies and sets vm errorMessage', async () => {
+    const notifyConnectionError = vi.fn();
+    const serial: Partial<SerialFacadeService> = {
+      state$: of(SerialSessionState.Idle),
+      isConnected$: of(false),
+      isBrowserSupported: vi.fn(() => true),
+      connect$: vi.fn(() =>
+        of({ ok: false, errorMessage: 'port busy' } as const),
+      ),
+      disconnect$: vi.fn(() => of(undefined)),
+    };
+
+    const injector = Injector.create({
+      providers: [
+        SerialConnectionViewModelFacade,
+        { provide: SerialFacadeService, useValue: serial },
+        {
+          provide: PiZeroSessionService,
+          useValue: { setupStatus$: of('idle') },
+        },
+        {
+          provide: PiZeroShellReadinessService,
+          useValue: { ready$: of(false) },
+        },
+        {
+          provide: SerialNotificationService,
+          useValue: {
+            notifyConnectionSuccess: vi.fn(),
+            notifyConnectionError,
+          },
+        },
+        {
+          provide: TerminalCommandRequestService,
+          useValue: { requestCommand: vi.fn() },
+        },
+      ],
+    });
+
+    const facade = injector.get(SerialConnectionViewModelFacade);
+    facade.connect();
+
+    const vm = await firstValueFrom(facade.vm$);
+    expect(vm.errorMessage).toBe('port busy');
+    expect(notifyConnectionError).toHaveBeenCalledWith('port busy');
+  });
+
   it('clearError resets errorMessage in vm$', async () => {
     const serial: Partial<SerialFacadeService> = {
       state$: of(SerialSessionState.Idle),


### PR DESCRIPTION
## Summary

Issue #651（親 #643）に沿い、Web Serial 周辺の回帰を単体テストと README の手動チェックリストで整理した。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #651
- Related #643

## What changed?

- `SerialConnectionOrchestrationService` の接続・切断・再接続・epoch・`connectionEstablished$` を Vitest でカバーした。
- `SerialConnectionViewModelFacade` の接続失敗時に通知と `vm$` のエラー表示が行われることをテストで明示した。
- `libs/web-serial/data-access/README.md` に、自動テストと観点の対応表・手動回帰チェックリスト・変更後に壊れやすい箇所を追記した。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx test libs-web-serial-data-access`
2. `pnpm nx lint libs-web-serial-data-access`
3. （任意）`node tools/verify-serial-feature-boundary.mjs`
4. README の「回帰テスト（自動 / 手動）」に沿い、必要に応じて実機で手動チェックリストを確認する

## Environment (if relevant)

- Browser: （手動確認時に記入）
- OS: macOS / Windows / Linux
- Node version: （記入）
- pnpm version: （記入）

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant