### PR TITLE
feat(console-shell): 左右サイドバーアイコンのクリックで開閉トグル (#688)

### DIFF
--- a/libs/console-shell/ui/src/lib/left-sidebar/left-sidebar.component.html
+++ b/libs/console-shell/ui/src/lib/left-sidebar/left-sidebar.component.html
@@ -9,7 +9,14 @@
   <div
     class="flex shrink-0 flex-col items-center gap-1 border-l border-gray-200 py-2"
   >
-    <mat-icon aria-hidden="true">folder</mat-icon>
+    <button
+      mat-icon-button
+      type="button"
+      aria-label="Toggle left panel"
+      (click)="toggleLeftSidebar.emit()"
+    >
+      <mat-icon>folder</mat-icon>
+    </button>
     <button
       mat-icon-button
       type="button"

--- a/libs/console-shell/ui/src/lib/left-sidebar/left-sidebar.component.spec.ts
+++ b/libs/console-shell/ui/src/lib/left-sidebar/left-sidebar.component.spec.ts
@@ -38,10 +38,20 @@ describe('LeftSidebarComponent', () => {
 
   it('should emit toggleLeftSidebar when the panel toggle is clicked', () => {
     const emitSpy = vi.spyOn(component.toggleLeftSidebar, 'emit');
-    const button: HTMLButtonElement | null =
-      fixture.nativeElement.querySelector('button[mat-icon-button]');
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('button[mat-icon-button]');
 
-    button?.click();
+    buttons[1]?.click();
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should emit toggleLeftSidebar when the folder icon is clicked', () => {
+    const emitSpy = vi.spyOn(component.toggleLeftSidebar, 'emit');
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('button[mat-icon-button]');
+
+    buttons[0]?.click();
 
     expect(emitSpy).toHaveBeenCalledTimes(1);
   });

--- a/libs/console-shell/ui/src/lib/right-sidebar/right-sidebar.component.html
+++ b/libs/console-shell/ui/src/lib/right-sidebar/right-sidebar.component.html
@@ -4,7 +4,14 @@
   <div
     class="flex shrink-0 flex-col items-center gap-1 border-r border-gray-200 py-2"
   >
-    <mat-icon aria-hidden="true">fiber_pin</mat-icon>
+    <button
+      mat-icon-button
+      type="button"
+      aria-label="Toggle right panel"
+      (click)="toggleRightSidebar.emit()"
+    >
+      <mat-icon>fiber_pin</mat-icon>
+    </button>
     <button
       mat-icon-button
       type="button"

--- a/libs/console-shell/ui/src/lib/right-sidebar/right-sidebar.component.spec.ts
+++ b/libs/console-shell/ui/src/lib/right-sidebar/right-sidebar.component.spec.ts
@@ -22,10 +22,20 @@ describe('RightSidebarComponent', () => {
 
   it('should emit toggleRightSidebar when the panel toggle is clicked', () => {
     const emitSpy = vi.spyOn(component.toggleRightSidebar, 'emit');
-    const button: HTMLButtonElement | null =
-      fixture.nativeElement.querySelector('button[mat-icon-button]');
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('button[mat-icon-button]');
 
-    button?.click();
+    buttons[1]?.click();
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should emit toggleRightSidebar when the fiber_pin icon is clicked', () => {
+    const emitSpy = vi.spyOn(component.toggleRightSidebar, 'emit');
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('button[mat-icon-button]');
+
+    buttons[0]?.click();
 
     expect(emitSpy).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary

- 左サイドバーの `folder` アイコンと、右サイドバーの `fiber_pin` アイコンに、`mat-icon-button` でラップしてクリックイベントを追加した。
- クリックすると隣接するトグルボタンと同じ `toggleLeftSidebar` / `toggleRightSidebar` が emit され、`ConsoleShellStore.toggleLeftNav()` / `toggleRightNav()` を通じてサイドバーの開閉が切り替わる。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #688

## What changed?

- `libs/console-shell/ui/src/lib/left-sidebar/left-sidebar.component.html`: `folder` アイコンを `mat-icon-button` でラップし、`(click)="toggleLeftSidebar.emit()"` と `aria-label="Toggle left panel"` を追加。
- `libs/console-shell/ui/src/lib/right-sidebar/right-sidebar.component.html`: `fiber_pin` アイコンを `mat-icon-button` でラップし、`(click)="toggleRightSidebar.emit()"` と `aria-label="Toggle right panel"` を追加。
- `libs/console-shell/ui/src/lib/left-sidebar/left-sidebar.component.spec.ts` / `right-sidebar.component.spec.ts`: 既存のトグルボタンに加えて、新しくクリック可能になった `folder` / `fiber_pin` アイコンボタンを押した際にも対応する output が emit されることを確認するテストを追加。`querySelectorAll('button[mat-icon-button]')` で取得し直し、`[0]` をアイコンボタン、`[1]` を既存のトグルボタンとして検証。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx run libs-console-shell-ui:test` がグリーンであることを確認する。
2. `pnpm nx run libs-console-shell-ui:lint` がエラーなく完了することを確認する。
3. `pnpm nx serve console` 後に Web Serial 接続し、左サイドバーの `folder` アイコンと右サイドバーの `fiber_pin` アイコンをクリックして、それぞれサイドバーの開閉がトグルされることを確認する。

## Environment (if relevant)

- Browser: Chrome (Web Serial 対応ブラウザ)
- OS: macOS / Windows / Linux
- Node version: -
- pnpm version: -

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)