### PR TITLE
refactor(web-serial-data-access): Facade 経由の exec 入口と公開境界の整理 (#664)

### DIFF
--- a/docs/serial-architecture.md
+++ b/docs/serial-architecture.md
@@ -33,6 +33,8 @@ chirimen-lite-console（本リポジトリ）
 
 Issue #590 / [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) / [#649](https://github.com/gurezo/chirimen-lite-console/issues/649) 以降は、外部公開 API を `SerialFacadeService` に集約し、利用側は `terminalText$` / `lines$` / `state$` / `isConnected$` / `errors$` / `portInfo$` / `connectionEstablished$` と `connect$()` / `disconnect$()` / `send$()` / `exec$()` / `execRaw$()` / `readUntilPrompt$()` / `isBrowserSupported()` / `isRaspberryPiZero()` を基本導線とする。`receive$` は **Facade では橋渡しせず**、`SerialTransportService` 経由で data-access 内部（`SerialCommandPipelineService`）のみがプロンプト照合・`exec$` の stdout 集約に用いる（[#646](https://github.com/gurezo/chirimen-lite-console/issues/646)）。Pi Zero のログイン〜タイムゾーン初期化の期待シーケンスは [Issue #606](https://github.com/gurezo/chirimen-lite-console/issues/606) を参照。
 
+[#664](https://github.com/gurezo/chirimen-lite-console/issues/664) に沿い、`@libs-web-serial-data-access` のパッケージ公開面からは **`SerialCommandPipelineService` クラスを export せず**、コマンド実行の利用入口は Facade の `exec$` / `execRaw$` / `readUntilPrompt$` とする。一方、接続ライフサイクルの read loop 開始・停止・切断時キャンセルは、`SerialFacadeService` と `SerialConnectionOrchestrationService` の **循環 DI を避けるため**、オーケストレーションが Pipeline を **data-access 内部だけ**直接 inject して制御する（詳細は [libs/web-serial/data-access/README.md](../libs/web-serial/data-access/README.md) の「Orchestration と Pipeline」節）。
+
 ### `exec$` 系 API の責務（[#616](https://github.com/gurezo/chirimen-lite-console/issues/616)）
 
 - **ターミナル（xterm）経路**では `send$()` と `terminalText$` のみを使い、`exec$()` / `execRaw$()` / `readUntilPrompt$()` は **呼ばない**（親 [#609](https://github.com/gurezo/chirimen-lite-console/issues/609)）。
@@ -98,3 +100,4 @@ Issue #590 / [#601](https://github.com/gurezo/chirimen-lite-console/issues/601) 
 - [#617](https://github.com/gurezo/chirimen-lite-console/issues/617) — `terminalText$` の責務明確化（ドキュメント・JSDoc）
 - [#646](https://github.com/gurezo/chirimen-lite-console/issues/646) — README / ドキュメント上の `receive$` / `lines$` / `terminalText$` と Feature 境界の明文化
 - [#649](https://github.com/gurezo/chirimen-lite-console/issues/649) — `SerialFacadeService` の公開 API 縮小（`receive$` 等を Facade から除去）
+- [#664](https://github.com/gurezo/chirimen-lite-console/issues/664) — Facade を実質入口に統一し、パッケージ公開面からコマンド Pipeline クラスを除く（Orchestration の内部例外を文書化）

--- a/libs/web-serial/data-access/README.md
+++ b/libs/web-serial/data-access/README.md
@@ -30,9 +30,16 @@ PiZeroSerialBootstrapService
   -> login / environment setup の具体処理
 ```
 
+### Orchestration と Pipeline（data-access 内部）（[#664](https://github.com/gurezo/chirimen-lite-console/issues/664)）
+
+`SerialConnectionOrchestrationService` は、接続成功直後にコマンド用 **read loop** を開始し、切断時に実行中コマンドをキャンセルして read loop を停止する。これらは **`SerialCommandPipelineService` を直接 inject** して呼ぶ（`startReadLoop` / `stopReadLoop` / `cancelAllCommands`）。
+
+`SerialFacadeService` が既に `SerialConnectionOrchestrationService` を inject しているため、オーケストレーション側まで Facade 経由にすると **Angular DI の循環依存**になりやすい。よって read loop ライフサイクルだけ Pipeline を直接触るのは **data-access 内部の例外** とし、Feature 層の「入口は `SerialFacadeService` のみ」とは両立させる。
+
 ### 実装時のルール（要約）
 
 - Feature 側から `SerialTransportService` を直接参照しない（入口は `SerialFacadeService` のみ）。
+- `@libs-web-serial-data-access` の公開境界では **`SerialCommandPipelineService`（および旧名エイリアス `SerialCommandService`）クラスを export しない**。`exec$` 系の戻り値型など必要な **型**（`CommandResult` 等）のみ barrel から再エクスポートする（[#664](https://github.com/gurezo/chirimen-lite-console/issues/664)）。
 - ターミナル表示には `terminalText$` を使う。
 - 生の `receive$` は原則 **data-access internal**（Feature から購読しない。プロンプト照合は `SerialCommandPipelineService` が `receive$` からバッファを構築）。
 - コマンド実行（stdout キャプチャ付き）には `exec$` / `execRaw$` を使う。

--- a/libs/web-serial/data-access/src/index.ts
+++ b/libs/web-serial/data-access/src/index.ts
@@ -8,7 +8,11 @@ export * from './lib/pi-zero-session.service';
 export * from './lib/pi-zero-serial-bootstrap.service';
 export * from './lib/pi-zero-shell-readiness.service';
 export * from './lib/serial-setup-status';
-export * from './lib/serial-command/serial-command-facade.service';
+export type {
+  CommandExecutionConfig,
+  CommandResult,
+} from './lib/serial-command/serial-command-types';
+export type { SerialCommandEnqueueOptions } from './lib/serial-command/serial-command-pipeline.service';
 export * from './lib/serial-facade.service';
 export * from './lib/serial-notification.service';
 export * from './lib/serial-connection-view-model.facade';


### PR DESCRIPTION
## Summary

Issue #664 に沿い、`@libs-web-serial-data-access` の公開面から `SerialCommandPipelineService`（および `SerialCommandService` エイリアス）クラスの再エクスポートをやめ、コマンド関連は型（`CommandResult` 等）のみ barrel から公開する。`SerialConnectionOrchestrationService` が Pipeline を直接 inject する理由（Facade との循環 DI 回避・read loop ライフサイクル）を README と `docs/serial-architecture.md` に明記した。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [x] Breaking change

## Related issues

- Fixes #664
- Refs #662

## What changed?

- `libs/web-serial/data-access/src/index.ts` でコマンド実装クラスの barrel export を削除し、必要な型のみ再エクスポートした。
- README に Orchestration × Pipeline の内部例外と、Feature は引き続き `SerialFacadeService` のみ参照する方針を追記した。
- `docs/serial-architecture.md` に #664 の要点と README への参照を追記した。

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - Details: `@libs-web-serial-data-access` から `SerialCommandPipelineService` / `SerialCommandService` の export を削除。外部がこれらを import していた場合は、`SerialFacadeService` の `exec$` / `execRaw$` / `readUntilPrompt$` に寄せるか、モノレポ内では data-access 内部パスを参照する必要がある（本リポジトリ内に該当 import はなかった）。
- [ ] This change is backward compatible
- [x] This change introduces a breaking change
  - Migration notes: 上記のとおり、パッケージ公開 API から Pipeline クラスが除かれる。アプリの Feature 層はもともと `SerialFacadeService` のみを参照している想定。

## How to test

1. `pnpm nx run libs-web-serial-data-access:test`
2. `pnpm nx run libs-web-serial-data-access:lint`
3. （任意）シリアル接続・切断で read loop が従来どおり動くことを実機で確認

## Environment (if relevant)

- Browser: （該当時）
- OS: macOS / Windows / Linux
- Node version: （ローカル値）
- pnpm version: （ローカル値）

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant