### PR TITLE
docs(workspace): add Conventional Commits cursor rules and agent skill (#692)

### DIFF
--- a/.agents/skills/conventional-commits/SKILL.md
+++ b/.agents/skills/conventional-commits/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: conventional-commits
+description: Generates Conventional Commits compliant commit messages and pull request titles for the chirimen-lite-console workspace. Trigger when authoring commit messages, drafting PR titles or descriptions, reviewing whether existing commits follow Conventional Commits, or when the user mentions commitlint, scope, scope-enum, breaking change, semantic-release, nx release, or release notes. Aligns with the project's commitlint.config.js scope-enum and CONTRIBUTING.md.
+metadata:
+  version: '1.0'
+---
+
+# Conventional Commits Skill (chirimen-lite-console)
+
+このスキルは、`chirimen-lite-console` の Angular + Nx モノレポ構成と `commitlint.config.js`（`@commitlint/config-angular` 継承）の運用に最適化した Conventional Commits を生成するためのものです。
+
+## 前提
+
+- Angular + Nx モノレポ
+- パッケージマネージャ: `pnpm`
+- commitlint は導入済み（`.husky/commit-msg` で `pnpm exec commitlint --edit "$1"` を実行）
+- GitHub Actions（[.github/workflows/commitlint.yml](../../../.github/workflows/commitlint.yml)）で PR の commit 群を検証
+- scope の単一の真実は [commitlint.config.js](../../../commitlint.config.js) の `scope-enum`
+- 詳細は [CONTRIBUTING.md](../../../CONTRIBUTING.md) のスコープ表を参照
+
+## コミットメッセージ形式
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+- ヘッダ（必須）: `<type>(<scope>): <description>`
+- ボディ（任意）: 変更の理由や背景。空行を 1 行入れて記載
+- フッタ（任意）: `BREAKING CHANGE: ...` / `Closes #<n>` / `Refs #<n>`
+
+## 許可 type
+
+`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `revert`
+
+## description の書式
+
+- lowercase 始まり
+- 命令形（imperative）— 例: `add` / `fix` / `update`
+- 末尾ピリオドなし
+- 72 文字以内を目安に簡潔に
+
+## scope の選び方
+
+1. 影響が Nx の特定 lib / app に閉じる → その lib / app 名を scope に
+2. ルート設定（package.json, nx.json, tsconfig, GitHub Actions, husky, commitlint 等）の変更 → `workspace`
+3. ドキュメント単独の変更でも、最も関係する scope を選ぶ。リポジトリ横断の場合は `workspace`
+
+scope 一覧は [scopes.md](scopes.md) を参照。`commitlint.config.js` の `scope-enum` を超えた scope は使用しない。
+
+## 破壊的変更（BREAKING CHANGE）
+
+- ヘッダに `!`: `feat(web-serial)!: change session connection interface`
+- もしくはフッタに `BREAKING CHANGE: <summary>` を記述
+
+## PR タイトル
+
+PR タイトルも Conventional Commits に統一する。1 PR = 1 type / 1 scope を基本とし、`Closes #<n>` / `Fixes #<n>` は PR 本文の `Related issues` セクションに記載する。
+
+## カテゴリ別ガイド
+
+### Angular コンポーネント / UI 変更
+
+```
+feat(console): add dark mode toggle
+refactor(console-shell): split toolbar into smaller components
+fix(dialogs): prevent duplicated open events
+```
+
+### Web Serial 関連
+
+```
+feat(web-serial): add reconnect strategy
+fix(web-serial-data-access): handle unexpected port close
+refactor(web-serial-util): simplify port detection
+```
+
+### Terminal / Editor
+
+```
+fix(terminal): prevent resize on reconnect
+feat(editor): add Monaco theme switcher
+```
+
+### Shared lib（共通）
+
+```
+refactor(shared-util): simplify session helpers
+feat(shared-ui): add status badge component
+fix(shared-guards): redirect when serial is disconnected
+```
+
+### CI / Release / Workspace
+
+```
+ci(workspace): tighten commitlint workflow trigger
+build(workspace): bump @angular/* to 21.2.13
+docs(workspace): update CONTRIBUTING with scope list
+```
+
+## 参照ファイル
+
+- [examples.md](examples.md) — 良い例 / 悪い例
+- [assertions.md](assertions.md) — 検証項目と Valid / Invalid サンプル
+- [scopes.md](scopes.md) — scope 一覧と用途（`commitlint.config.js` と同期）
+- [CONTRIBUTING.md](../../../CONTRIBUTING.md) — リポジトリ全体のコントリビュートルール
+
+## 将来連携
+
+- 本リポジトリは [nx.json](../../../nx.json) の `release.version.conventionalCommits` を有効化することで Conventional Commits から bump 種別（`fix` → patch / `feat` → minor）を自動決定できる。
+- 一貫した commit message は changelog 自動生成 / semantic-release / Nx Release の前提となる。

--- a/.agents/skills/conventional-commits/assertions.md
+++ b/.agents/skills/conventional-commits/assertions.md
@@ -1,0 +1,49 @@
+# Conventional Commits Assertions (chirimen-lite-console)
+
+AI が生成 / 提案するコミットメッセージや PR タイトルに対して満たすべき検証項目。
+
+## 検証項目
+
+- [ ] Conventional Commits の形式（`<type>(<scope>): <description>`）に一致しているか
+- [ ] `type` が許可リスト（`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `revert`）にあるか
+- [ ] `scope` が [commitlint.config.js](../../../commitlint.config.js) の `scope-enum` にあるか
+- [ ] `description` が lowercase 始まりか
+- [ ] `description` が命令形（imperative）か（`added` / `fixes` などになっていないか）
+- [ ] `description` の末尾にピリオドがないか
+- [ ] `description` が 72 文字を大きく超えていないか
+- [ ] 破壊的変更がある場合に `!` または `BREAKING CHANGE:` が付与されているか
+- [ ] `scope` と実際の変更対象（lib / app / workspace ルート）が一致しているか
+- [ ] 1 commit / 1 PR に複数 scope の変更が混在していないか
+
+## Valid サンプル
+
+```
+feat(console-shell): add serial connection banner
+fix(web-serial-data-access): handle unexpected port close
+refactor(shared-util): simplify session helpers
+docs(workspace): update CONTRIBUTING with scope list
+ci(workspace): tighten commitlint workflow trigger
+build(workspace): bump @angular/* to 21.2.13
+feat(web-serial)!: change session connection interface
+```
+
+## Invalid サンプル
+
+| メッセージ                                  | 問題点                                  |
+| ------------------------------------------- | --------------------------------------- |
+| `fix stuff`                                 | 形式違反 (`type(scope): description`)   |
+| `update console`                            | type なし                               |
+| `Added new component`                       | type なし / 大文字 / 過去形             |
+| `WIP`                                       | type / scope / description すべて欠落   |
+| `chore(workspace): cleanup`                 | `chore` は許可されていない              |
+| `feat(web-serial-rxjs): add observable`     | `scope-enum` に未登録の scope           |
+| `feat(connection): add reconnect`           | `scope-enum` に未登録の scope           |
+| `feat(console): Add dark mode.`             | 大文字始まり / 末尾ピリオド             |
+| `fix(console): fixed bug`                   | 過去形（imperative 違反）               |
+| `feat(console)!: change everything`         | description が雑 / 詳細不明             |
+
+## 自動チェック
+
+- 手元: `git commit` 時に `.husky/commit-msg` が `pnpm exec commitlint --edit $1` を実行
+- CI: PR 作成時に [.github/workflows/commitlint.yml](../../../.github/workflows/commitlint.yml) が `pnpm exec commitlint --from <base> --to <head> --verbose` を実行
+- 任意（ローカル検証）: `pnpm exec commitlint --from origin/main --to HEAD --verbose`

--- a/.agents/skills/conventional-commits/examples.md
+++ b/.agents/skills/conventional-commits/examples.md
@@ -1,0 +1,79 @@
+# Conventional Commits Examples (chirimen-lite-console)
+
+`commitlint.config.js` の `scope-enum` に整合した、本リポジトリで実際に使用できる例。
+
+## 良い例
+
+### feat
+
+```
+feat(console): add dark mode toggle
+feat(console-shell): add connection status indicator
+feat(web-serial): add reconnect strategy
+feat(editor): add Monaco theme switcher
+feat(terminal): add auto scroll on output
+feat(shared-ui): add status badge component
+```
+
+### fix
+
+```
+fix(terminal): prevent resize on reconnect
+fix(web-serial-data-access): handle unexpected port close
+fix(dialogs): prevent duplicated open events
+fix(shared-guards): redirect when serial is disconnected
+fix(i2cdetect-ui): align device list rows
+```
+
+### refactor
+
+```
+refactor(console-shell): split toolbar into smaller components
+refactor(web-serial-util): simplify port detection
+refactor(shared-util): simplify session helpers
+refactor(remote): extract command parser
+```
+
+### docs / build / ci / test / perf / style / revert
+
+```
+docs(workspace): update CONTRIBUTING with scope list
+docs(console): document dark mode usage
+build(workspace): bump @angular/* to 21.2.13
+ci(workspace): tighten commitlint workflow trigger
+test(web-serial): cover reconnect timing
+perf(terminal): debounce resize handler
+style(console): apply prettier formatting
+revert(workspace): revert "build(workspace): bump nx to 22.7.2"
+```
+
+### 破壊的変更
+
+```
+feat(web-serial)!: change session connection interface
+
+BREAKING CHANGE: SerialSession.connect() now returns Promise<Result>
+instead of Promise<void>. Callers must handle the new return shape.
+```
+
+## 悪い例（避ける）
+
+```
+update files
+fix issue
+WIP
+Refactoring
+Added New Feature.
+feat: Added New Feature.
+fix(console): Fix bug.
+feat(web-serial-rxjs): add observable          # scope-enum に存在しない
+chore(workspace): cleanup                       # chore は許可されていない
+feat(console)!: BREAKING CHANGE in dark mode    # description が雑
+```
+
+### よくある誤り
+
+- `chore` を使う → 許可されていない。`build` / `ci` / `docs` / `refactor` のいずれかに分類する
+- `web-serial-rxjs` / `signal-store` / `connection` などを scope に使う → `scope-enum` に存在しない
+- description の先頭を大文字 / 過去形 / 末尾ピリオド → ルール違反
+- 1 commit に複数 scope の変更が混在する → なるべく分割する

--- a/.agents/skills/conventional-commits/scopes.md
+++ b/.agents/skills/conventional-commits/scopes.md
@@ -1,0 +1,60 @@
+# Conventional Commits Scopes (chirimen-lite-console)
+
+scope の単一の真実は [commitlint.config.js](../../../commitlint.config.js) の `scope-enum` です。詳細用途は [CONTRIBUTING.md](../../../CONTRIBUTING.md) のスコープ表を参照してください。本ファイルは AI が scope を選択する際のクイックリファレンスです。
+
+## scope 一覧
+
+| Scope                    | 用途                                                         |
+| ------------------------ | ------------------------------------------------------------ |
+| `console`                | メインアプリ (`apps/console`)                                |
+| `console-shell`          | コンソールシェル lib                                         |
+| `connect`                | 接続 lib                                                     |
+| `page-not-found`         | 404 ページ lib                                               |
+| `web-serial`             | Web Serial lib（全体）                                       |
+| `web-serial-util`        | Web Serial lib の util                                       |
+| `web-serial-data-access` | Web Serial lib の data-access                                |
+| `example`                | サンプル lib                                                 |
+| `wifi`                   | Wi-Fi lib                                                    |
+| `dialogs`                | ダイアログ lib                                               |
+| `unsupported-browser`    | 非対応ブラウザ lib                                           |
+| `editor`                 | エディタ lib                                                 |
+| `terminal`               | ターミナル lib                                               |
+| `pin-assign-panel`       | ピン割り当てパネル lib                                       |
+| `shared-ui`              | 共有 UI lib                                                  |
+| `shared-guards`          | 共有ガード lib                                               |
+| `shared-types`           | 共有型定義 lib                                               |
+| `shared-util`            | 共有ユーティリティ lib                                       |
+| `i2cdetect`              | I2C 検出 lib（feature 全体）                                 |
+| `i2cdetect-ui`           | I2C 検出 lib の UI                                           |
+| `i2cdetect-data-access`  | I2C 検出 lib の data-access                                  |
+| `i2cdetect-util`         | I2C 検出 lib の util                                         |
+| `workspace`              | ルート・共通設定（package.json, nx.json, tsconfig, CI など） |
+| `setup`                  | chirimen セットアップ lib                                    |
+| `file-manager`           | ファイルマネージャ lib                                       |
+| `remote`                 | リモート lib                                                 |
+
+## 選び方
+
+1. 影響が 1 つの lib / app に閉じる → その lib / app 名を選ぶ
+2. ルート設定 / CI / husky / commitlint / docs 横断 → `workspace`
+3. リポジトリ全体の運用ドキュメント → `workspace`
+4. 複数 lib にまたがる変更は、可能なら commit / PR を分割する
+
+## 採用しない scope（Issue #692 由来）
+
+下記は本ワークスペースに対応する Nx プロジェクトが存在しない、または既存 scope と重複するため採用しません。
+
+- `web-serial-rxjs` — 外部パッケージ。本リポジトリの変更 scope ではない
+- `signal-store`, `ngrx`, `shared-store` — 専用 lib として分離されていない
+- `connection`, `connection-guard` — 機能は `connect` / `shared-guards` でカバー
+- `auth`, `timezone`, `device-detection` — 該当 lib なし
+- `i2c-detect` — `i2cdetect` を使用する
+- `menu`, `layout`, `theme`, `toolbar`, `router`, `settings` — 該当 lib なし、`console` / `console-shell` で吸収
+- `release`, `ci`, `docs` — `workspace` で吸収
+
+## scope を追加したい場合
+
+1. Nx generator で新 lib を作成（`nx-generate` skill を参照）
+2. [commitlint.config.js](../../../commitlint.config.js) の `scope-enum` に追加
+3. [CONTRIBUTING.md](../../../CONTRIBUTING.md) のスコープ表を更新
+4. このファイルと [.cursor/rules/commit/20-chirimen-lite-console-scope.mdc](../../../.cursor/rules/commit/20-chirimen-lite-console-scope.mdc) を更新

--- a/.cursor/rules/commit/00-conventional-commits.mdc
+++ b/.cursor/rules/commit/00-conventional-commits.mdc
@@ -1,0 +1,65 @@
+---
+description: Conventional Commits baseline rules for commit messages.
+globs:
+  - "**/*"
+alwaysApply: false
+---
+
+# Conventional Commits Rules
+
+本リポジトリのコミットメッセージは [Conventional Commits](https://www.conventionalcommits.org/) に準拠する。commitlint は `@commitlint/config-angular` を継承しており、`commitlint.config.js` の `scope-enum` を満たすこと。
+
+## フォーマット
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+- ヘッダ（必須）: `<type>(<scope>): <description>`
+- ボディ（任意）: 変更の理由・背景
+- フッタ（任意）: `BREAKING CHANGE: ...` や `Closes #<issue>` など
+
+## 許可される type
+
+- `feat` — 新機能
+- `fix` — バグ修正
+- `docs` — ドキュメントのみの変更
+- `style` — 動作に影響しない書式変更
+- `refactor` — 機能を変えないリファクタリング
+- `perf` — パフォーマンス改善
+- `test` — テストの追加・修正
+- `build` — ビルド・依存関係関連
+- `ci` — CI 設定関連
+- `revert` — 過去のコミットの取り消し
+
+## description の書式
+
+- lowercase で開始する
+- 命令形（imperative）で書く（例: `add`, `fix`, `update`、`added` や `fixes` ではなく）
+- 末尾にピリオドを付けない
+- 簡潔にする（目安: 72 文字以内）
+
+## 破壊的変更（BREAKING CHANGE）
+
+次のいずれかで明示する。
+
+- ヘッダに `!` を付ける: `feat(web-serial)!: change session connection interface`
+- フッタに `BREAKING CHANGE: <summary>` を記載
+
+## scope
+
+scope は `commitlint.config.js` の `scope-enum` から選択する。詳細は `20-chirimen-lite-console-scope.mdc` および `CONTRIBUTING.md` のスコープ表を参照。
+
+## 例
+
+```
+feat(console): add dark mode toggle
+fix(terminal): prevent resize on reconnect
+build(workspace): bump nx to 22.7.2
+docs(workspace): update CONTRIBUTING with scope list
+refactor(web-serial): simplify port detection logic
+```

--- a/.cursor/rules/commit/10-pull-request-title.mdc
+++ b/.cursor/rules/commit/10-pull-request-title.mdc
@@ -1,0 +1,53 @@
+---
+description: Pull request title rules aligned with Conventional Commits.
+globs:
+  - ".github/pull_request_template.md"
+  - "**/*.md"
+alwaysApply: false
+---
+
+# Pull Request Title Rules
+
+PR タイトルは Conventional Commits に統一する。`commitlint.config.js` の `scope-enum` を満たす scope を必ず指定する。
+
+## フォーマット
+
+```
+<type>(<scope>): <description>
+```
+
+## 推奨
+
+- 1 PR = 1 type / 1 scope を基本とする
+- description は lowercase + imperative + 末尾ピリオドなし
+- 関連 Issue は PR 本文（[.github/pull_request_template.md](.github/pull_request_template.md) の `Related issues` セクション）で `Closes #<n>` / `Fixes #<n>` で紐付ける
+- 破壊的変更がある場合は `!` を付ける（例: `feat(web-serial)!: ...`）
+
+## 良い例
+
+```
+feat(console-shell): add connection status indicator
+fix(web-serial): handle unexpected port close
+refactor(shared-util): simplify session state
+docs(workspace): update CONTRIBUTING with scope list
+ci(workspace): tighten commitlint workflow trigger
+build(workspace): bump @angular/* to 21.2.13
+```
+
+## 悪い例
+
+```
+update files
+fix issue
+WIP
+Refactoring
+Added New Feature.
+feat: Added New Feature.
+```
+
+## チェック観点
+
+- type が許可リストにあるか
+- scope が `commitlint.config.js` の `scope-enum` にあるか
+- description が lowercase / imperative / 末尾ピリオドなし か
+- 破壊的変更がある場合に `!` または `BREAKING CHANGE:` が記載されているか

--- a/.cursor/rules/commit/20-chirimen-lite-console-scope.mdc
+++ b/.cursor/rules/commit/20-chirimen-lite-console-scope.mdc
@@ -1,0 +1,66 @@
+---
+description: chirimen-lite-console specific scope rules for Conventional Commits.
+globs:
+  - "**/*"
+alwaysApply: false
+---
+
+# chirimen-lite-console Scope Rules
+
+scope の単一の真実は [commitlint.config.js](../../../commitlint.config.js) の `scope-enum` および [CONTRIBUTING.md](../../../CONTRIBUTING.md) のスコープ表とする。ここから外れる scope はコミット時に commitlint で拒否される。
+
+## 選び方の方針
+
+- 影響範囲が Nx の特定の lib / app に閉じる場合は、その lib / app 名を scope にする
+- ルート（`package.json`, `nx.json`, `tsconfig.base.json`, GitHub Actions 等）への変更は `workspace`
+- ドキュメント単独の変更も、最も関連する scope を選ぶ（リポジトリ横断なら `workspace`）
+
+## scope 一覧
+
+`commitlint.config.js` に登録された scope（実 Nx プロジェクトと整合）。
+
+| Scope                     | 用途                                                          |
+| ------------------------- | ------------------------------------------------------------- |
+| `console`                 | メインアプリ (`apps/console`)                                 |
+| `console-shell`           | コンソールシェル lib                                          |
+| `connect`                 | 接続 lib                                                      |
+| `page-not-found`          | 404 ページ lib                                                |
+| `web-serial`              | Web Serial lib                                                |
+| `web-serial-util`         | Web Serial lib の util                                        |
+| `web-serial-data-access`  | Web Serial lib の data-access                                 |
+| `example`                 | サンプル lib                                                  |
+| `wifi`                    | Wi-Fi lib                                                     |
+| `dialogs`                 | ダイアログ lib                                                |
+| `unsupported-browser`     | 非対応ブラウザ lib                                            |
+| `editor`                  | エディタ lib                                                  |
+| `terminal`                | ターミナル lib                                                |
+| `pin-assign-panel`        | ピン割り当てパネル lib                                        |
+| `shared-ui`               | 共有 UI lib                                                   |
+| `shared-guards`           | 共有ガード lib                                                |
+| `shared-types`            | 共有型定義 lib                                                |
+| `shared-util`             | 共有ユーティリティ lib                                        |
+| `i2cdetect`               | I2C 検出 lib（feature 全体）                                  |
+| `i2cdetect-ui`            | I2C 検出 lib の UI                                            |
+| `i2cdetect-data-access`   | I2C 検出 lib の data-access                                   |
+| `i2cdetect-util`          | I2C 検出 lib の util                                          |
+| `workspace`               | ルート・共通設定（package.json, nx.json, tsconfig, CI など）  |
+| `setup`                   | chirimen セットアップ lib                                     |
+| `file-manager`            | ファイルマネージャ lib                                        |
+| `remote`                  | リモート lib                                                  |
+
+## 採用しない scope
+
+Issue #692 で挙げられていた以下の scope は、現状のワークスペース構成と `commitlint.config.js` に存在しないため採用しない。
+
+- `web-serial-rxjs`, `signal-store`, `ngrx`, `connection`, `connection-guard`, `auth`, `timezone`, `device-detection`, `i2c-detect`（`i2cdetect` を使用）, `menu`, `layout`, `theme`, `shared-store`, `toolbar`, `router`, `settings`, `release`, `ci`, `docs`
+
+`ci` / `release` / `docs` 系の変更は `workspace` scope を使用すること。
+
+## 新しい scope が必要になった場合
+
+新規 lib を作成したり、横断的な scope を増やしたい場合は次の手順で進める。
+
+1. 新規 lib は Nx generator で作成する（必要に応じて `nx-generate` skill を利用）
+2. `commitlint.config.js` の `scope-enum` に新 scope を追加
+3. `CONTRIBUTING.md` のスコープ表を更新
+4. このファイルおよび `.agents/skills/conventional-commits/scopes.md` を更新

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,20 @@
+<!--
+PR タイトルは Conventional Commits 形式で記載してください。
+
+  <type>(<scope>): <description>
+
+- type: feat / fix / docs / style / refactor / perf / test / build / ci / revert
+- scope: commitlint.config.js の scope-enum から選択（例: console, web-serial, workspace ...）
+- description: lowercase / imperative / 末尾ピリオドなし
+
+例:
+  feat(console): add dark mode toggle
+  fix(terminal): prevent resize on reconnect
+  docs(workspace): update CONTRIBUTING with scope list
+
+詳細は CONTRIBUTING.md および .cursor/rules/commit/ を参照してください。
+-->
+
 ## Summary
 
 ## Type of change

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,3 +94,16 @@ Nx Release は、`nx.json` の `release.version.conventionalCommits` を `true` 
 - ブランチ名は Conventional Commits の意図が分かるようにしてください（例: `feat/console/add-dark-mode`）。
 - プルリクエストのタイトルも Conventional Commits 形式を推奨します。
 - `.github/pull_request_template.md` に沿って概要・変更内容・テスト方法を記載してください。
+
+## AI による補助（Conventional Commits Skill / Rules）
+
+Cursor などの AI コーディングエージェント向けに、本リポジトリ用の Conventional Commits 補助を導入しています。
+
+- `.cursor/rules/commit/`
+  - `00-conventional-commits.mdc` — 形式 / 許可 type / lowercase / imperative / 末尾ピリオド禁止
+  - `10-pull-request-title.mdc` — PR タイトルの統一ルール
+  - `20-chirimen-lite-console-scope.mdc` — 本プロジェクト固有 scope の選び方
+- `.agents/skills/conventional-commits/`
+  - `SKILL.md` / `examples.md` / `assertions.md` / `scopes.md`
+
+scope の単一の真実は本ファイルの「スコープ一覧」と `commitlint.config.js` の `scope-enum` です。AI が生成したメッセージも、`pnpm install` 後は husky の `commit-msg` フックおよび CI の commitlint で検証されます。

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ Vitest で全プロジェクトのユニットテストを実行します。
 npx skills add https://github.com/angular/skills
 ```
 
+### Conventional Commits Skill
+
+本プロジェクト固有の Conventional Commits を AI が生成できるよう、`.agents/skills/conventional-commits/` に Skill を導入しています。
+
+- `SKILL.md` — Conventional Commits の形式・scope 選択・カテゴリ別ガイド
+- `examples.md` — 良い例 / 悪い例
+- `assertions.md` — 検証項目と Valid / Invalid サンプル
+- `scopes.md` — scope 一覧（`commitlint.config.js` と同期）
+
+詳細は Issue [#692](https://github.com/gurezo/chirimen-lite-console/issues/692) および [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。
+
 ### Nx AI Agent 設定
 
 [Nx AI Agents](https://nx.dev/blog/nx-ai-agent-skills) により、Nx Workspace 構造を AI に理解させるための Skills (`nx-workspace` / `nx-generate` / `nx-run-tasks` ほか)、Nx Console (MCP) 連携、ルート `AGENTS.md`、`.cursor/agents/` 配下のサブエージェント定義を導入しています。
@@ -98,6 +109,10 @@ pnpm nx configure-ai-agents
 │   ├── 10-angular-signals.mdc    # Signals の使い分け
 │   ├── 20-angular-components.mdc # Component 設計
 │   └── 30-angular-testing.mdc    # テスト方針
+├── commit/
+│   ├── 00-conventional-commits.mdc        # Conventional Commits 基本
+│   ├── 10-pull-request-title.mdc          # PR タイトル統一
+│   └── 20-chirimen-lite-console-scope.mdc # 本プロジェクト固有 scope
 ├── nx/
 │   ├── 00-nx-workspace.mdc       # Workspace 全体ルール
 │   ├── 10-nx-generators.mdc      # Nx Generator 利用方針
@@ -108,7 +123,7 @@ pnpm nx configure-ai-agents
 
 各 `.mdc` は `globs` で対象ファイルを限定しているため、対象ファイルを Cursor で開くと自動でルールが参照されます。
 
-詳細は Issue [#690](https://github.com/gurezo/chirimen-lite-console/issues/690) を参照してください。
+詳細は Issue [#690](https://github.com/gurezo/chirimen-lite-console/issues/690) / [#692](https://github.com/gurezo/chirimen-lite-console/issues/692) を参照してください。
 
 ## その他
 


### PR DESCRIPTION
## Summary

Issue #692 対応として、`chirimen-lite-console` 用 Conventional Commits の Cursor Rules / Agent Skill / 関連ドキュメントを追加します。AI コーディングエージェントが本リポジトリ規約に沿った commit message / PR タイトルを生成できるようにし、既存の `commitlint` / `husky` / GitHub Actions と整合させます。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Closes #692

## What changed?

- `.cursor/rules/commit/` を新設
  - `00-conventional-commits.mdc` — Conventional Commits の基本形式・許可 type・lowercase / imperative / 末尾ピリオド禁止・`BREAKING CHANGE:` の扱い
  - `10-pull-request-title.mdc` — PR タイトルの統一ルールと良い例 / 悪い例
  - `20-chirimen-lite-console-scope.mdc` — 本プロジェクト固有 scope の選び方（`commitlint.config.js` の `scope-enum` と同期）
- `.agents/skills/conventional-commits/` を新設
  - `SKILL.md` — AI 用 Conventional Commits ガイド（カテゴリ別ガイド・参照ファイル）
  - `examples.md` — 良い例 / 悪い例（実 scope のみ）
  - `assertions.md` — 検証項目と Valid / Invalid サンプル
  - `scopes.md` — scope 一覧（`commitlint.config.js` と同期）
- ドキュメント更新
  - `README.md` — 「AI エージェント向け設定」に Conventional Commits Skill / Rules セクションを追記
  - `CONTRIBUTING.md` — 末尾に「AI による補助（Conventional Commits Skill / Rules）」セクションを追記
  - `.github/pull_request_template.md` — 冒頭に Conventional Commits 形式の PR title 例コメントを追加

既存の `commitlint.config.js` / `.husky/commit-msg` / `.github/workflows/commitlint.yml` には **変更なし**（整合確認のみ）。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details: なし（ドキュメント / AI 補助のみ）
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes: なし

## How to test

1. ブランチをチェックアウトし、`pnpm install` 後 `.husky/commit-msg` が有効であることを確認
2. `pnpm exec commitlint --from origin/main --to HEAD --verbose` を実行し、本 PR の 4 コミットが全て検証を通ることを確認（ローカル確認済み）
3. Cursor で本リポジトリを開き、`.cursor/rules/commit/*.mdc` が `globs` に従って参照されることを確認
4. AI エージェントから `.agents/skills/conventional-commits/SKILL.md` がトリガーされ、scope が `commitlint.config.js` の `scope-enum` と整合した提案になることを確認
5. GitHub Actions の `commitlint` ワークフローが緑であることを確認

## Environment (if relevant)

- Browser: -
- OS: macOS / Windows / Linux
- Node version: 24
- pnpm version: 9

## Checklist

- [x] I ran tests locally (if available) — `pnpm exec commitlint --from origin/main --to HEAD --verbose` で 4 件全て pass
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)