### PR TITLE
fix(terminal): オートログイン初期化時のターミナル表示インデント崩れを修正

### DIFF
--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
@@ -122,7 +122,7 @@ describe('TerminalConsoleOrchestrationService', () => {
         .pipe(defaultIfEmpty(undefined)),
     );
     expect(write).not.toHaveBeenCalled();
-    expect(writeln).toHaveBeenCalledWith('prefix 初期化済みのためスキップします。');
+    expect(writeln).not.toHaveBeenCalled();
   });
 
   it('bootstrapAfterConnect$ delegates post-connect work to PiZeroSessionService', async () => {
@@ -145,7 +145,8 @@ describe('TerminalConsoleOrchestrationService', () => {
 
     expect(shouldRunAfterConnect$).toHaveBeenCalledTimes(1);
     expect(runAfterConnect$).toHaveBeenCalledTimes(1);
-    expect(writeln).toHaveBeenCalledWith('prefix 初期化しています...');
+    expect(writeln).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
   });
 
   it('bootstrapAfterConnect$ rethrows bootstrap errors for caller handling', async () => {
@@ -166,7 +167,6 @@ describe('TerminalConsoleOrchestrationService', () => {
         ),
       ),
     ).rejects.toThrow('auth failed');
-    expect(writeln).toHaveBeenCalledWith('prefix 初期化しています...');
     expect(writeln).toHaveBeenCalledWith('prefix 初期化に失敗しました: auth failed');
   });
 
@@ -194,6 +194,27 @@ describe('TerminalConsoleOrchestrationService', () => {
     expect(writeln).toHaveBeenCalledWith(
       'prefix 初期化に失敗しました: Shell readiness timeout while waiting for prompt',
     );
+  });
+
+  it('bootstrapAfterConnect$ does not pass status sink into runAfterConnect$', async () => {
+    const writeln = vi.fn();
+    const write = vi.fn();
+    const runAfterConnect$ = vi.fn(() => of(undefined));
+    TestBed.overrideProvider(PiZeroSessionService, {
+      useValue: {
+        shouldRunAfterConnect$: () => of(true),
+        runAfterConnect$,
+      },
+    });
+    const svc = TestBed.inject(TerminalConsoleOrchestrationService);
+
+    await firstValueFrom(
+      svc
+        .bootstrapAfterConnect$('prefix', { writeln, write })
+        .pipe(defaultIfEmpty(undefined)),
+    );
+
+    expect(runAfterConnect$).toHaveBeenCalledWith();
   });
 
 });

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts
@@ -121,10 +121,8 @@ describe('TerminalConsoleOrchestrationService', () => {
         .bootstrapAfterConnect$('prefix', { writeln, write })
         .pipe(defaultIfEmpty(undefined)),
     );
-    expect(writeln).not.toHaveBeenCalled();
-    expect(write).toHaveBeenCalledWith(
-      '\r\nprefix 初期化済みのためスキップします。\r\n',
-    );
+    expect(write).not.toHaveBeenCalled();
+    expect(writeln).toHaveBeenCalledWith('prefix 初期化済みのためスキップします。');
   });
 
   it('bootstrapAfterConnect$ delegates post-connect work to PiZeroSessionService', async () => {
@@ -147,7 +145,7 @@ describe('TerminalConsoleOrchestrationService', () => {
 
     expect(shouldRunAfterConnect$).toHaveBeenCalledTimes(1);
     expect(runAfterConnect$).toHaveBeenCalledTimes(1);
-    expect(write).toHaveBeenCalledWith('\r\nprefix 初期化しています...\r\n');
+    expect(writeln).toHaveBeenCalledWith('prefix 初期化しています...');
   });
 
   it('bootstrapAfterConnect$ rethrows bootstrap errors for caller handling', async () => {
@@ -168,10 +166,8 @@ describe('TerminalConsoleOrchestrationService', () => {
         ),
       ),
     ).rejects.toThrow('auth failed');
-    expect(write).toHaveBeenCalledWith('\r\nprefix 初期化しています...\r\n');
-    expect(write).toHaveBeenCalledWith(
-      '\r\nprefix 初期化に失敗しました: auth failed\r\n',
-    );
+    expect(writeln).toHaveBeenCalledWith('prefix 初期化しています...');
+    expect(writeln).toHaveBeenCalledWith('prefix 初期化に失敗しました: auth failed');
   });
 
   it('bootstrapAfterConnect$ keeps explicit shell readiness timeout errors', async () => {
@@ -195,8 +191,8 @@ describe('TerminalConsoleOrchestrationService', () => {
         ),
       ),
     ).rejects.toThrow('Shell readiness timeout while waiting for prompt');
-    expect(write).toHaveBeenCalledWith(
-      '\r\nprefix 初期化に失敗しました: Shell readiness timeout while waiting for prompt\r\n',
+    expect(writeln).toHaveBeenCalledWith(
+      'prefix 初期化に失敗しました: Shell readiness timeout while waiting for prompt',
     );
   });
 

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
@@ -125,6 +125,6 @@ export class TerminalConsoleOrchestrationService {
   }
 
   private writeConsoleLine(sink: TerminalConsoleSink, line: string): void {
-    sink.write(`\r\n${line}\r\n`);
+    sink.writeln(line);
   }
 }

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts
@@ -103,13 +103,9 @@ export class TerminalConsoleOrchestrationService {
     return this.piZeroSession.shouldRunAfterConnect$().pipe(
       switchMap((should) => {
         if (!should) {
-          this.writeConsoleLine(sink, `${prefixMessage} 初期化済みのためスキップします。`);
           return EMPTY;
         }
-        this.writeConsoleLine(sink, `${prefixMessage} 初期化しています...`);
-        return this.piZeroSession.runAfterConnect$((line) =>
-          this.writeConsoleLine(sink, line),
-        );
+        return this.piZeroSession.runAfterConnect$();
       }),
       catchError((error: unknown) => {
         const message =

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts
@@ -169,14 +169,16 @@ describe('TerminalViewComponent', () => {
     });
   });
 
-  it('forwards terminalText$ payload to xterm without sanitizing ANSI/CR/TAB', async () => {
+  it('keeps ANSI/CR/TAB and normalizes LF to CRLF for xterm write', async () => {
     const writeSpy = vi.spyOn(fixture.componentInstance.xterminal, 'write');
     writeSpy.mockClear();
 
-    const raw = '\u001b[2K\ra\tb\r\n$ ';
+    const raw = '\u001b[2K\ra\tb\n$ ';
     terminalTextSubject.next(raw);
 
-    await vi.waitFor(() => expect(writeSpy).toHaveBeenCalledWith(raw));
+    await vi.waitFor(() =>
+      expect(writeSpy).toHaveBeenCalledWith('\u001b[2K\ra\tb\r\n$ '),
+    );
   });
 
   it('skips re-emission when terminalText$ value is identical to previous', async () => {

--- a/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts
@@ -181,14 +181,22 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
     if (text.startsWith(this.lastTerminalText)) {
       const delta = text.slice(this.lastTerminalText.length);
       if (delta) {
-        this.xterminal.write(delta);
+        this.xterminal.write(this.normalizeNewlinesForXterm(delta));
       }
     } else {
       this.xterminal.reset();
       if (text) {
-        this.xterminal.write(text);
+        this.xterminal.write(this.normalizeNewlinesForXterm(text));
       }
     }
     this.lastTerminalText = text;
+  }
+
+  /**
+   * xterm へは LF を CRLF に揃えて渡す。LF のみだと同じカラム位置で改行され、
+   * 行頭が右へずれて見えるため。
+   */
+  private normalizeNewlinesForXterm(chunk: string): string {
+    return chunk.replace(/\r?\n/g, '\r\n');
   }
 }


### PR DESCRIPTION
## Summary
- 接続後初期化フローで xterm と `terminalText$` の表示競合を減らすため、bootstrap の直接出力経路を整理
- `terminalText$` 差分描画前に改行を `LF -> CRLF` へ正規化し、行頭が右へずれ続ける表示崩れを防止
- 変更に合わせて `terminal-console-orchestration` / `terminal-view` の unit test を更新

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #608

## What changed?

- `libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.ts`
- `libs/terminal/ui/src/lib/terminal-view/terminal-console-orchestration.service.spec.ts`
- `libs/terminal/ui/src/lib/terminal-view/terminal-view.component.ts`
- `libs/terminal/ui/src/lib/terminal-view/terminal-view.component.spec.ts`

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm exec nx test libs-terminal-ui`
2. `npx nx serve apps-console` を起動し、`localhost:4200` で対象ポートへ接続
3. オートログイン〜環境初期化〜`ls -al` 実行まで、行頭が右にずれ続けないことを確認

## Environment (if relevant)

- Browser: Chrome v147.x
- OS: macOS
- Node version: (ローカル環境)
- pnpm version: (ローカル環境)

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)