### PR TITLE
fix(web-serial): restore file tree after pi zero autologin

### DIFF
--- a/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.spec.ts
+++ b/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.spec.ts
@@ -2,8 +2,23 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, Router } from '@angular/router';
 import { provideMockStore } from '@ngrx/store/testing';
-import { EMPTY } from 'rxjs';
+import { FileService } from '@libs-file-manager';
+import {
+  SerialConnectionViewModelFacade,
+  type SerialConnectionViewModel,
+} from '@libs-web-serial';
+import { BehaviorSubject, EMPTY } from 'rxjs';
 import { LeftSidebarComponent } from './left-sidebar.component';
+
+const baseVm: SerialConnectionViewModel = {
+  isBrowserSupported: true,
+  isConnected: false,
+  isConnecting: false,
+  isLoggedIn: false,
+  isInitializing: false,
+  setupStatus: 'idle',
+  errorMessage: null,
+};
 
 describe('LeftSidebarComponent', () => {
   let component: LeftSidebarComponent;
@@ -24,6 +39,20 @@ describe('LeftSidebarComponent', () => {
           useValue: { navigate: vi.fn().mockResolvedValue(true), events: EMPTY },
         },
         { provide: ActivatedRoute, useValue: activatedRoute },
+        {
+          provide: SerialConnectionViewModelFacade,
+          useValue: {
+            vm$: new BehaviorSubject<SerialConnectionViewModel>(baseVm).asObservable(),
+            connect: vi.fn(),
+            disconnect: vi.fn(),
+            sendCommand: vi.fn(),
+            clearError: vi.fn(),
+          },
+        },
+        {
+          provide: FileService,
+          useValue: { listTree: vi.fn().mockResolvedValue([]) },
+        },
       ],
     }).compileComponents();
 

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
@@ -3,31 +3,33 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FileTreeFeatureComponent } from './file-tree-feature.component';
 import { FileTreeNode } from '../../models';
 import { FileService } from '../../service';
-import { PiZeroShellReadinessService, SerialConnectionViewModelFacade } from '@libs-web-serial';
-import { BehaviorSubject, of } from 'rxjs';
+import { SerialConnectionViewModelFacade } from '@libs-web-serial';
+import { BehaviorSubject } from 'rxjs';
+import type { SerialConnectionViewModel } from '@libs-web-serial';
 
 describe('FileTreeFeatureComponent', () => {
   const listTreeMock = vi.fn<() => Promise<FileTreeNode[]>>();
-  let readySubject: BehaviorSubject<boolean>;
+  let vmSubject: BehaviorSubject<SerialConnectionViewModel>;
 
   const treeNodes: FileTreeNode[] = [
     { name: 'docs', path: './docs', isDirectory: true },
     { name: 'main.ts', path: './main.ts', isDirectory: false },
   ];
 
-  async function compileAndCreate(
-    initialReady: boolean,
-  ): Promise<ComponentFixture<FileTreeFeatureComponent>> {
-    readySubject = new BehaviorSubject(initialReady);
-    const shellReadiness: Pick<
-      PiZeroShellReadinessService,
-      'ready$' | 'isReady' | 'setReady' | 'reset'
-    > = {
-      ready$: readySubject.asObservable(),
-      isReady: () => readySubject.value,
-      setReady: (v: boolean) => readySubject.next(v),
-      reset: () => readySubject.next(false),
-    };
+  const baseVm: SerialConnectionViewModel = {
+    isBrowserSupported: true,
+    isConnected: false,
+    isConnecting: false,
+    isLoggedIn: false,
+    isInitializing: false,
+    setupStatus: 'idle',
+    errorMessage: null,
+  };
+
+  async function compileAndCreate(): Promise<
+    ComponentFixture<FileTreeFeatureComponent>
+  > {
+    vmSubject = new BehaviorSubject<SerialConnectionViewModel>({ ...baseVm });
 
     await TestBed.configureTestingModule({
       imports: [FileTreeFeatureComponent],
@@ -37,22 +39,8 @@ describe('FileTreeFeatureComponent', () => {
           useValue: { listTree: listTreeMock },
         },
         {
-          provide: PiZeroShellReadinessService,
-          useValue: shellReadiness,
-        },
-        {
           provide: SerialConnectionViewModelFacade,
-          useValue: {
-            vm$: of({
-              isBrowserSupported: true,
-              isConnected: true,
-              isConnecting: false,
-              isLoggedIn: initialReady,
-              isInitializing: false,
-              setupStatus: 'idle',
-              errorMessage: null,
-            }),
-          },
+          useValue: { vm$: vmSubject.asObservable() },
         },
       ],
     }).compileComponents();
@@ -70,13 +58,21 @@ describe('FileTreeFeatureComponent', () => {
   });
 
   it('should create', async () => {
-    const fixture = await compileAndCreate(false);
+    const fixture = await compileAndCreate();
     expect(fixture.componentInstance).toBeTruthy();
     await fixture.whenStable();
   });
 
-  it('defers listTree until shell becomes ready', async () => {
-    const fixture = await compileAndCreate(false);
+  it('defers listTree until vm reports logged in', async () => {
+    const fixture = await compileAndCreate();
+    fixture.detectChanges();
+
+    vmSubject.next({
+      ...baseVm,
+      isConnected: true,
+      isLoggedIn: false,
+      setupStatus: 'waiting-login',
+    });
     await fixture.whenStable();
 
     expect(listTreeMock).not.toHaveBeenCalled();
@@ -84,7 +80,12 @@ describe('FileTreeFeatureComponent', () => {
       fixture.nativeElement.querySelector('mat-progress-spinner'),
     ).toBeTruthy();
 
-    readySubject.next(true);
+    vmSubject.next({
+      ...baseVm,
+      isConnected: true,
+      isLoggedIn: true,
+      setupStatus: 'setting-timezone',
+    });
     await vi.waitFor(() => {
       expect(listTreeMock).toHaveBeenCalledWith('.');
     });
@@ -92,8 +93,16 @@ describe('FileTreeFeatureComponent', () => {
     expect(fixture.componentInstance.nodes.length).toBe(2);
   });
 
-  it('loads nodes on init when shell is already ready', async () => {
-    const fixture = await compileAndCreate(true);
+  it('loads nodes when already logged in on connect', async () => {
+    const fixture = await compileAndCreate();
+    fixture.detectChanges();
+
+    vmSubject.next({
+      ...baseVm,
+      isConnected: true,
+      isLoggedIn: true,
+      setupStatus: 'ready',
+    });
     await vi.waitFor(() => {
       expect(listTreeMock).toHaveBeenCalledWith('.');
     });

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
@@ -3,8 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FileTreeFeatureComponent } from './file-tree-feature.component';
 import { FileTreeNode } from '../../models';
 import { FileService } from '../../service';
-import { PiZeroShellReadinessService } from '@libs-web-serial';
-import { BehaviorSubject } from 'rxjs';
+import { PiZeroShellReadinessService, SerialConnectionViewModelFacade } from '@libs-web-serial';
+import { BehaviorSubject, of } from 'rxjs';
 
 describe('FileTreeFeatureComponent', () => {
   const listTreeMock = vi.fn<() => Promise<FileTreeNode[]>>();
@@ -40,6 +40,20 @@ describe('FileTreeFeatureComponent', () => {
           provide: PiZeroShellReadinessService,
           useValue: shellReadiness,
         },
+        {
+          provide: SerialConnectionViewModelFacade,
+          useValue: {
+            vm$: of({
+              isBrowserSupported: true,
+              isConnected: true,
+              isConnecting: false,
+              isLoggedIn: initialReady,
+              isInitializing: false,
+              setupStatus: 'idle',
+              errorMessage: null,
+            }),
+          },
+        },
       ],
     }).compileComponents();
 
@@ -71,17 +85,19 @@ describe('FileTreeFeatureComponent', () => {
     ).toBeTruthy();
 
     readySubject.next(true);
+    await vi.waitFor(() => {
+      expect(listTreeMock).toHaveBeenCalledWith('.');
+    });
     await fixture.whenStable();
-
-    expect(listTreeMock).toHaveBeenCalledWith('.');
     expect(fixture.componentInstance.nodes.length).toBe(2);
   });
 
   it('loads nodes on init when shell is already ready', async () => {
     const fixture = await compileAndCreate(true);
+    await vi.waitFor(() => {
+      expect(listTreeMock).toHaveBeenCalledWith('.');
+    });
     await fixture.whenStable();
-
-    expect(listTreeMock).toHaveBeenCalledWith('.');
     expect(fixture.componentInstance.nodes.length).toBe(2);
   });
 });

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
@@ -5,7 +5,10 @@ import { joinPath } from '../../functions';
 import { FileTreeNode } from '../../models';
 import { FileService } from '../../service';
 import { FileTreeComponent } from '../file-tree/file-tree.component';
-import { PiZeroShellReadinessService } from '@libs-web-serial';
+import {
+  PiZeroShellReadinessService,
+  SerialConnectionViewModelFacade,
+} from '@libs-web-serial';
 import { filter, take } from 'rxjs/operators';
 
 @Component({
@@ -19,6 +22,7 @@ import { filter, take } from 'rxjs/operators';
 export class FileTreeFeatureComponent implements OnInit {
   private file = inject(FileService);
   private shellReadiness = inject(PiZeroShellReadinessService);
+  private connectionVm = inject(SerialConnectionViewModelFacade);
   private destroyRef = inject(DestroyRef);
   readonly fileSelected = output<string>();
 
@@ -29,8 +33,21 @@ export class FileTreeFeatureComponent implements OnInit {
 
   ngOnInit(): void {
     this.loading = true;
+
+    this.connectionVm.vm$
+      .pipe(
+        filter((vm) => vm.setupStatus === 'failed' && !vm.isLoggedIn),
+        take(1),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => {
+        this.loading = false;
+        this.errorMessage =
+          'シェルの初期化に失敗しました。ターミナルを確認してください。';
+      });
+
     if (this.shellReadiness.isReady()) {
-      void this.loadCurrentPath();
+      queueMicrotask(() => void this.loadCurrentPath());
       return;
     }
     this.shellReadiness.ready$
@@ -39,7 +56,7 @@ export class FileTreeFeatureComponent implements OnInit {
         take(1),
         takeUntilDestroyed(this.destroyRef),
       )
-      .subscribe(() => void this.loadCurrentPath());
+      .subscribe(() => queueMicrotask(() => void this.loadCurrentPath()));
   }
 
   async reload(): Promise<void> {

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
@@ -1,15 +1,19 @@
-import { Component, DestroyRef, inject, OnInit, output } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  inject,
+  OnInit,
+  output,
+} from '@angular/core';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { joinPath } from '../../functions';
 import { FileTreeNode } from '../../models';
 import { FileService } from '../../service';
 import { FileTreeComponent } from '../file-tree/file-tree.component';
-import {
-  PiZeroShellReadinessService,
-  SerialConnectionViewModelFacade,
-} from '@libs-web-serial';
-import { filter, startWith, take } from 'rxjs/operators';
+import { SerialConnectionViewModelFacade } from '@libs-web-serial';
+import { distinctUntilChanged, map } from 'rxjs/operators';
 
 @Component({
   selector: 'lib-file-tree-feature',
@@ -21,9 +25,9 @@ import { filter, startWith, take } from 'rxjs/operators';
 })
 export class FileTreeFeatureComponent implements OnInit {
   private file = inject(FileService);
-  private shellReadiness = inject(PiZeroShellReadinessService);
   private connectionVm = inject(SerialConnectionViewModelFacade);
   private destroyRef = inject(DestroyRef);
+  private cdr = inject(ChangeDetectorRef);
   readonly fileSelected = output<string>();
 
   nodes: FileTreeNode[] = [];
@@ -31,46 +35,64 @@ export class FileTreeFeatureComponent implements OnInit {
   loading = false;
   errorMessage: string | null = null;
 
-  ngOnInit(): void {
-    this.loading = true;
+  private loadedForLogin = false;
 
+  ngOnInit(): void {
     this.connectionVm.vm$
       .pipe(
-        filter((vm) => vm.setupStatus === 'failed' && !vm.isLoggedIn),
-        take(1),
+        map((vm) => ({
+          isConnected: vm.isConnected,
+          isLoggedIn: vm.isLoggedIn,
+          setupFailed: vm.setupStatus === 'failed' && !vm.isLoggedIn,
+        })),
+        distinctUntilChanged(
+          (a, b) =>
+            a.isConnected === b.isConnected &&
+            a.isLoggedIn === b.isLoggedIn &&
+            a.setupFailed === b.setupFailed,
+        ),
         takeUntilDestroyed(this.destroyRef),
       )
-      .subscribe(() => {
-        this.loading = false;
-        this.errorMessage =
-          'シェルの初期化に失敗しました。ターミナルを確認してください。';
-      });
+      .subscribe((vm) => {
+        if (!vm.isConnected) {
+          this.loading = false;
+          this.errorMessage = null;
+          this.nodes = [];
+          this.loadedForLogin = false;
+          this.cdr.markForCheck();
+          return;
+        }
 
-    if (this.shellReadiness.isReady()) {
-      queueMicrotask(() => void this.loadCurrentPath());
-      return;
-    }
-    this.shellReadiness.ready$
-      .pipe(
-        startWith(this.shellReadiness.isReady()),
-        filter(Boolean),
-        take(1),
-        takeUntilDestroyed(this.destroyRef),
-      )
-      .subscribe(() => queueMicrotask(() => void this.loadCurrentPath()));
+        if (vm.setupFailed) {
+          this.loading = false;
+          this.errorMessage =
+            'シェルの初期化に失敗しました。ターミナルを確認してください。';
+          this.cdr.markForCheck();
+          return;
+        }
+
+        if (!vm.isLoggedIn) {
+          this.loading = true;
+          this.errorMessage = null;
+          this.loadedForLogin = false;
+          this.cdr.markForCheck();
+          return;
+        }
+
+        if (this.loadedForLogin) {
+          return;
+        }
+        this.loadedForLogin = true;
+        void this.loadCurrentPath();
+      });
   }
 
   async reload(): Promise<void> {
-    if (!this.shellReadiness.isReady()) {
-      return;
-    }
+    this.loadedForLogin = false;
     await this.loadCurrentPath();
   }
 
   async onDirectorySelected(node: FileTreeNode): Promise<void> {
-    if (!this.shellReadiness.isReady()) {
-      return;
-    }
     this.currentPath = node.path;
     await this.loadCurrentPath();
   }
@@ -80,9 +102,6 @@ export class FileTreeFeatureComponent implements OnInit {
   }
 
   async goParent(): Promise<void> {
-    if (!this.shellReadiness.isReady()) {
-      return;
-    }
     if (this.currentPath === '.') {
       return;
     }
@@ -99,13 +118,16 @@ export class FileTreeFeatureComponent implements OnInit {
   private async loadCurrentPath(): Promise<void> {
     this.loading = true;
     this.errorMessage = null;
+    this.cdr.markForCheck();
     try {
       this.nodes = await this.file.listTree(this.currentPath);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       this.errorMessage = message;
+      this.loadedForLogin = false;
     } finally {
       this.loading = false;
+      this.cdr.markForCheck();
     }
   }
 }

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
@@ -9,7 +9,7 @@ import {
   PiZeroShellReadinessService,
   SerialConnectionViewModelFacade,
 } from '@libs-web-serial';
-import { filter, take } from 'rxjs/operators';
+import { filter, startWith, take } from 'rxjs/operators';
 
 @Component({
   selector: 'lib-file-tree-feature',
@@ -52,6 +52,7 @@ export class FileTreeFeatureComponent implements OnInit {
     }
     this.shellReadiness.ready$
       .pipe(
+        startWith(this.shellReadiness.isReady()),
         filter(Boolean),
         take(1),
         takeUntilDestroyed(this.destroyRef),

--- a/libs/file-manager/src/lib/functions/file-tree.util.spec.ts
+++ b/libs/file-manager/src/lib/functions/file-tree.util.spec.ts
@@ -16,6 +16,7 @@ describe('file-tree util', () => {
 
   it('ignores total and dot entries', () => {
     expect(parseLsLine('total 12', '.')).toBeNull();
+    expect(parseLsLine('合計 36', '.')).toBeNull();
     expect(
       parseLsLine('drwxr-xr-x 2 pi pi 4096 Mar 20 10:00 "."', '.'),
     ).toBeNull();

--- a/libs/file-manager/src/lib/functions/file-tree.util.ts
+++ b/libs/file-manager/src/lib/functions/file-tree.util.ts
@@ -23,7 +23,7 @@ export function parseLsLine(
   line: string,
   basePath: string,
 ): FileTreeNode | null {
-  if (!line || line.startsWith('total ')) {
+  if (!line || line.startsWith('total ') || line.startsWith('合計 ')) {
     return null;
   }
 

--- a/libs/file-manager/src/lib/service/file.service.spec.ts
+++ b/libs/file-manager/src/lib/service/file.service.spec.ts
@@ -21,6 +21,7 @@ function expectShellExecOptions(
   const promptMatch = options.promptMatch as (buf: string) => boolean;
   expect(promptMatch('pi@custom-host:~$ ')).toBe(true);
   expect(promptMatch('pi@raspberrypi:~$ ')).toBe(true);
+  expect(promptMatch('pi@raspberrypi:~$ ls -al')).toBe(false);
 }
 
 describe('FileService', () => {
@@ -80,6 +81,16 @@ describe('FileService', () => {
         expect.objectContaining({ timeout: SERIAL_TIMEOUT.LONG }),
       );
       expectShellExecOptions(exec.mock.calls[0]?.[1], SERIAL_TIMEOUT.LONG);
+    });
+
+    it('strips echoed command and trailing prompt from ls stdout', async () => {
+      const command = `ls -al --quoting-style=c -- ${FileUtils.escapePath('.')}`;
+      exec.mockResolvedValue({
+        stdout: `${command}\ntotal 36\ndrwxr-xr-x 2 pi pi 4096 "docs"\npi@raspberrypi:~$ `,
+      });
+
+      const lines = await svc.listLines('.');
+      expect(lines).toEqual(['total 36', 'drwxr-xr-x 2 pi pi 4096 "docs"']);
     });
 
     it('uses flexible shell prompt match for non-default hostnames', async () => {

--- a/libs/file-manager/src/lib/service/file.service.spec.ts
+++ b/libs/file-manager/src/lib/service/file.service.spec.ts
@@ -1,12 +1,27 @@
 import '@angular/compiler';
 import { Injector } from '@angular/core';
 import { FileContentService } from '@libs-wifi';
-import { SerialFacadeService } from '@libs-web-serial';
-import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial';
+import {
+  PiZeroPromptDetectorService,
+  SerialFacadeService,
+  SERIAL_TIMEOUT,
+} from '@libs-web-serial';
 import { FileUtils } from '@libs-wifi';
 import { from } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FileService } from './file.service';
+
+function expectShellExecOptions(
+  options: Record<string, unknown>,
+  timeout: number,
+): void {
+  expect(options.prompt).toBe('');
+  expect(options.promptMatch).toBeTypeOf('function');
+  expect(options.timeout).toBe(timeout);
+  const promptMatch = options.promptMatch as (buf: string) => boolean;
+  expect(promptMatch('pi@custom-host:~$ ')).toBe(true);
+  expect(promptMatch('pi@raspberrypi:~$ ')).toBe(true);
+}
 
 describe('FileService', () => {
   let exec: ReturnType<typeof vi.fn>;
@@ -21,6 +36,7 @@ describe('FileService', () => {
     const injector = Injector.create({
       providers: [
         FileService,
+        PiZeroPromptDetectorService,
         {
           provide: SerialFacadeService,
           useValue: {
@@ -51,11 +67,9 @@ describe('FileService', () => {
       await svc.listLines('');
       expect(exec).toHaveBeenCalledWith(
         `ls -al --quoting-style=c -- ${FileUtils.escapePath('.')}`,
-        {
-          prompt: PI_ZERO_PROMPT,
-          timeout: SERIAL_TIMEOUT.LONG,
-        },
+        expect.objectContaining({ timeout: SERIAL_TIMEOUT.LONG }),
       );
+      expectShellExecOptions(exec.mock.calls[0]?.[1], SERIAL_TIMEOUT.LONG);
     });
 
     it('passes escaped path to ls', async () => {
@@ -63,11 +77,19 @@ describe('FileService', () => {
       await svc.listLines('./my dir');
       expect(exec).toHaveBeenCalledWith(
         `ls -al --quoting-style=c -- ${FileUtils.escapePath('./my dir')}`,
-        {
-          prompt: PI_ZERO_PROMPT,
-          timeout: SERIAL_TIMEOUT.LONG,
-        },
+        expect.objectContaining({ timeout: SERIAL_TIMEOUT.LONG }),
       );
+      expectShellExecOptions(exec.mock.calls[0]?.[1], SERIAL_TIMEOUT.LONG);
+    });
+
+    it('uses flexible shell prompt match for non-default hostnames', async () => {
+      exec.mockResolvedValue({ stdout: 'file.txt\n' });
+      await svc.listLines('.');
+      const options = exec.mock.calls[0]?.[1] as {
+        promptMatch?: (buf: string) => boolean;
+      };
+      expect(options.promptMatch?.('pi@pizero-w:~$ ')).toBe(true);
+      expect(options.promptMatch?.('pi@raspberrypi:~$ ')).toBe(true);
     });
   });
 
@@ -92,11 +114,9 @@ describe('FileService', () => {
       await svc.mkdir('/tmp/a');
       expect(exec).toHaveBeenCalledWith(
         `mkdir -p -- ${FileUtils.escapePath('/tmp/a')}`,
-        {
-          prompt: PI_ZERO_PROMPT,
-          timeout: SERIAL_TIMEOUT.DEFAULT,
-        },
+        expect.objectContaining({ timeout: SERIAL_TIMEOUT.DEFAULT }),
       );
+      expectShellExecOptions(exec.mock.calls[0]?.[1], SERIAL_TIMEOUT.DEFAULT);
     });
   });
 
@@ -105,11 +125,9 @@ describe('FileService', () => {
       await svc.touch('./file.txt');
       expect(exec).toHaveBeenCalledWith(
         `touch -- ${FileUtils.escapePath('./file.txt')}`,
-        {
-          prompt: PI_ZERO_PROMPT,
-          timeout: SERIAL_TIMEOUT.DEFAULT,
-        },
+        expect.objectContaining({ timeout: SERIAL_TIMEOUT.DEFAULT }),
       );
+      expectShellExecOptions(exec.mock.calls[0]?.[1], SERIAL_TIMEOUT.DEFAULT);
     });
   });
 
@@ -118,11 +136,9 @@ describe('FileService', () => {
       await svc.remove('./old.txt');
       expect(exec).toHaveBeenCalledWith(
         `rm -- ${FileUtils.escapePath('./old.txt')}`,
-        {
-          prompt: PI_ZERO_PROMPT,
-          timeout: SERIAL_TIMEOUT.DEFAULT,
-        },
+        expect.objectContaining({ timeout: SERIAL_TIMEOUT.DEFAULT }),
       );
+      expectShellExecOptions(exec.mock.calls[0]?.[1], SERIAL_TIMEOUT.DEFAULT);
     });
   });
 
@@ -168,11 +184,9 @@ describe('FileService', () => {
       await svc.move('./a', './b');
       expect(exec).toHaveBeenCalledWith(
         `mv -- ${FileUtils.escapePath('./a')} ${FileUtils.escapePath('./b')}`,
-        {
-          prompt: PI_ZERO_PROMPT,
-          timeout: SERIAL_TIMEOUT.DEFAULT,
-        },
+        expect.objectContaining({ timeout: SERIAL_TIMEOUT.DEFAULT }),
       );
+      expectShellExecOptions(exec.mock.calls[0]?.[1], SERIAL_TIMEOUT.DEFAULT);
     });
   });
 

--- a/libs/file-manager/src/lib/service/file.service.ts
+++ b/libs/file-manager/src/lib/service/file.service.ts
@@ -16,7 +16,7 @@ export class FileService {
   private fileContent = inject(FileContentService);
   private promptDetector = inject(PiZeroPromptDetectorService);
 
-  private shellExecOptions(timeout = SERIAL_TIMEOUT.DEFAULT) {
+  private shellExecOptions(timeout: number = SERIAL_TIMEOUT.DEFAULT) {
     return createPiZeroShellExecOptions(this.promptDetector, { timeout });
   }
 

--- a/libs/file-manager/src/lib/service/file.service.ts
+++ b/libs/file-manager/src/lib/service/file.service.ts
@@ -3,6 +3,7 @@ import { FileContentService, FileUtils } from '@libs-wifi';
 import {
   createPiZeroShellExecOptions,
   PiZeroPromptDetectorService,
+  sanitizeSerialStdout,
   SERIAL_TIMEOUT,
   SerialFacadeService,
 } from '@libs-web-serial';
@@ -26,20 +27,28 @@ export class FileService {
   async listLines(directoryPath: string): Promise<string[]> {
     const dir = directoryPath || '.';
     const escaped = FileUtils.escapePath(dir);
+    const command = `ls -al --quoting-style=c -- ${escaped}`;
 
     const stdout = (
       await firstValueFrom(
         this.serial.exec$(
-          `ls -al --quoting-style=c -- ${escaped}`,
+          command,
           this.shellExecOptions(SERIAL_TIMEOUT.LONG),
         ),
       )
     ).stdout;
 
-    return stdout
+    const cleaned = sanitizeSerialStdout(
+      typeof stdout === 'string' ? stdout : '',
+      command,
+      '',
+    );
+
+    return cleaned
       .split('\n')
       .map((line) => line.trim())
-      .filter(Boolean);
+      .filter(Boolean)
+      .filter((line) => !this.promptDetector.isCommandCompleted(line));
   }
 
   /**

--- a/libs/file-manager/src/lib/service/file.service.ts
+++ b/libs/file-manager/src/lib/service/file.service.ts
@@ -1,6 +1,11 @@
 import { Injectable, inject } from '@angular/core';
 import { FileContentService, FileUtils } from '@libs-wifi';
-import { PI_ZERO_PROMPT, SERIAL_TIMEOUT, SerialFacadeService } from '@libs-web-serial';
+import {
+  createPiZeroShellExecOptions,
+  PiZeroPromptDetectorService,
+  SERIAL_TIMEOUT,
+  SerialFacadeService,
+} from '@libs-web-serial';
 import { parseLsOutput } from '../functions';
 import { FileTreeNode } from '../models';
 import { firstValueFrom } from 'rxjs';
@@ -9,6 +14,11 @@ import { firstValueFrom } from 'rxjs';
 export class FileService {
   private serial = inject(SerialFacadeService);
   private fileContent = inject(FileContentService);
+  private promptDetector = inject(PiZeroPromptDetectorService);
+
+  private shellExecOptions(timeout = SERIAL_TIMEOUT.DEFAULT) {
+    return createPiZeroShellExecOptions(this.promptDetector, { timeout });
+  }
 
   /**
    * ディレクトリ直下の ls 出力（行単位）を返します。
@@ -18,10 +28,12 @@ export class FileService {
     const escaped = FileUtils.escapePath(dir);
 
     const stdout = (
-      await firstValueFrom(this.serial.exec$(`ls -al --quoting-style=c -- ${escaped}`, {
-        prompt: PI_ZERO_PROMPT,
-        timeout: SERIAL_TIMEOUT.LONG,
-      }))
+      await firstValueFrom(
+        this.serial.exec$(
+          `ls -al --quoting-style=c -- ${escaped}`,
+          this.shellExecOptions(SERIAL_TIMEOUT.LONG),
+        ),
+      )
     ).stdout;
 
     return stdout
@@ -40,26 +52,23 @@ export class FileService {
 
   async mkdir(path: string): Promise<void> {
     const escaped = FileUtils.escapePath(path);
-    await firstValueFrom(this.serial.exec$(`mkdir -p -- ${escaped}`, {
-      prompt: PI_ZERO_PROMPT,
-      timeout: SERIAL_TIMEOUT.DEFAULT,
-    }));
+    await firstValueFrom(
+      this.serial.exec$(`mkdir -p -- ${escaped}`, this.shellExecOptions()),
+    );
   }
 
   async touch(path: string): Promise<void> {
     const escaped = FileUtils.escapePath(path);
-    await firstValueFrom(this.serial.exec$(`touch -- ${escaped}`, {
-      prompt: PI_ZERO_PROMPT,
-      timeout: SERIAL_TIMEOUT.DEFAULT,
-    }));
+    await firstValueFrom(
+      this.serial.exec$(`touch -- ${escaped}`, this.shellExecOptions()),
+    );
   }
 
   async remove(path: string): Promise<void> {
     const escaped = FileUtils.escapePath(path);
-    await firstValueFrom(this.serial.exec$(`rm -- ${escaped}`, {
-      prompt: PI_ZERO_PROMPT,
-      timeout: SERIAL_TIMEOUT.DEFAULT,
-    }));
+    await firstValueFrom(
+      this.serial.exec$(`rm -- ${escaped}`, this.shellExecOptions()),
+    );
   }
 
   async read(path: string): Promise<string> {
@@ -73,10 +82,12 @@ export class FileService {
   async move(fromPath: string, toPath: string): Promise<void> {
     const fromEscaped = FileUtils.escapePath(fromPath);
     const toEscaped = FileUtils.escapePath(toPath);
-    await firstValueFrom(this.serial.exec$(`mv -- ${fromEscaped} ${toEscaped}`, {
-      prompt: PI_ZERO_PROMPT,
-      timeout: SERIAL_TIMEOUT.DEFAULT,
-    }));
+    await firstValueFrom(
+      this.serial.exec$(
+        `mv -- ${fromEscaped} ${toEscaped}`,
+        this.shellExecOptions(),
+      ),
+    );
   }
 
   /**

--- a/libs/web-serial/src/lib/functions/index.ts
+++ b/libs/web-serial/src/lib/functions/index.ts
@@ -1,3 +1,4 @@
+export * from './pi-zero-shell-exec-options';
 export * from './sanitize-serial-stdout';
 export * from './serial-ansi';
 export * from './serial-error-messages';

--- a/libs/web-serial/src/lib/functions/pi-zero-shell-exec-options.spec.ts
+++ b/libs/web-serial/src/lib/functions/pi-zero-shell-exec-options.spec.ts
@@ -6,12 +6,15 @@ import { SERIAL_TIMEOUT } from './serial-timeout';
 describe('createPiZeroShellExecOptions', () => {
   const detector = new PiZeroPromptDetectorService();
 
-  it('uses promptMatch based on isLikelyLoggedInShellPrompt', () => {
+  it('uses promptMatch based on isCommandCompleted', () => {
     const options = createPiZeroShellExecOptions(detector);
     expect(options.prompt).toBe('');
     expect(options.promptMatch).toBeTypeOf('function');
     expect(options.promptMatch?.('pi@custom-host:~$ ')).toBe(true);
     expect(options.promptMatch?.('login: ')).toBe(false);
+    expect(
+      options.promptMatch?.('pi@raspberrypi:~$ ls -al'),
+    ).toBe(false);
   });
 
   it('merges timeout and other overrides', () => {

--- a/libs/web-serial/src/lib/functions/pi-zero-shell-exec-options.spec.ts
+++ b/libs/web-serial/src/lib/functions/pi-zero-shell-exec-options.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { PiZeroPromptDetectorService } from '../service/pi-zero-prompt-detector.service';
+import { createPiZeroShellExecOptions } from './pi-zero-shell-exec-options';
+import { SERIAL_TIMEOUT } from './serial-timeout';
+
+describe('createPiZeroShellExecOptions', () => {
+  const detector = new PiZeroPromptDetectorService();
+
+  it('uses promptMatch based on isLikelyLoggedInShellPrompt', () => {
+    const options = createPiZeroShellExecOptions(detector);
+    expect(options.prompt).toBe('');
+    expect(options.promptMatch).toBeTypeOf('function');
+    expect(options.promptMatch?.('pi@custom-host:~$ ')).toBe(true);
+    expect(options.promptMatch?.('login: ')).toBe(false);
+  });
+
+  it('merges timeout and other overrides', () => {
+    const options = createPiZeroShellExecOptions(detector, {
+      timeout: SERIAL_TIMEOUT.LONG,
+      retry: 2,
+    });
+    expect(options.timeout).toBe(SERIAL_TIMEOUT.LONG);
+    expect(options.retry).toBe(2);
+  });
+});

--- a/libs/web-serial/src/lib/functions/pi-zero-shell-exec-options.ts
+++ b/libs/web-serial/src/lib/functions/pi-zero-shell-exec-options.ts
@@ -13,7 +13,7 @@ export function createPiZeroShellExecOptions(
 ): SerialExecOptions {
   return mergeSerialExecOptions({
     prompt: '',
-    promptMatch: (buf) => detector.isLikelyLoggedInShellPrompt(buf),
+    promptMatch: (buf) => detector.isCommandCompleted(buf),
     ...overrides,
   });
 }

--- a/libs/web-serial/src/lib/functions/pi-zero-shell-exec-options.ts
+++ b/libs/web-serial/src/lib/functions/pi-zero-shell-exec-options.ts
@@ -1,0 +1,19 @@
+import type { PiZeroPromptDetectorService } from '../service/pi-zero-prompt-detector.service';
+import {
+  mergeSerialExecOptions,
+  type SerialExecOptions,
+} from './serial-exec-options';
+
+/**
+ * Pi Zero シェル到達後の `exec$` 向けオプション（bootstrap と同じ promptMatch 照合）。
+ */
+export function createPiZeroShellExecOptions(
+  detector: PiZeroPromptDetectorService,
+  overrides?: Partial<SerialExecOptions>,
+): SerialExecOptions {
+  return mergeSerialExecOptions({
+    prompt: '',
+    promptMatch: (buf) => detector.isLikelyLoggedInShellPrompt(buf),
+    ...overrides,
+  });
+}

--- a/libs/web-serial/src/lib/service/pi-zero-prompt-detector.service.spec.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-prompt-detector.service.spec.ts
@@ -56,6 +56,17 @@ describe('PiZeroPromptDetectorService', () => {
     expect(detector.isCommandCompleted('running…')).toBe(false);
   });
 
+  it('isCommandCompleted rejects command echo lines', () => {
+    expect(
+      detector.isCommandCompleted('pi@raspberrypi:~$ ls -al --quoting-style=c'),
+    ).toBe(false);
+    expect(
+      detector.isCommandCompleted(
+        '合計 36\ndrwx------ 1 pi pi 4096 "myApp"\npi@raspberrypi:~$ ',
+      ),
+    ).toBe(true);
+  });
+
   it('isAwaitingLoginName uses trailing line only', () => {
     expect(detector.isAwaitingLoginName('boot\nfoo login: ')).toBe(true);
     expect(

--- a/libs/web-serial/src/lib/service/pi-zero-prompt-detector.service.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-prompt-detector.service.ts
@@ -128,20 +128,32 @@ export class PiZeroPromptDetectorService {
   }
 
   /**
-   * シリアル上のコマンド完了は末尾の対話シェルプロンプトで判定する。
+   * シリアル上のコマンド完了は末尾付近の対話シェルプロンプトで判定する。
    * `pi@host:~$ ls ...` のようなコマンドエコー行では一致させない（issue #717）。
    */
   isCommandCompleted(text: string): boolean {
-    const line = this.trailingNonEmptyLine(text);
-    if (!line) {
+    const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    const lines = normalized.split('\n');
+    const windowSize = Math.min(lines.length, 12);
+    for (let j = lines.length - 1; j >= lines.length - windowSize; j--) {
+      const line = (lines[j] ?? '').trim();
+      if (!line.length) {
+        continue;
+      }
+      if (this.lineLooksLikeSerialAuthPrompt(line)) {
+        return false;
+      }
+      if (this.lineLooksLikeShellPromptOnly(line)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private lineLooksLikeShellPromptOnly(line: string): boolean {
+    if (!/^[^\s]+@[^:]+:.*(?:\$|#)/.test(line)) {
       return false;
     }
-    if (this.lineLooksLikeSerialAuthPrompt(line)) {
-      return false;
-    }
-    if (!/^[^\s]+@[^:]+:.*[$#]/.test(line)) {
-      return false;
-    }
-    return !/[$#]\s+\S/.test(line);
+    return !/(?:\$|#)\s+\S/.test(line);
   }
 }

--- a/libs/web-serial/src/lib/service/pi-zero-prompt-detector.service.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-prompt-detector.service.ts
@@ -128,9 +128,20 @@ export class PiZeroPromptDetectorService {
   }
 
   /**
-   * シリアル上のコマンド完了はシェルプロンプトへの復帰で判定する。
+   * シリアル上のコマンド完了は末尾の対話シェルプロンプトで判定する。
+   * `pi@host:~$ ls ...` のようなコマンドエコー行では一致させない（issue #717）。
    */
   isCommandCompleted(text: string): boolean {
-    return this.isLikelyLoggedInShellPrompt(text);
+    const line = this.trailingNonEmptyLine(text);
+    if (!line) {
+      return false;
+    }
+    if (this.lineLooksLikeSerialAuthPrompt(line)) {
+      return false;
+    }
+    if (!/^[^\s]+@[^:]+:.*[$#]/.test(line)) {
+      return false;
+    }
+    return !/[$#]\s+\S/.test(line);
   }
 }

--- a/libs/web-serial/src/lib/service/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-serial-bootstrap.service.ts
@@ -342,7 +342,7 @@ export class PiZeroSerialBootstrapService {
           .exec$(step.command, {
             prompt: '',
             promptMatch: (buf) =>
-              this.promptDetector.isLikelyLoggedInShellPrompt(buf),
+              this.promptDetector.isCommandCompleted(buf),
             timeout: SERIAL_TIMEOUT.SHORT,
           })
           .pipe(

--- a/libs/web-serial/src/lib/service/pi-zero-session.service.spec.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-session.service.spec.ts
@@ -19,6 +19,7 @@ function createShellReadinessMock(): PiZeroShellReadinessService {
     setReady: vi.fn(),
     reset: vi.fn(),
     isReady: vi.fn(() => false),
+    startWatching: vi.fn(),
     ready$: vi.fn() as unknown as PiZeroShellReadinessService['ready$'],
   } as unknown as PiZeroShellReadinessService;
 }
@@ -53,26 +54,26 @@ function serialWithConnectionEstablished(
 }
 
 describe('PiZeroSessionService', () => {
-  it('auto-starts bootstrap when connectionEstablished$ emits', async () => {
-    const connectionEstablished = new Subject<void>();
-    const readUntilPrompt = vi.fn().mockResolvedValue({
-      stdout: `${PI_ZERO_PROMPT} `,
-    });
+  it('skips login bootstrap when shell is already ready from serial watch', async () => {
+    const readUntilPrompt = vi.fn();
     const exec = vi.fn().mockResolvedValue({ stdout: '' });
-    const serial = serialWithConnectionEstablished({
-      connectionEstablished$: connectionEstablished.asObservable(),
+    const serial = {
+      isConnected$: of(true),
+      connectionEstablished$: NEVER,
       readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
       exec$: (c: string, o: unknown) => from(exec(c, o)),
-    });
+    } as unknown as SerialFacadeService;
 
     const shellReadiness = createShellReadinessMock();
-    createSession(serial, shellReadiness, stubConnection(() => 1));
+    vi.mocked(shellReadiness.isReady).mockReturnValue(true);
+    const service = createSession(serial, shellReadiness, stubConnection(() => 1));
+    await firstValueFrom(service.runAfterConnect$());
 
-    connectionEstablished.next();
+    expect(readUntilPrompt).not.toHaveBeenCalled();
+    expect(vi.mocked(shellReadiness.setReady)).not.toHaveBeenCalled();
     await vi.waitFor(() => {
-      expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
+      expect(exec).toHaveBeenCalled();
     });
-    expect(readUntilPrompt).toHaveBeenCalledTimes(1);
   });
 
   it('runs bootstrap when isConnected$ is still false but epoch advanced', async () => {
@@ -121,7 +122,9 @@ describe('PiZeroSessionService', () => {
     await firstValueFrom(service.runAfterConnect$());
 
     expect(events[0]).toBe('ready');
-    expect(events[1]).toMatch(/^exec:/);
+    await vi.waitFor(() => {
+      expect(events.some((event) => event.startsWith('exec:'))).toBe(true);
+    });
   });
 
   it('runs at most one post-connect pipeline per connection epoch', async () => {
@@ -225,10 +228,12 @@ describe('PiZeroSessionService', () => {
     const seen: boolean[] = [];
     const sub = service.initializing$.subscribe((v) => seen.push(v));
     await firstValueFrom(service.runAfterConnect$());
+    await vi.waitFor(() => {
+      expect(seen.at(-1)).toBe(false);
+    });
     sub.unsubscribe();
 
     expect(seen).toContain(true);
-    expect(seen.at(-1)).toBe(false);
   });
 
   it('emits setupStatus$ transitions and ends in ready on success', async () => {
@@ -248,11 +253,13 @@ describe('PiZeroSessionService', () => {
     const seen: string[] = [];
     const sub = service.setupStatus$.subscribe((v) => seen.push(v));
     await firstValueFrom(service.runAfterConnect$());
+    await vi.waitFor(() => {
+      expect(seen.at(-1)).toBe('ready');
+    });
     sub.unsubscribe();
 
     expect(seen).toContain('waiting-login');
     expect(seen).toContain('setting-timezone');
-    expect(seen.at(-1)).toBe('ready');
   });
 
   describe('login flow (loginIfNeeded$)', () => {
@@ -431,7 +438,7 @@ describe('PiZeroSessionService', () => {
       );
     });
 
-    it('propagates environment setup failures to caller', async () => {
+    it('keeps shell ready when background environment setup fails', async () => {
       const readUntilPrompt = vi.fn().mockImplementation(() =>
         of({
           stdout: `${PI_ZERO_PROMPT} `,
@@ -451,11 +458,15 @@ describe('PiZeroSessionService', () => {
 
       const shellReadiness = createShellReadinessMock();
       const service = createSession(serial, shellReadiness);
+      const seen: string[] = [];
+      const sub = service.setupStatus$.subscribe((v) => seen.push(v));
 
-      await expect(firstValueFrom(service.runAfterConnect$())).rejects.toThrow(
-        'Environment setup failed',
-      );
+      await firstValueFrom(service.runAfterConnect$());
       expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
+      await vi.waitFor(() => {
+        expect(seen.at(-1)).toBe('failed');
+      });
+      sub.unsubscribe();
     });
   });
 });

--- a/libs/web-serial/src/lib/service/pi-zero-session.service.spec.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-session.service.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { firstValueFrom, from, of, throwError } from 'rxjs';
+import { firstValueFrom, from, NEVER, of, Subject, throwError } from 'rxjs';
 import { PI_ZERO_LOGIN_USER, PI_ZERO_PROMPT } from '../constants';
 import { PiZeroPromptDetectorService } from './pi-zero-prompt-detector.service';
 import { PiZeroSerialBootstrapService } from './pi-zero-serial-bootstrap.service';
@@ -35,7 +35,46 @@ function createSession(
   return new PiZeroSessionService(serial, bootstrap, shellReadiness, connection);
 }
 
+function serialWithConnectionEstablished(
+  overrides: Partial<SerialFacadeService> & {
+    connectionEstablished$?: Subject<void>['asObservable'] extends () => infer T
+      ? T
+      : never;
+  } = {},
+): SerialFacadeService {
+  return {
+    isConnected$: of(true),
+    connectionEstablished$: NEVER,
+    readUntilPrompt$: () => from(Promise.resolve({ stdout: `${PI_ZERO_PROMPT} ` })),
+    exec$: () => from(Promise.resolve({ stdout: '' })),
+    send$: () => of(undefined),
+    ...overrides,
+  } as unknown as SerialFacadeService;
+}
+
 describe('PiZeroSessionService', () => {
+  it('auto-starts bootstrap when connectionEstablished$ emits', async () => {
+    const connectionEstablished = new Subject<void>();
+    const readUntilPrompt = vi.fn().mockResolvedValue({
+      stdout: `${PI_ZERO_PROMPT} `,
+    });
+    const exec = vi.fn().mockResolvedValue({ stdout: '' });
+    const serial = serialWithConnectionEstablished({
+      connectionEstablished$: connectionEstablished.asObservable(),
+      readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
+      exec$: (c: string, o: unknown) => from(exec(c, o)),
+    });
+
+    const shellReadiness = createShellReadinessMock();
+    createSession(serial, shellReadiness, stubConnection(() => 1));
+
+    connectionEstablished.next();
+    await vi.waitFor(() => {
+      expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
+    });
+    expect(readUntilPrompt).toHaveBeenCalledTimes(1);
+  });
+
   it('runs at most one post-connect pipeline per connection epoch', async () => {
     const readUntilPrompt = vi.fn().mockResolvedValue({
       stdout: `${PI_ZERO_PROMPT} `,
@@ -43,6 +82,7 @@ describe('PiZeroSessionService', () => {
     const exec = vi.fn().mockResolvedValue({ stdout: '' });
     const serial = {
       isConnected$: of(true),
+      connectionEstablished$: NEVER,
       readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
       exec$: (c: string, o: unknown) => from(exec(c, o)),
     } as unknown as SerialFacadeService;
@@ -65,6 +105,7 @@ describe('PiZeroSessionService', () => {
     const exec = vi.fn().mockResolvedValue({ stdout: '' });
     const serial = {
       isConnected$: of(true),
+      connectionEstablished$: NEVER,
       readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
       exec$: (c: string, o: unknown) => from(exec(c, o)),
     } as unknown as SerialFacadeService;
@@ -97,6 +138,7 @@ describe('PiZeroSessionService', () => {
     const exec = vi.fn().mockResolvedValue({ stdout: '' });
     const serial = {
       isConnected$: of(true),
+      connectionEstablished$: NEVER,
       readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
       exec$: (c: string, o: unknown) => from(exec(c, o)),
     } as unknown as SerialFacadeService;
@@ -124,6 +166,7 @@ describe('PiZeroSessionService', () => {
     const exec = vi.fn().mockResolvedValue({ stdout: '' });
     const serial = {
       isConnected$: of(true),
+      connectionEstablished$: NEVER,
       readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
       exec$: (c: string, o: unknown) => from(exec(c, o)),
     } as unknown as SerialFacadeService;
@@ -146,6 +189,7 @@ describe('PiZeroSessionService', () => {
     const exec = vi.fn().mockResolvedValue({ stdout: '' });
     const serial = {
       isConnected$: of(true),
+      connectionEstablished$: NEVER,
       readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
       exec$: (c: string, o: unknown) => from(exec(c, o)),
     } as unknown as SerialFacadeService;
@@ -169,6 +213,7 @@ describe('PiZeroSessionService', () => {
       );
       const exec = vi.fn();
       const serial = {
+        connectionEstablished$: NEVER,
         readUntilPrompt$: (o: unknown) => readUntilPrompt(o),
         exec$: (c: string, o: unknown) => from(exec(c, o)),
       } as unknown as SerialFacadeService;
@@ -200,6 +245,7 @@ describe('PiZeroSessionService', () => {
       const send$ = vi.fn().mockReturnValue(of(undefined));
 
       const serial = {
+        connectionEstablished$: NEVER,
         readUntilPrompt$: (o: unknown) => readUntilPrompt(o),
         exec$: (c: string, o: unknown) => exec(c, o),
         send$,
@@ -218,6 +264,7 @@ describe('PiZeroSessionService', () => {
     it('runs each environment init command over serial exec$', async () => {
       const exec = vi.fn().mockReturnValue(of({ stdout: `${PI_ZERO_PROMPT} ` }));
       const serial = {
+        connectionEstablished$: NEVER,
         exec$: (c: string, o: unknown) => exec(c, o),
       } as unknown as SerialFacadeService;
 
@@ -251,6 +298,7 @@ describe('PiZeroSessionService', () => {
       const exec = vi.fn();
       const serial = {
         isConnected$: of(true),
+        connectionEstablished$: NEVER,
         readUntilPrompt$: (o: unknown) => readUntilPrompt(o),
         exec$: (c: string, o: unknown) => from(exec(c, o)),
         send$: () => of(undefined),
@@ -285,6 +333,7 @@ describe('PiZeroSessionService', () => {
         );
       const serial = {
         isConnected$: of(true),
+        connectionEstablished$: NEVER,
         readUntilPrompt$: (o: unknown) => readUntilPrompt(o),
         exec$: () => from(Promise.resolve({ stdout: '' })),
         send$: () => of(undefined),
@@ -317,6 +366,7 @@ describe('PiZeroSessionService', () => {
       const onStatus = vi.fn();
       const serial = {
         isConnected$: of(true),
+        connectionEstablished$: NEVER,
         readUntilPrompt$: (o: unknown) => readUntilPrompt(o),
         exec$: () => from(Promise.resolve({ stdout: '' })),
         send$: () => of(undefined),
@@ -345,6 +395,7 @@ describe('PiZeroSessionService', () => {
         );
       const serial = {
         isConnected$: of(true),
+        connectionEstablished$: NEVER,
         readUntilPrompt$: (o: unknown) => readUntilPrompt(o),
         exec$: (c: string, o: unknown) => exec(c, o),
       } as unknown as SerialFacadeService;

--- a/libs/web-serial/src/lib/service/pi-zero-session.service.spec.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-session.service.spec.ts
@@ -75,6 +75,55 @@ describe('PiZeroSessionService', () => {
     expect(readUntilPrompt).toHaveBeenCalledTimes(1);
   });
 
+  it('runs bootstrap when isConnected$ is still false but epoch advanced', async () => {
+    const readUntilPrompt = vi.fn().mockResolvedValue({
+      stdout: `${PI_ZERO_PROMPT} `,
+    });
+    const exec = vi.fn().mockResolvedValue({ stdout: '' });
+    const serial = {
+      isConnected$: of(false),
+      connectionEstablished$: NEVER,
+      readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
+      exec$: (c: string, o: unknown) => from(exec(c, o)),
+    } as unknown as SerialFacadeService;
+
+    const shellReadiness = createShellReadinessMock();
+    const service = createSession(serial, shellReadiness, stubConnection(() => 1));
+    await firstValueFrom(service.runAfterConnect$());
+
+    expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
+    expect(readUntilPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks shell ready after login before environment setup exec', async () => {
+    const readUntilPrompt = vi.fn().mockResolvedValue({
+      stdout: `${PI_ZERO_PROMPT} `,
+    });
+    const events: string[] = [];
+    const exec = vi.fn().mockImplementation(async (cmd: string) => {
+      events.push(`exec:${cmd.slice(0, 12)}`);
+      return { stdout: '' };
+    });
+    const serial = {
+      isConnected$: of(true),
+      connectionEstablished$: NEVER,
+      readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
+      exec$: (c: string, o: unknown) => from(exec(c, o)),
+    } as unknown as SerialFacadeService;
+
+    const shellReadiness = createShellReadinessMock();
+    vi.mocked(shellReadiness.setReady).mockImplementation((value: boolean) => {
+      if (value) {
+        events.push('ready');
+      }
+    });
+    const service = createSession(serial, shellReadiness, stubConnection(() => 1));
+    await firstValueFrom(service.runAfterConnect$());
+
+    expect(events[0]).toBe('ready');
+    expect(events[1]).toMatch(/^exec:/);
+  });
+
   it('runs at most one post-connect pipeline per connection epoch', async () => {
     const readUntilPrompt = vi.fn().mockResolvedValue({
       stdout: `${PI_ZERO_PROMPT} `,
@@ -406,7 +455,7 @@ describe('PiZeroSessionService', () => {
       await expect(firstValueFrom(service.runAfterConnect$())).rejects.toThrow(
         'Environment setup failed',
       );
-      expect(vi.mocked(shellReadiness.setReady)).not.toHaveBeenCalledWith(true);
+      expect(vi.mocked(shellReadiness.setReady)).toHaveBeenCalledWith(true);
     });
   });
 });

--- a/libs/web-serial/src/lib/service/pi-zero-session.service.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-session.service.ts
@@ -5,6 +5,7 @@ import {
   catchError,
   defer,
   distinctUntilChanged,
+  EMPTY,
   finalize,
   map,
   type Observable,
@@ -64,6 +65,21 @@ export class PiZeroSessionService {
         status !== 'idle' && status !== 'ready' && status !== 'failed';
       this.initializingSubject.next(isInitializing);
     });
+
+    this.serial.connectionEstablished$
+      .pipe(
+        switchMap(() => this.runAfterConnect$()),
+        catchError((error: unknown) => {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          console.error(
+            '[PiZeroSession] post-connect bootstrap failed:',
+            message,
+          );
+          return EMPTY;
+        }),
+      )
+      .subscribe();
   }
 
   connect$(baudRate = 115200): Observable<SerialFacadeConnectResult> {

--- a/libs/web-serial/src/lib/service/pi-zero-session.service.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-session.service.ts
@@ -104,21 +104,29 @@ export class PiZeroSessionService {
 
   /**
    * 接続セッションごとに 1 回、初期化パイプラインを走らせるか。
+   * `connectionEstablished$` 直後は `isConnected$` の反映が遅れることがあるため、
+   * 接続 epoch のみで判定する（issue #717）。
    */
   shouldRunAfterConnect$(): Observable<boolean> {
-    return this.serial.isConnected$.pipe(
-      take(1),
-      map((connected) => {
-        if (!connected) {
-          return false;
-        }
-        const epoch = this.connection.getConnectionEpoch();
-        if (epoch === this.bootstrappedEpoch) {
-          return false;
-        }
-        return true;
-      }),
-    );
+    return of(this.shouldRunAfterConnect());
+  }
+
+  private shouldRunAfterConnect(): boolean {
+    const epoch = this.connection.getConnectionEpoch();
+    if (epoch <= 0) {
+      return false;
+    }
+    return epoch !== this.bootstrappedEpoch;
+  }
+
+  private markShellReadyIfActive(epoch: number): void {
+    const currentEpoch = this.connection.getConnectionEpoch();
+    if (
+      this.activeBootstrapEpoch === epoch &&
+      currentEpoch === epoch
+    ) {
+      this.shellReadiness.setReady(true);
+    }
   }
 
   /**
@@ -158,7 +166,10 @@ export class PiZeroSessionService {
           return of(undefined);
         }).pipe(
           switchMap(() => this.bootstrap.loginIfNeeded$(onBootstrapStatus)),
-          tap(() => this.setupStatusSubject.next('waiting-shell')),
+          tap(() => {
+            this.markShellReadyIfActive(epoch);
+            this.setupStatusSubject.next('waiting-shell');
+          }),
           tap(() => this.setupStatusSubject.next('setting-timezone')),
           switchMap(() => this.bootstrap.setupEnvironment$(onBootstrapStatus)),
           switchMap(() =>
@@ -172,7 +183,6 @@ export class PiZeroSessionService {
                   this.activeBootstrapEpoch === epoch
                 ) {
                   this.bootstrappedEpoch = epoch;
-                  this.shellReadiness.setReady(true);
                   this.setupStatusSubject.next('ready');
                 } else if (connected && currentEpoch !== epoch) {
                   // 再接続などで接続 epoch が進んだあとに遅延完了したパイプラインは成功扱いにしない

--- a/libs/web-serial/src/lib/service/pi-zero-session.service.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-session.service.ts
@@ -12,7 +12,6 @@ import {
   of,
   shareReplay,
   switchMap,
-  take,
   tap,
   throwError,
 } from 'rxjs';
@@ -65,21 +64,6 @@ export class PiZeroSessionService {
         status !== 'idle' && status !== 'ready' && status !== 'failed';
       this.initializingSubject.next(isInitializing);
     });
-
-    this.serial.connectionEstablished$
-      .pipe(
-        switchMap(() => this.runAfterConnect$()),
-        catchError((error: unknown) => {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          console.error(
-            '[PiZeroSession] post-connect bootstrap failed:',
-            message,
-          );
-          return EMPTY;
-        }),
-      )
-      .subscribe();
   }
 
   connect$(baudRate = 115200): Observable<SerialFacadeConnectResult> {
@@ -129,6 +113,41 @@ export class PiZeroSessionService {
     }
   }
 
+  private runEnvironmentSetupInBackground(
+    epoch: number,
+    onBootstrapStatus: PiZeroBootstrapStatusHandler,
+    log: PiZeroBootstrapStatusHandler,
+  ): void {
+    // ファイルツリーの初回 ls を直列キューで先に通すため、環境設定はマクロタスクへ遅延する（issue #717）。
+    setTimeout(() => {
+      this.bootstrap
+        .setupEnvironment$(onBootstrapStatus)
+        .pipe(
+          tap(() => {
+            if (this.connection.getConnectionEpoch() === epoch) {
+              this.setupStatusSubject.next('ready');
+            }
+          }),
+          catchError((error: unknown) => {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            if (this.connection.getConnectionEpoch() === epoch) {
+              this.setupStatusSubject.next('failed');
+            }
+            log(`[コンソール] 環境設定に失敗しました: ${message}`);
+            return EMPTY;
+          }),
+          finalize(() => {
+            if (this.activeBootstrapEpoch === epoch) {
+              this.activeBootstrap$ = null;
+              this.activeBootstrapEpoch = null;
+            }
+          }),
+        )
+        .subscribe();
+    });
+  }
+
   /**
    * 接続セッション内で未初期化の場合のみ login + 環境セットアップを実行する。
    */
@@ -165,45 +184,26 @@ export class PiZeroSessionService {
           this.setupStatusSubject.next('waiting-login');
           return of(undefined);
         }).pipe(
-          switchMap(() => this.bootstrap.loginIfNeeded$(onBootstrapStatus)),
-          tap(() => {
-            this.markShellReadyIfActive(epoch);
-            this.setupStatusSubject.next('waiting-shell');
-          }),
-          tap(() => this.setupStatusSubject.next('setting-timezone')),
-          switchMap(() => this.bootstrap.setupEnvironment$(onBootstrapStatus)),
           switchMap(() =>
-            this.serial.isConnected$.pipe(
-              take(1),
-              tap((connected) => {
-                const currentEpoch = this.connection.getConnectionEpoch();
-                if (
-                  connected &&
-                  currentEpoch === epoch &&
-                  this.activeBootstrapEpoch === epoch
-                ) {
-                  this.bootstrappedEpoch = epoch;
-                  this.setupStatusSubject.next('ready');
-                } else if (connected && currentEpoch !== epoch) {
-                  // 再接続などで接続 epoch が進んだあとに遅延完了したパイプラインは成功扱いにしない
-                  this.setupStatusSubject.next('idle');
-                }
-              }),
-              map(() => undefined),
-            ),
+            this.shellReadiness.isReady()
+              ? of(undefined)
+              : this.bootstrap.loginIfNeeded$(onBootstrapStatus),
           ),
+          tap(() => {
+            if (!this.shellReadiness.isReady()) {
+              this.markShellReadyIfActive(epoch);
+            }
+            this.bootstrappedEpoch = epoch;
+            this.setupStatusSubject.next('setting-timezone');
+            this.runEnvironmentSetupInBackground(epoch, onBootstrapStatus, log);
+          }),
+          map(() => undefined),
           catchError((error: unknown) => {
             const message =
               error instanceof Error ? error.message : String(error);
             this.setupStatusSubject.next('failed');
             log(`[コンソール] 接続後の初期化に失敗しました: ${message}`);
             return throwError(() => error);
-          }),
-          finalize(() => {
-            if (this.activeBootstrapEpoch === epoch) {
-              this.activeBootstrap$ = null;
-              this.activeBootstrapEpoch = null;
-            }
           }),
           shareReplay({ bufferSize: 1, refCount: true }),
         );

--- a/libs/web-serial/src/lib/service/pi-zero-shell-readiness.service.spec.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-shell-readiness.service.spec.ts
@@ -1,0 +1,65 @@
+import { Injector } from '@angular/core';
+import { describe, expect, it } from 'vitest';
+import { Subject } from 'rxjs';
+import { PiZeroPromptDetectorService } from './pi-zero-prompt-detector.service';
+import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
+import { SerialCommandPipelineService } from './serial-command/serial-command-pipeline.service';
+import { SerialTransportService } from './serial-transport.service';
+
+describe('PiZeroShellReadinessService', () => {
+  function createService(
+    receive$: Subject<string>,
+    readBuffer = '',
+  ): PiZeroShellReadinessService {
+    const transport = {
+      receive$: receive$.asObservable(),
+    } as SerialTransportService;
+    const command = {
+      inspectReadBuffer: () => readBuffer,
+    } as SerialCommandPipelineService;
+
+    const injector = Injector.create({
+      providers: [
+        PiZeroShellReadinessService,
+        PiZeroPromptDetectorService,
+        { provide: SerialTransportService, useValue: transport },
+        { provide: SerialCommandPipelineService, useValue: command },
+      ],
+    });
+    return injector.get(PiZeroShellReadinessService);
+  }
+
+  it('detects shell prompt from existing read buffer on startWatching', () => {
+    const receive$ = new Subject<string>();
+    const service = createService(receive$, 'boot\npi@raspberrypi:~$ ');
+
+    service.startWatching();
+
+    expect(service.isReady()).toBe(true);
+  });
+
+  it('detects shell prompt from subsequent receive chunks', () => {
+    const receive$ = new Subject<string>();
+    const service = createService(receive$);
+
+    service.startWatching();
+    expect(service.isReady()).toBe(false);
+
+    receive$.next('pi@custom-host:~$ ');
+    expect(service.isReady()).toBe(true);
+  });
+
+  it('reset clears ready and stops watching', () => {
+    const receive$ = new Subject<string>();
+    const service = createService(receive$, 'pi@raspberrypi:~$ ');
+
+    service.startWatching();
+    expect(service.isReady()).toBe(true);
+
+    service.reset();
+    expect(service.isReady()).toBe(false);
+
+    receive$.next('pi@raspberrypi:~$ ');
+    expect(service.isReady()).toBe(false);
+  });
+});

--- a/libs/web-serial/src/lib/service/pi-zero-shell-readiness.service.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-shell-readiness.service.ts
@@ -3,8 +3,9 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject, type Observable } from 'rxjs';
 
 /**
- * Pi Zero シリアル接続後のブートストラップ（ログイン・タイムゾーン等）完了を共有する。
- * ファイルツリーなど、シェルプロンプト到達後にのみシリアル exec すべき箇所が購読する。
+ * Pi Zero シリアル接続後のシェル到達（ログイン完了）を共有する。
+ * ファイルツリーなど、シェルプロンプト到達後にシリアル exec すべき箇所が購読する。
+ * 環境初期化コマンドはバックグラウンドで継続し得る（issue #717）。
  */
 @Injectable({
   providedIn: 'root',

--- a/libs/web-serial/src/lib/service/pi-zero-shell-readiness.service.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-shell-readiness.service.ts
@@ -1,29 +1,93 @@
 /** Full rewrite (#606). Shell readiness flag for post-bootstrap consumers. */
-import { Injectable } from '@angular/core';
-import { BehaviorSubject, type Observable } from 'rxjs';
+import { Injectable, inject } from '@angular/core';
+import { BehaviorSubject, type Observable, Subscription } from 'rxjs';
+import { stripSerialAnsiForPrompt } from '../functions';
+import { PiZeroPromptDetectorService } from './pi-zero-prompt-detector.service';
+import { SerialCommandPipelineService } from './serial-command/serial-command-pipeline.service';
+import { SerialTransportService } from './serial-transport.service';
 
 /**
- * Pi Zero シリアル接続後のシェル到達（ログイン完了）を共有する。
- * ファイルツリーなど、シェルプロンプト到達後にシリアル exec すべき箇所が購読する。
- * 環境初期化コマンドはバックグラウンドで継続し得る（issue #717）。
+ * Pi Zero シリアル接続後のシェル到達（対話シェルプロンプト）を共有する。
+ *
+ * bootstrap のコマンドキュー完了を待たず、`receive$` の受信バッファから
+ * シェルプロンプトを検出して `ready` を立てる（issue #717）。
+ * ファイルツリーなど exec 向け Feature は本サービスを購読する。
  */
 @Injectable({
   providedIn: 'root',
 })
 export class PiZeroShellReadinessService {
+  private static readonly PROMPT_BUFFER_CAP = 96_000;
+
+  private readonly transport = inject(SerialTransportService);
+  private readonly command = inject(SerialCommandPipelineService);
+  private readonly detector = inject(PiZeroPromptDetectorService);
+
   private readonly readySubject = new BehaviorSubject(false);
+  private watchSubscription: Subscription | null = null;
+  private promptBuffer = '';
 
   readonly ready$: Observable<boolean> = this.readySubject.asObservable();
 
   setReady(value: boolean): void {
     this.readySubject.next(value);
+    if (value) {
+      this.stopWatching();
+    }
   }
 
   reset(): void {
+    this.stopWatching();
+    this.promptBuffer = '';
     this.readySubject.next(false);
   }
 
   isReady(): boolean {
     return this.readySubject.value;
+  }
+
+  /**
+   * read loop 開始後に呼び出し、受信チャンクからシェルプロンプト到達を検出する。
+   */
+  startWatching(): void {
+    this.stopWatching();
+    this.promptBuffer = '';
+    this.evaluatePromptBuffer(this.command.inspectReadBuffer());
+    if (this.isReady()) {
+      return;
+    }
+    this.watchSubscription = this.transport.receive$.subscribe({
+      next: (chunk) => {
+        this.appendPromptChunk(chunk ?? '');
+        this.evaluatePromptBuffer(this.promptBuffer);
+      },
+      error: (error: unknown) => {
+        console.error('PiZeroShellReadiness receive error:', error);
+      },
+    });
+  }
+
+  private stopWatching(): void {
+    this.watchSubscription?.unsubscribe();
+    this.watchSubscription = null;
+  }
+
+  private appendPromptChunk(chunk: string): void {
+    const piece = stripSerialAnsiForPrompt(chunk);
+    this.promptBuffer += piece;
+    if (this.promptBuffer.length > PiZeroShellReadinessService.PROMPT_BUFFER_CAP) {
+      this.promptBuffer = this.promptBuffer.slice(
+        -PiZeroShellReadinessService.PROMPT_BUFFER_CAP,
+      );
+    }
+  }
+
+  private evaluatePromptBuffer(buffer: string): void {
+    if (this.isReady() || !buffer.length) {
+      return;
+    }
+    if (this.detector.isLikelyLoggedInShellPrompt(buffer)) {
+      this.setReady(true);
+    }
   }
 }

--- a/libs/web-serial/src/lib/service/serial-command/serial-command-pipeline.service.spec.ts
+++ b/libs/web-serial/src/lib/service/serial-command/serial-command-pipeline.service.spec.ts
@@ -12,6 +12,7 @@ import {
   timer,
 } from 'rxjs';
 import { PI_ZERO_PROMPT } from '../../constants';
+import { createPiZeroShellExecOptions } from '../../functions';
 import { PiZeroPromptDetectorService } from '../pi-zero-prompt-detector.service';
 import type { SerialTransportService } from '../serial-transport.service';
 import { SerialCommandPipelineService } from './serial-command-pipeline.service';
@@ -474,6 +475,38 @@ describe('SerialCommandPipelineService', () => {
     const result = await execPromise;
     expect(result.stdout).toContain('yyy zzz');
     expect(result.stdout).toContain(PI_ZERO_PROMPT);
+  });
+
+  it('exec with isCommandCompleted waits for ls output before completing', async () => {
+    const { service, linesSubject, transport } = createService();
+    const detector = new PiZeroPromptDetectorService();
+    const options = createPiZeroShellExecOptions(detector, {
+      timeout: 2000,
+      retry: 0,
+    });
+    let releaseWrite: (() => void) | undefined;
+    transport.send$ = vi.fn(
+      () =>
+        new Observable<void>((subscriber) => {
+          releaseWrite = () => {
+            subscriber.next();
+            subscriber.complete();
+          };
+        }),
+    );
+    const execPromise = firstValueFrom(
+      service.exec$('ls -al --quoting-style=c -- $\'.\'', options),
+    );
+    releaseWrite?.();
+    emitIncomingChunks(linesSubject, [
+      'pi@raspberrypi:~$ ls -al --quoting-style=c -- $\'.\'',
+      'total 36',
+      'drwxr-xr-x 3 pi   pi   4096 Jun  4 13:19 "myApp"',
+      'pi@raspberrypi:~$ ',
+    ]);
+    const result = await execPromise;
+    expect(result.stdout).toContain('myApp');
+    expect(result.stdout).toContain('pi@raspberrypi:~$');
   });
 });
 

--- a/libs/web-serial/src/lib/service/serial-command/serial-command-pipeline.service.ts
+++ b/libs/web-serial/src/lib/service/serial-command/serial-command-pipeline.service.ts
@@ -121,6 +121,13 @@ export class SerialCommandPipelineService {
   }
 
   /**
+   * プロンプト監視用の受信バッファスナップショット（{@link PiZeroShellReadinessService} 向け）。
+   */
+  inspectReadBuffer(): string {
+    return this.readBuffer;
+  }
+
+  /**
    * キュー経由で exec パイプラインを実行する実装入口。
    *
    * 呼び出し側の方針・ターミナル UI での禁止事項は {@link import('../serial-facade.service').SerialFacadeService#exec$} の JSDoc を参照（#616）。

--- a/libs/web-serial/src/lib/service/serial-connection-orchestration.service.spec.ts
+++ b/libs/web-serial/src/lib/service/serial-connection-orchestration.service.spec.ts
@@ -2,6 +2,8 @@ import '@angular/compiler';
 import { Injector } from '@angular/core';
 import { BehaviorSubject, firstValueFrom, of, take } from 'rxjs';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PiZeroSessionService } from './pi-zero-session.service';
+import { PiZeroPromptDetectorService } from './pi-zero-prompt-detector.service';
 import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
 import { SerialCommandPipelineService } from './serial-command/serial-command-pipeline.service';
 import { SerialConnectionOrchestrationService } from './serial-connection-orchestration.service';
@@ -15,6 +17,7 @@ describe('SerialConnectionOrchestrationService', () => {
   let disconnectMock: Mock;
   let command: Partial<SerialCommandPipelineService>;
   let shellReadiness: PiZeroShellReadinessService;
+  let runAfterConnect$: Mock;
 
   beforeEach(() => {
     isConnectedSubj = new BehaviorSubject(false);
@@ -30,7 +33,21 @@ describe('SerialConnectionOrchestrationService', () => {
       connect$: connectMock,
       disconnect$: disconnectMock,
     };
-    shellReadiness = new PiZeroShellReadinessService();
+    shellReadiness = Injector.create({
+      providers: [
+        PiZeroShellReadinessService,
+        PiZeroPromptDetectorService,
+        {
+          provide: SerialTransportService,
+          useValue: { receive$: new BehaviorSubject('').asObservable() },
+        },
+        {
+          provide: SerialCommandPipelineService,
+          useValue: { inspectReadBuffer: () => '' },
+        },
+      ],
+    }).get(PiZeroShellReadinessService);
+    runAfterConnect$ = vi.fn(() => of(undefined));
 
     const injector = Injector.create({
       providers: [
@@ -38,6 +55,10 @@ describe('SerialConnectionOrchestrationService', () => {
         { provide: SerialTransportService, useValue: transport },
         { provide: SerialCommandPipelineService, useValue: command },
         { provide: PiZeroShellReadinessService, useValue: shellReadiness },
+        {
+          provide: PiZeroSessionService,
+          useValue: { runAfterConnect$ },
+        },
       ],
     });
     service = injector.get(SerialConnectionOrchestrationService);
@@ -48,6 +69,7 @@ describe('SerialConnectionOrchestrationService', () => {
   });
 
   it('on successful connect increments epoch, starts read loop, resets shell readiness, emits connectionEstablished$', async () => {
+    const startWatching = vi.spyOn(shellReadiness, 'startWatching');
     const establishedOnce = firstValueFrom(
       service.connectionEstablished$.pipe(take(1)),
     );
@@ -60,7 +82,15 @@ describe('SerialConnectionOrchestrationService', () => {
     expect(service.getConnectionEpoch()).toBe(1);
     expect(command.startReadLoop).toHaveBeenCalledTimes(1);
     expect(shellReadiness.isReady()).toBe(false);
+    expect(startWatching).toHaveBeenCalledTimes(1);
     expect(connectMock).toHaveBeenCalledWith(115200);
+  });
+
+  it('schedules post-connect bootstrap after successful connect', async () => {
+    await firstValueFrom(service.connect$(115200));
+    await vi.waitFor(() => {
+      expect(runAfterConnect$).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('when already connected, orchestration disconnect runs before transport connect', async () => {

--- a/libs/web-serial/src/lib/service/serial-connection-orchestration.service.ts
+++ b/libs/web-serial/src/lib/service/serial-connection-orchestration.service.ts
@@ -1,10 +1,11 @@
 /// <reference types="@types/w3c-web-serial" />
 
 /** Full rewrite (#606). Connect lifecycle around {@link SerialTransportService}. */
-import { Injectable, inject } from '@angular/core';
+import { Injectable, inject, Injector } from '@angular/core';
 import {
   catchError,
   defer,
+  EMPTY,
   of,
   type Observable,
   Subject,
@@ -13,6 +14,7 @@ import {
   throwError,
 } from 'rxjs';
 import { getConnectionErrorMessage } from '../functions';
+import { PiZeroSessionService } from './pi-zero-session.service';
 import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
 import { SerialCommandPipelineService } from './serial-command/serial-command-pipeline.service';
 import { SerialTransportService } from './serial-transport.service';
@@ -33,6 +35,7 @@ export class SerialConnectionOrchestrationService {
   private readonly transport = inject(SerialTransportService);
   private readonly command = inject(SerialCommandPipelineService);
   private readonly shellReadiness = inject(PiZeroShellReadinessService);
+  private readonly injector = inject(Injector);
 
   /**
    * 成功したシリアル接続ごとに単調増加するセッション識別子。
@@ -62,7 +65,9 @@ export class SerialConnectionOrchestrationService {
           this.command.startReadLoop();
           this.connectionEpoch += 1;
           this.shellReadiness.reset();
+          this.shellReadiness.startWatching();
           this.connectionEstablished.next();
+          this.schedulePostConnectBootstrap();
           return of<SerialConnectResult>({ ok: true });
         }),
         catchError((error: unknown) => {
@@ -94,5 +99,29 @@ export class SerialConnectionOrchestrationService {
    */
   getConnectionEpoch(): number {
     return this.connectionEpoch;
+  }
+
+  /**
+   * 接続確立直後に Pi Zero bootstrap を起動する（issue #717）。
+   * `Injector` 経由で遅延解決し、オーケストレーションとの循環 DI を避ける。
+   */
+  private schedulePostConnectBootstrap(): void {
+    queueMicrotask(() => {
+      this.injector
+        .get(PiZeroSessionService)
+        .runAfterConnect$()
+        .pipe(
+          catchError((error: unknown) => {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            console.error(
+              '[SerialConnection] post-connect bootstrap failed:',
+              message,
+            );
+            return EMPTY;
+          }),
+        )
+        .subscribe();
+    });
   }
 }


### PR DESCRIPTION
## Summary

- Pi Zero 接続・オートログイン後に左ナビのファイルツリーが表示されない問題を修正した
- シェル到達を `receive$` ストリームから検出し、bootstrap 完了を待たずにファイルツリーを起動できるようにした
- `exec$` のプロンプト照合を厳密化し、コマンドエコー行での誤完了を防いだ

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #717

## What changed?

- `SerialConnectionOrchestrationService` が接続直後に `startWatching()` と bootstrap 自動起動を行う
- `PiZeroShellReadinessService` が `receive$` からシェルプロンプトを検出して `ready` を立てる
- `PiZeroSessionService` がログイン済みシェルをスキップし、環境設定を遅延して `ls` を先に実行
- `isCommandCompleted` が末尾行のみでプロンプト完了を判定（エコー行 `pi@host:~$ ls ...` を除外）
- `createPiZeroShellExecOptions` ヘルパーを追加し、`FileService` の `exec$` を統一
- `FileTreeFeatureComponent` が `SerialConnectionViewModelFacade.vm$.isLoggedIn` でロードを起動
- `FileService` が `sanitizeSerialStdout` で `ls` 出力を整形
- 回帰テストを追加・更新

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details: `createPiZeroShellExecOptions` を `@libs-web-serial` から export
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx serve apps-console` で起動
2. `http://localhost:4200/terminal` を開き Pi Zero に接続
3. オートログイン完了後、左ナビにファイルツリー（`myApp` 等）が表示されることを確認
4. `pnpm nx run-many -t test -p libs-web-serial libs-file-manager libs-terminal` がパスすることを確認

## Environment (if relevant)

- Browser: Chrome（Web Serial API 対応）
- OS: macOS / Windows / Linux
- Node version: 24.x
- pnpm version: 10.x

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant