### PR TITLE
build(web-serial): bump web-serial-rxjs to 3.1.0

### DIFF
--- a/libs/web-serial/src/lib/service/serial-connection-orchestration.service.spec.ts
+++ b/libs/web-serial/src/lib/service/serial-connection-orchestration.service.spec.ts
@@ -23,7 +23,7 @@ describe('SerialConnectionOrchestrationService', () => {
       stopReadLoop: vi.fn(),
       cancelAllCommands: vi.fn(),
     };
-    connectMock = vi.fn(() => of({ port: {} as SerialPort }));
+    connectMock = vi.fn(() => of({ ok: true as const }));
     disconnectMock = vi.fn(() => of(undefined));
     transport = {
       isConnected$: isConnectedSubj.asObservable(),

--- a/libs/web-serial/src/lib/service/serial-transport.service.spec.ts
+++ b/libs/web-serial/src/lib/service/serial-transport.service.spec.ts
@@ -32,7 +32,7 @@ vi.mock('@gurezo/web-serial-rxjs', async (importOriginal) => {
 });
 
 function buildMockSession(
-  port: SerialPort | null,
+  portInfo: SerialPortInfo | null,
   lines$?: Observable<string>,
   terminalText$?: Observable<string>,
   receive$?: Observable<string>,
@@ -41,31 +41,30 @@ function buildMockSession(
     status: SerialSessionStatus.Connecting,
   });
   const isConnected$ = new BehaviorSubject(false);
-  const getCurrentPort = vi.fn((): SerialPort | null => port);
+  const getPortInfo = vi.fn((): SerialPortInfo | null => portInfo);
   return {
     isBrowserSupported: () => true,
     connect$: vi.fn(() => {
       state$.next({
         status: SerialSessionStatus.Connected,
-        portInfo: {} as SerialPortInfo,
+        portInfo: portInfo ?? ({} as SerialPortInfo),
       });
       isConnected$.next(true);
-      if (port) {
-        getCurrentPort.mockReturnValue(port);
+      if (portInfo) {
+        getPortInfo.mockReturnValue(portInfo);
       }
       return of(undefined);
     }),
     disconnect$: vi.fn(() => {
       state$.next({ status: SerialSessionStatus.Idle });
       isConnected$.next(false);
-      getCurrentPort.mockReturnValue(null);
+      getPortInfo.mockReturnValue(null);
       return of(undefined);
     }),
     state$: state$.asObservable(),
     isConnected$: isConnected$.asObservable(),
     portInfo$: of(null),
-    getPortInfo: vi.fn(() => null),
-    getCurrentPort,
+    getPortInfo,
     errors$: EMPTY,
     receive$: receive$ ?? EMPTY,
     receiveReplay$: EMPTY,
@@ -88,13 +87,15 @@ describe('SerialTransportService', () => {
     expect(state.status).toBe(SerialSessionStatus.Idle);
     const connectedFlag = await firstValueFrom(service.isConnected$);
     expect(connectedFlag).toBe(false);
-    expect(service.getPort()).toBeUndefined();
     expect(service.getPortInfo()).toBeNull();
   });
 
   it('should delegate state$ and isConnected$ to SerialSession after connect', async () => {
-    const mockPort = {} as SerialPort;
-    const session = buildMockSession(mockPort);
+    const portInfo: SerialPortInfo = {
+      usbVendorId: 0x0525,
+      usbProductId: 0xa4a7,
+    };
+    const session = buildMockSession(portInfo);
     mockCreateSerialSession.mockReturnValue(session);
 
     await firstValueFrom(service.connect$());
@@ -103,13 +104,16 @@ describe('SerialTransportService', () => {
     expect(state.status).toBe(SerialSessionStatus.Connected);
     const connectedFlag = await firstValueFrom(service.isConnected$);
     expect(connectedFlag).toBe(true);
-    expect(service.getPort()).toBe(mockPort);
+    expect(service.getPortInfo()).toEqual(portInfo);
     expect(session.connect$).toHaveBeenCalledTimes(1);
   });
 
   it('should clear session and return to idle after disconnect', async () => {
-    const mockPort = {} as SerialPort;
-    mockCreateSerialSession.mockReturnValue(buildMockSession(mockPort));
+    const portInfo: SerialPortInfo = {
+      usbVendorId: 0x0525,
+      usbProductId: 0xa4a7,
+    };
+    mockCreateSerialSession.mockReturnValue(buildMockSession(portInfo));
 
     await firstValueFrom(service.connect$());
     expect(
@@ -123,14 +127,13 @@ describe('SerialTransportService', () => {
     expect(
       await firstValueFrom(service.isConnected$.pipe(take(1))),
     ).toBe(false);
-    expect(service.getPort()).toBeUndefined();
+    expect(service.getPortInfo()).toBeNull();
   });
 
   it('should expose errors$ from the active session when connected', async () => {
-    const mockPort = {} as SerialPort;
     const err = new SerialError(SerialErrorCode.READ_FAILED, 'read');
     const errSubj = new BehaviorSubject(err);
-    const session = buildMockSession(mockPort);
+    const session = buildMockSession({} as SerialPortInfo);
     (
       session as unknown as { errors$: Observable<SerialError> }
     ).errors$ = errSubj.asObservable();
@@ -142,8 +145,7 @@ describe('SerialTransportService', () => {
   });
 
   it('should emit from lines$ when session is active', async () => {
-    const mockPort = {} as SerialPort;
-    mockCreateSerialSession.mockReturnValue(buildMockSession(mockPort));
+    mockCreateSerialSession.mockReturnValue(buildMockSession({} as SerialPortInfo));
 
     await firstValueFrom(service.connect$());
     const line = await firstValueFrom(service.lines$.pipe(take(1)));
@@ -151,10 +153,9 @@ describe('SerialTransportService', () => {
   });
 
   it('lines$ should emit line strings from session lines$', async () => {
-    const mockPort = {} as SerialPort;
     const lineSubject = new Subject<string>();
     mockCreateSerialSession.mockReturnValue(
-      buildMockSession(mockPort, lineSubject.asObservable()),
+      buildMockSession({} as SerialPortInfo, lineSubject.asObservable()),
     );
 
     await firstValueFrom(service.connect$());
@@ -164,10 +165,9 @@ describe('SerialTransportService', () => {
   });
 
   it('lines$ should share source lines$ for multiple subscribers', async () => {
-    const mockPort = {} as SerialPort;
     const lineSubject = new Subject<string>();
     mockCreateSerialSession.mockReturnValue(
-      buildMockSession(mockPort, lineSubject.asObservable()),
+      buildMockSession({} as SerialPortInfo, lineSubject.asObservable()),
     );
 
     await firstValueFrom(service.connect$());
@@ -180,11 +180,10 @@ describe('SerialTransportService', () => {
   });
 
   it('should emit receive$ from session receive$', async () => {
-    const mockPort = {} as SerialPort;
     const chunkSubject = new Subject<string>();
     mockCreateSerialSession.mockReturnValue(
       buildMockSession(
-        mockPort,
+        {} as SerialPortInfo,
         undefined,
         undefined,
         chunkSubject.asObservable(),
@@ -198,10 +197,9 @@ describe('SerialTransportService', () => {
   });
 
   it('should emit terminalText$ from session terminalText$', async () => {
-    const mockPort = {} as SerialPort;
     const chunkSubject = new Subject<string>();
     mockCreateSerialSession.mockReturnValue(
-      buildMockSession(mockPort, undefined, chunkSubject.asObservable()),
+      buildMockSession({} as SerialPortInfo, undefined, chunkSubject.asObservable()),
     );
 
     await firstValueFrom(service.connect$());
@@ -211,8 +209,7 @@ describe('SerialTransportService', () => {
   });
 
   it('send$ should delegate to session send$', async () => {
-    const mockPort = {} as SerialPort;
-    const session = buildMockSession(mockPort);
+    const session = buildMockSession({} as SerialPortInfo);
     mockCreateSerialSession.mockReturnValue(session);
 
     await firstValueFrom(service.connect$());
@@ -228,63 +225,22 @@ describe('SerialTransportService', () => {
     };
 
     it('returns true when the current port info matches Pi Zero', async () => {
-      const mockPort = {} as SerialPort;
-      const session = buildMockSession(mockPort);
-      (
-        session as unknown as { getPortInfo: () => SerialPortInfo | null }
-      ).getPortInfo = () => PI_ZERO_INFO;
+      const session = buildMockSession(PI_ZERO_INFO);
       mockCreateSerialSession.mockReturnValue(session);
 
       await firstValueFrom(service.connect$());
       expect(await service.isRaspberryPiZero()).toBe(true);
-    });
-
-    it('falls back to port.getInfo() and returns true on match', async () => {
-      const mockPort = {
-        getInfo: vi.fn(() => Promise.resolve(PI_ZERO_INFO)),
-      } as unknown as SerialPort;
-      const session = buildMockSession(mockPort);
-      mockCreateSerialSession.mockReturnValue(session);
-
-      await firstValueFrom(service.connect$());
-      expect(await service.isRaspberryPiZero()).toBe(true);
-      expect(mockPort.getInfo).toHaveBeenCalledTimes(1);
     });
 
     it('returns false when VID/PID do not match Pi Zero', async () => {
-      const mockPort = {
-        getInfo: vi.fn(() =>
-          Promise.resolve({
-            usbVendorId: 0x1234,
-            usbProductId: 0x5678,
-          } satisfies SerialPortInfo),
-        ),
-      } as unknown as SerialPort;
-      const session = buildMockSession(mockPort);
+      const session = buildMockSession({
+        usbVendorId: 0x1234,
+        usbProductId: 0x5678,
+      });
       mockCreateSerialSession.mockReturnValue(session);
 
       await firstValueFrom(service.connect$());
       expect(await service.isRaspberryPiZero()).toBe(false);
-    });
-
-    it('returns false and logs when port.getInfo() rejects', async () => {
-      const consoleErrorSpy = vi
-        .spyOn(console, 'error')
-        .mockImplementation(() => undefined);
-      const rejection = new Error('getInfo failed');
-      const mockPort = {
-        getInfo: vi.fn(() => Promise.reject(rejection)),
-      } as unknown as SerialPort;
-      const session = buildMockSession(mockPort);
-      mockCreateSerialSession.mockReturnValue(session);
-
-      await firstValueFrom(service.connect$());
-      expect(await service.isRaspberryPiZero()).toBe(false);
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'Failed to get port info:',
-        rejection,
-      );
-      consoleErrorSpy.mockRestore();
     });
 
     it('returns false when no session is active', async () => {

--- a/libs/web-serial/src/lib/service/serial-transport.service.ts
+++ b/libs/web-serial/src/lib/service/serial-transport.service.ts
@@ -107,11 +107,11 @@ export class SerialTransportService {
 
   /**
    * {@link SerialSession.connect$} を呼び出し、Pi Zero フィルタでポートを開く。
-   * 戻り値だけアプリ向けに `{ port } | { error }` に整形する。
+   * 戻り値だけアプリ向けに `{ ok: true } | { error }` に整形する。
    */
   connect$(
     baudRate = 115200,
-  ): Observable<{ port: SerialPort } | { error: string }> {
+  ): Observable<{ ok: true } | { error: string }> {
     return defer(() => {
       this.detachSession();
       const session = createSerialSession({
@@ -127,8 +127,7 @@ export class SerialTransportService {
       this.activeSession$.next(session);
       return session.connect$().pipe(
         switchMap(() => {
-          const port = session.getCurrentPort();
-          if (!port) {
+          if (!session.getPortInfo()) {
             this.detachSession();
             return of({
               error: getConnectionErrorMessage(
@@ -136,7 +135,7 @@ export class SerialTransportService {
               ),
             });
           }
-          return of({ port });
+          return of({ ok: true as const });
         }),
         catchError((error) => {
           this.detachSession();
@@ -168,31 +167,14 @@ export class SerialTransportService {
     });
   }
 
-  getPort(): SerialPort | undefined {
-    return this.active?.getCurrentPort() ?? undefined;
-  }
-
   /**
    * 現在接続中のポートが Raspberry Pi Zero 互換か判定する（Pi Zero 判定の集約先。[#674](https://github.com/gurezo/chirimen-lite-console/issues/674)）。
    *
-   * 同期 `getPortInfo()` → NG なら `getPort()?.getInfo()` の順に評価する。
+   * v3.1 以降は {@link SerialSession.getPortInfo}（接続時は `state.portInfo` と同等）のみを参照する。
    * Feature 層からは {@link SerialFacadeService#isRaspberryPiZero} 経由でのみ参照する。
    */
   async isRaspberryPiZero(): Promise<boolean> {
-    if (this.isPiZeroPortInfo(this.getPortInfo())) {
-      return true;
-    }
-    const port = this.getPort();
-    if (!port) {
-      return false;
-    }
-    try {
-      const info = await port.getInfo();
-      return this.isPiZeroPortInfo(info);
-    } catch (error) {
-      console.error('Failed to get port info:', error);
-      return false;
-    }
+    return this.isPiZeroPortInfo(this.getPortInfo());
   }
 
   private isPiZeroPortInfo(info: SerialPortInfo | null | undefined): boolean {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@angular/platform-browser": "22.0.6",
     "@angular/platform-browser-dynamic": "22.0.6",
     "@angular/router": "22.0.6",
-    "@gurezo/web-serial-rxjs": "3.0.0",
+    "@gurezo/web-serial-rxjs": "3.1.0",
     "@ngrx/component-store": "21.1.1",
     "@ngrx/effects": "21.1.1",
     "@ngrx/operators": "21.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,8 +39,8 @@ importers:
         specifier: 22.0.6
         version: 22.0.6(@angular/common@22.0.6(@angular/core@22.0.6(@angular/compiler@22.0.6)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.6(@angular/compiler@22.0.6)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.6(@angular/animations@22.0.6(@angular/core@22.0.6(@angular/compiler@22.0.6)(rxjs@7.8.2)(zone.js@0.16.2)))(@angular/common@22.0.6(@angular/core@22.0.6(@angular/compiler@22.0.6)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.6(@angular/compiler@22.0.6)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
       '@gurezo/web-serial-rxjs':
-        specifier: 3.0.0
-        version: 3.0.0(rxjs@7.8.2)
+        specifier: 3.1.0
+        version: 3.1.0(rxjs@7.8.2)
       '@ngrx/component-store':
         specifier: 21.1.1
         version: 21.1.1(@angular/core@22.0.6(@angular/compiler@22.0.6)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2)
@@ -1742,8 +1742,8 @@ packages:
     resolution: {integrity: sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  '@gurezo/web-serial-rxjs@3.0.0':
-    resolution: {integrity: sha512-f1OEDQc1KaLj9yW3hog4ehx555OB6vMomvA/oBqJZJ7m2a1QJuH5AUzv4rEQ9G/vcIlhLPOoLblz49DMLl1YGw==}
+  '@gurezo/web-serial-rxjs@3.1.0':
+    resolution: {integrity: sha512-wmECfGGdm6nFpGfcBa3BBYwxjPe1hH9ezHJ4lGs/z7BklVQBaEAXFyyZ+he8SfjcfMRwzGP8bh6Ka3O1PFt/kA==}
     peerDependencies:
       rxjs: ^7.8.0
 
@@ -10407,7 +10407,7 @@ snapshots:
 
   '@gar/promise-retry@1.0.3': {}
 
-  '@gurezo/web-serial-rxjs@3.0.0(rxjs@7.8.2)':
+  '@gurezo/web-serial-rxjs@3.1.0(rxjs@7.8.2)':
     dependencies:
       rxjs: 7.8.2
 


### PR DESCRIPTION
## Summary
- Bump `@gurezo/web-serial-rxjs` from 3.0.0 to 3.1.0
- Adapt `SerialTransportService` to v3.1.0 breaking changes where `SerialSession.getCurrentPort()` was removed
- Use `getPortInfo()` for post-connect validation and Pi Zero detection instead of exposing `SerialPort` directly

## Test plan
- [x] `pnpm nx run libs-web-serial:test`
- [x] `pnpm nx run apps-console:build:production`


Made with [Cursor](https://cursor.com)