### PR TITLE
fix(workspace): add rootDir to libs and apps tsconfig files

### DIFF
--- a/apps/console/tsconfig.app.json
+++ b/apps/console/tsconfig.app.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/app",
+    "rootDir": "../..",
     "types": [],
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,

--- a/apps/console/tsconfig.spec.json
+++ b/apps/console/tsconfig.spec.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/spec",
+    "rootDir": "../..",
     "types": ["vitest/globals", "node"],
     "moduleResolution": "bundler",
     "isolatedModules": true

--- a/libs/chirimen-setup/tsconfig.lib.json
+++ b/libs/chirimen-setup/tsconfig.lib.json
@@ -2,12 +2,15 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": []
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",

--- a/libs/chirimen-setup/tsconfig.spec.json
+++ b/libs/chirimen-setup/tsconfig.spec.json
@@ -2,13 +2,19 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": ".",
     "module": "preserve",
     "target": "ES2022",
-    "types": ["vitest/globals", "node"],
+    "types": [
+      "vitest/globals",
+      "node"
+    ],
     "moduleResolution": "bundler",
     "isolatedModules": true
   },
-  "files": ["src/test-setup.ts"],
+  "files": [
+    "src/test-setup.ts"
+  ],
   "include": [
     "vitest.config.ts",
     "src/**/*.test.ts",

--- a/libs/connect/tsconfig.lib.json
+++ b/libs/connect/tsconfig.lib.json
@@ -2,12 +2,15 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": []
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",

--- a/libs/connect/tsconfig.spec.json
+++ b/libs/connect/tsconfig.spec.json
@@ -2,13 +2,19 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": ".",
     "module": "preserve",
     "target": "ES2022",
-    "types": ["vitest/globals", "node"],
+    "types": [
+      "vitest/globals",
+      "node"
+    ],
     "moduleResolution": "bundler",
     "isolatedModules": true
   },
-  "files": ["src/test-setup.ts"],
+  "files": [
+    "src/test-setup.ts"
+  ],
   "include": [
     "vitest.config.ts",
     "src/**/*.test.ts",

--- a/libs/console-shell/tsconfig.lib.json
+++ b/libs/console-shell/tsconfig.lib.json
@@ -2,12 +2,15 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": []
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",

--- a/libs/console-shell/tsconfig.spec.json
+++ b/libs/console-shell/tsconfig.spec.json
@@ -2,13 +2,19 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": ".",
     "module": "preserve",
     "target": "ES2022",
-    "types": ["vitest/globals", "node"],
+    "types": [
+      "vitest/globals",
+      "node"
+    ],
     "moduleResolution": "bundler",
     "isolatedModules": true
   },
-  "files": ["src/test-setup.ts"],
+  "files": [
+    "src/test-setup.ts"
+  ],
   "include": [
     "vitest.config.ts",
     "src/**/*.test.ts",

--- a/libs/dialogs/tsconfig.lib.json
+++ b/libs/dialogs/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": false,
     "inlineSources": true,
@@ -15,5 +16,7 @@
     "src/test-setup.ts",
     "src/**/*.test.ts"
   ],
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/libs/dialogs/tsconfig.spec.json
+++ b/libs/dialogs/tsconfig.spec.json
@@ -2,13 +2,19 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": ".",
     "module": "preserve",
     "target": "ES2022",
-    "types": ["vitest/globals", "node"],
+    "types": [
+      "vitest/globals",
+      "node"
+    ],
     "moduleResolution": "bundler",
     "isolatedModules": true
   },
-  "files": ["src/test-setup.ts"],
+  "files": [
+    "src/test-setup.ts"
+  ],
   "include": [
     "vitest.config.ts",
     "src/**/*.test.ts",

--- a/libs/editor/tsconfig.lib.json
+++ b/libs/editor/tsconfig.lib.json
@@ -2,12 +2,15 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": []
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",

--- a/libs/editor/tsconfig.spec.json
+++ b/libs/editor/tsconfig.spec.json
@@ -2,13 +2,19 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": ".",
     "module": "preserve",
     "target": "ES2022",
-    "types": ["vitest/globals", "node"],
+    "types": [
+      "vitest/globals",
+      "node"
+    ],
     "moduleResolution": "bundler",
     "isolatedModules": true
   },
-  "files": ["src/test-setup.ts"],
+  "files": [
+    "src/test-setup.ts"
+  ],
   "include": [
     "vitest.config.ts",
     "src/**/*.test.ts",

--- a/libs/example/tsconfig.lib.json
+++ b/libs/example/tsconfig.lib.json
@@ -2,12 +2,15 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": []
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",

--- a/libs/example/tsconfig.spec.json
+++ b/libs/example/tsconfig.spec.json
@@ -2,7 +2,12 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["vitest/globals", "vite/client", "node"]
+    "rootDir": ".",
+    "types": [
+      "vitest/globals",
+      "vite/client",
+      "node"
+    ]
   },
   "include": [
     "vite.config.ts",
@@ -19,5 +24,7 @@
     "src/**/*.spec.jsx",
     "src/**/*.d.ts"
   ],
-  "files": ["src/test-setup.ts"]
+  "files": [
+    "src/test-setup.ts"
+  ]
 }

--- a/libs/file-manager/tsconfig.lib.json
+++ b/libs/file-manager/tsconfig.lib.json
@@ -2,12 +2,15 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": []
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",

--- a/libs/file-manager/tsconfig.spec.json
+++ b/libs/file-manager/tsconfig.spec.json
@@ -2,13 +2,19 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": ".",
     "module": "preserve",
     "target": "ES2022",
-    "types": ["vitest/globals", "node"],
+    "types": [
+      "vitest/globals",
+      "node"
+    ],
     "moduleResolution": "bundler",
     "isolatedModules": true
   },
-  "files": ["src/test-setup.ts"],
+  "files": [
+    "src/test-setup.ts"
+  ],
   "include": [
     "vitest.config.ts",
     "src/**/*.test.ts",

--- a/libs/i2cdetect/tsconfig.lib.json
+++ b/libs/i2cdetect/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": false,
     "inlineSources": true,
@@ -12,5 +13,7 @@
     "src/test-setup.ts",
     "src/**/*.test.ts"
   ],
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/libs/i2cdetect/tsconfig.spec.json
+++ b/libs/i2cdetect/tsconfig.spec.json
@@ -2,13 +2,19 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": ".",
     "module": "preserve",
     "target": "ES2022",
-    "types": ["vitest/globals", "node"],
+    "types": [
+      "vitest/globals",
+      "node"
+    ],
     "moduleResolution": "bundler",
     "isolatedModules": true
   },
-  "files": ["src/test-setup.ts"],
+  "files": [
+    "src/test-setup.ts"
+  ],
   "include": [
     "vitest.config.ts",
     "src/**/*.test.ts",

--- a/libs/page-not-found/tsconfig.lib.json
+++ b/libs/page-not-found/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": false,
     "inlineSources": true,
@@ -15,5 +16,7 @@
     "src/test-setup.ts",
     "src/**/*.test.ts"
   ],
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/libs/page-not-found/tsconfig.spec.json
+++ b/libs/page-not-found/tsconfig.spec.json
@@ -2,13 +2,19 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": ".",
     "module": "preserve",
     "target": "ES2022",
-    "types": ["vitest/globals", "node"],
+    "types": [
+      "vitest/globals",
+      "node"
+    ],
     "moduleResolution": "bundler",
     "isolatedModules": true
   },
-  "files": ["src/test-setup.ts"],
+  "files": [
+    "src/test-setup.ts"
+  ],
   "include": [
     "vitest.config.ts",
     "src/**/*.test.ts",

--- a/libs/pin-assign-panel/tsconfig.lib.json
+++ b/libs/pin-assign-panel/tsconfig.lib.json
@@ -2,12 +2,15 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": []
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",

--- a/libs/pin-assign-panel/tsconfig.spec.json
+++ b/libs/pin-assign-panel/tsconfig.spec.json
@@ -2,7 +2,12 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
-    "types": ["vitest/globals", "vite/client", "node"]
+    "rootDir": ".",
+    "types": [
+      "vitest/globals",
+      "vite/client",
+      "node"
+    ]
   },
   "include": [
     "vite.config.ts",
@@ -19,5 +24,7 @@
     "src/**/*.spec.jsx",
     "src/**/*.d.ts"
   ],
-  "files": ["src/test-setup.ts"]
+  "files": [
+    "src/test-setup.ts"
+  ]
 }

--- a/libs/remote/tsconfig.lib.json
+++ b/libs/remote/tsconfig.lib.json
@@ -2,12 +2,15 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": []
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",

--- a/libs/remote/tsconfig.spec.json
+++ b/libs/remote/tsconfig.spec.json
@@ -2,13 +2,19 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": ".",
     "module": "preserve",
     "target": "ES2022",
-    "types": ["vitest/globals", "node"],
+    "types": [
+      "vitest/globals",
+      "node"
+    ],
     "moduleResolution": "bundler",
     "isolatedModules": true
   },
-  "files": ["src/test-setup.ts"],
+  "files": [
+    "src/test-setup.ts"
+  ],
   "include": [
     "vitest.config.ts",
     "src/**/*.test.ts",

--- a/libs/shared/tsconfig.lib.json
+++ b/libs/shared/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": false,
     "inlineSources": true,
@@ -16,5 +17,7 @@
     "src/**/*.test.ts",
     "src/**/*.stories.ts"
   ],
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/libs/shared/tsconfig.spec.json
+++ b/libs/shared/tsconfig.spec.json
@@ -2,13 +2,19 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": ".",
     "module": "preserve",
     "target": "ES2022",
-    "types": ["vitest/globals", "node"],
+    "types": [
+      "vitest/globals",
+      "node"
+    ],
     "moduleResolution": "bundler",
     "isolatedModules": true
   },
-  "files": ["src/test-setup.ts"],
+  "files": [
+    "src/test-setup.ts"
+  ],
   "include": [
     "vitest.config.ts",
     "src/**/*.test.ts",

--- a/libs/terminal/tsconfig.lib.json
+++ b/libs/terminal/tsconfig.lib.json
@@ -2,12 +2,15 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": []
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",

--- a/libs/terminal/tsconfig.spec.json
+++ b/libs/terminal/tsconfig.spec.json
@@ -2,13 +2,19 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": ".",
     "module": "preserve",
     "target": "ES2022",
-    "types": ["vitest/globals", "node"],
+    "types": [
+      "vitest/globals",
+      "node"
+    ],
     "moduleResolution": "bundler",
     "isolatedModules": true
   },
-  "files": ["src/test-setup.ts"],
+  "files": [
+    "src/test-setup.ts"
+  ],
   "include": [
     "vitest.config.ts",
     "src/**/*.test.ts",

--- a/libs/unsupported-browser/tsconfig.lib.json
+++ b/libs/unsupported-browser/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": false,
     "inlineSources": true,
@@ -15,5 +16,7 @@
     "src/test-setup.ts",
     "src/**/*.test.ts"
   ],
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/libs/unsupported-browser/tsconfig.spec.json
+++ b/libs/unsupported-browser/tsconfig.spec.json
@@ -2,13 +2,19 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": ".",
     "module": "preserve",
     "target": "ES2022",
-    "types": ["vitest/globals", "node"],
+    "types": [
+      "vitest/globals",
+      "node"
+    ],
     "moduleResolution": "bundler",
     "isolatedModules": true
   },
-  "files": ["src/test-setup.ts"],
+  "files": [
+    "src/test-setup.ts"
+  ],
   "include": [
     "vitest.config.ts",
     "src/**/*.test.ts",

--- a/libs/web-serial/tsconfig.lib.json
+++ b/libs/web-serial/tsconfig.lib.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": false,
     "inlineSources": true,
@@ -12,5 +13,7 @@
     "src/test-setup.ts",
     "src/**/*.test.ts"
   ],
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/libs/web-serial/tsconfig.spec.json
+++ b/libs/web-serial/tsconfig.spec.json
@@ -2,13 +2,19 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": ".",
     "module": "preserve",
     "target": "ES2022",
-    "types": ["vitest/globals", "node"],
+    "types": [
+      "vitest/globals",
+      "node"
+    ],
     "moduleResolution": "bundler",
     "isolatedModules": true
   },
-  "files": ["src/test-setup.ts"],
+  "files": [
+    "src/test-setup.ts"
+  ],
   "include": [
     "vitest.config.ts",
     "src/**/*.test.ts",

--- a/libs/wifi/tsconfig.lib.json
+++ b/libs/wifi/tsconfig.lib.json
@@ -2,12 +2,15 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": "./src",
     "declaration": true,
     "declarationMap": true,
     "inlineSources": true,
     "types": []
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",

--- a/libs/wifi/tsconfig.spec.json
+++ b/libs/wifi/tsconfig.spec.json
@@ -2,13 +2,19 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
+    "rootDir": ".",
     "module": "preserve",
     "target": "ES2022",
-    "types": ["vitest/globals", "node"],
+    "types": [
+      "vitest/globals",
+      "node"
+    ],
     "moduleResolution": "bundler",
     "isolatedModules": true
   },
-  "files": ["src/test-setup.ts"],
+  "files": [
+    "src/test-setup.ts"
+  ],
   "include": [
     "vitest.config.ts",
     "src/**/*.test.ts",


### PR DESCRIPTION
## Summary

TypeScript 6.0.3 の要件に合わせ、全 libs の `tsconfig.lib.json` / `tsconfig.spec.json` および `apps/console` の `tsconfig.app.json` / `tsconfig.spec.json` に明示的な `rootDir` を追加し、IDE で表示されていた tsconfig lint エラーを解消する。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #721

## What changed?

- 全 16 libs の `tsconfig.lib.json` に `"rootDir": "./src"` を追加
- 全 16 libs の `tsconfig.spec.json` に `"rootDir": "."` を追加
- `apps/console` の `tsconfig.app.json` / `tsconfig.spec.json` に `"rootDir": "../.."` を追加（path mapping 経由で libs を参照するため、ワークスペースルートを指定）

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. Cursor で任意の libs / apps の tsconfig を開き、rootDir 関連の lint エラーが表示されないことを確認
2. `pnpm exec tsc -p libs/web-serial/tsconfig.lib.json --noEmit` および `pnpm exec tsc -p apps/console/tsconfig.app.json --noEmit` が成功することを確認
3. `pnpm nx run-many -t test --projects=libs-web-serial,apps-console` でテストを実行

## Environment (if relevant)

- Browser: N/A
- OS: macOS
- Node version: ワークスペース既定
- pnpm version: ワークスペース既定

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)