### PR TITLE
docs(web-serial-data-access): readme に設計メモを追記 (#652)

### DIFF
--- a/libs/web-serial/data-access/README.md
+++ b/libs/web-serial/data-access/README.md
@@ -4,6 +4,32 @@ Angular 向けのシリアル（Web Serial + `@gurezo/web-serial-rxjs` v2.3.1）
 
 **リポジトリ間の責務分界**（ライブラリ一般と本アプリの対応、`SerialSession` を正とする方針など）: [docs/serial-architecture.md](../../../docs/serial-architecture.md)（[#568](https://github.com/gurezo/chirimen-lite-console/issues/568)）。
 
+## 設計メモ（責務と実装ルール）（[#652](https://github.com/gurezo/chirimen-lite-console/issues/652)）
+
+今後の実装判断用のレイヤ概要。ストリームの詳細・公開 API の契約・Pi Zero の集約方針は、本 README 下記の「受信ストリームの使い分け」「公開 API ポリシー」「接続 epoch と bootstrap 済み epoch」「CHIRIMEN / Pi Zero 固有ロジックの集約」などの各節を参照する。
+
+### 責務レイヤ（俯瞰）
+
+```text
+Feature / UI
+  -> SerialFacadeService のみ参照する
+
+SerialFacadeService
+  -> 外部 API の入口
+
+SerialTransportService
+  -> SerialSession の thin adapter
+
+SerialCommandService / SerialCommandRunnerService
+  -> exec / readUntilPrompt / prompt 判定
+
+PiZeroSessionService
+  -> Pi Zero 接続後 bootstrap の制御
+
+PiZeroSerialBootstrapService
+  -> login / environment setup の具体処理
+```
+
 ## 受信ストリームの使い分け（`SerialSession` / `SerialTransportService`）
 
 アプリでは `@gurezo/web-serial-rxjs` の `SerialSession` が提供する受信 Observable を、用途に応じて次のように使い分ける（[#559](https://github.com/gurezo/chirimen-lite-console/issues/559)）。

--- a/libs/web-serial/data-access/README.md
+++ b/libs/web-serial/data-access/README.md
@@ -30,6 +30,25 @@ PiZeroSerialBootstrapService
   -> login / environment setup の具体処理
 ```
 
+### 実装時のルール（要約）
+
+- Feature 側から `SerialTransportService` を直接参照しない（入口は `SerialFacadeService` のみ）。
+- ターミナル表示には `terminalText$` を使う。
+- 生の `receive$` は原則 **data-access internal**（Feature から購読しない。プロンプト照合は `SerialCommandRunnerService` が `receive$` からバッファを構築）。
+- コマンド実行（stdout キャプチャ付き）には `exec$` / `execRaw$` を使う。
+- prompt 待ちには `readUntilPrompt$` を使う。
+- Pi Zero 固有の login / 環境初期化 / 接続後オーケストレーションは **`PiZeroSerialBootstrapService` / `PiZeroSessionService` に集約**し、Feature 側に散らさない。
+
+### 受信ストリーム（`terminalText$` / `receive$` / `lines$`）の一行要約
+
+| Stream / 経路 | 役割（誰が使うか） |
+| --- | --- |
+| `terminalText$` | **ターミナル UI のライブ表示**（`\r` 再描画を含む）。Feature は Facade 経由で購読。プロンプト判定には使わない。 |
+| `lines$` | **行境界が確まった行**の購読（単発 1 行は `take(1)` 等）。コマンドランナーの唯一の入力ではない（[#593](https://github.com/gurezo/chirimen-lite-console/issues/593) 参照）。 |
+| `receive$`（Transport） | **UTF-8 デコード済みの生チャンク**。Facade では露出しない。プロンプト同期・`exec$` の stdout 照合は **`SerialCommandRunnerService` が `receive$` を購読**してバッファする。 |
+
+詳細な使い分け表・根拠は下記「受信ストリームの使い分け」節を参照する。
+
 ## 受信ストリームの使い分け（`SerialSession` / `SerialTransportService`）
 
 アプリでは `@gurezo/web-serial-rxjs` の `SerialSession` が提供する受信 Observable を、用途に応じて次のように使い分ける（[#559](https://github.com/gurezo/chirimen-lite-console/issues/559)）。


### PR DESCRIPTION
## Summary

親 Epic [#643](https://github.com/gurezo/chirimen-lite-console/issues/643)（Web Serial 実装の簡素化）の一環として、子 Issue [#652](https://github.com/gurezo/chirimen-lite-console/issues/652) に沿い、`libs/web-serial/data-access/README.md` に実装判断用の設計メモ（責務レイヤ図・ルール要約・`terminalText$` / `receive$` / `lines$` の対照）を追記した。既存の詳細セクションへの導線を置き、重複を抑えている。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #652
- Related to #643

## What changed?

- 「設計メモ（責務と実装ルール）」見出しを追加し、Issue 本文のテキスト形式レイヤ図（Feature → Facade → Transport / Command / Pi Zero 系）を掲載した。
- 実装時のルール（Facade のみ、`terminalText$`、`receive$` は internal、`exec$` / `readUntilPrompt$`、Pi Zero 集約）を箇条書きで要約した。
- 受信ストリーム 3 種の一行要約表を追加し、詳細は既存の「受信ストリームの使い分け」節へ誘導した。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `libs/web-serial/data-access/README.md` を開き、設計メモ節が冒頭付近にあり、下記の詳細節と矛盾しないことを目視する。
2. 必要ならローカルで Markdown プレビューし、表・コードブロックの表示を確認する。

## Environment (if relevant)

- Browser: N/A
- OS: macOS / Windows / Linux
- Node version: N/A
- pnpm version: N/A

## Checklist

- [ ] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [ ] I considered error handling where relevant
