### PR TITLE
feat(terminal): clear コマンドで表示をクリアする

### DIFF
--- a/libs/terminal/src/lib/component/terminal-input.spec.ts
+++ b/libs/terminal/src/lib/component/terminal-input.spec.ts
@@ -53,7 +53,7 @@ describe('attachTerminalInput', () => {
     expect(terminal.writeln).not.toHaveBeenCalled();
   });
 
-  it('executes command when input is enabled', async () => {
+  it('trims and executes command when input is enabled', async () => {
     let keyHandler: ((e: TerminalKeyEvent) => void) | undefined;
 
     const terminal = {
@@ -79,6 +79,15 @@ describe('attachTerminalInput', () => {
         altKey: false,
         ctrlKey: false,
         metaKey: false,
+        code: 'Space',
+        key: ' ',
+      },
+    });
+    keyHandler?.({
+      domEvent: {
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
         code: 'KeyL',
         key: 'l',
       },
@@ -90,6 +99,15 @@ describe('attachTerminalInput', () => {
         metaKey: false,
         code: 'KeyS',
         key: 's',
+      },
+    });
+    keyHandler?.({
+      domEvent: {
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        code: 'Space',
+        key: ' ',
       },
     });
     keyHandler?.({

--- a/libs/terminal/src/lib/component/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/src/lib/component/terminal-view/terminal-view.component.spec.ts
@@ -10,8 +10,32 @@ vi.mock('@xterm/xterm', () => {
     dispose = vi.fn();
     writeln = vi.fn();
     write = vi.fn();
+    clear = vi.fn();
     reset = vi.fn();
-    onKey = vi.fn();
+    keyHandler?: (event: {
+      domEvent: {
+        altKey: boolean;
+        ctrlKey: boolean;
+        metaKey: boolean;
+        code: string;
+        key: string;
+      };
+    }) => void;
+    onKey = vi.fn(
+      (
+        handler: (event: {
+          domEvent: {
+            altKey: boolean;
+            ctrlKey: boolean;
+            metaKey: boolean;
+            code: string;
+            key: string;
+          };
+        }) => void,
+      ) => {
+        this.keyHandler = handler;
+      },
+    );
   }
   return { Terminal: MockTerminal };
 });
@@ -37,6 +61,41 @@ describe('TerminalViewComponent', () => {
   let terminalTextSignal: ReturnType<typeof signal<string>>;
   let isConnectedSignal: ReturnType<typeof signal<boolean>>;
   let connectionEpochSignal: ReturnType<typeof signal<number>>;
+
+  function typeCommand(command: string): void {
+    const terminal = fixture.componentInstance.xterminal as unknown as {
+      keyHandler?: (event: {
+        domEvent: {
+          altKey: boolean;
+          ctrlKey: boolean;
+          metaKey: boolean;
+          code: string;
+          key: string;
+        };
+      }) => void;
+    };
+
+    for (const key of command) {
+      terminal.keyHandler?.({
+        domEvent: {
+          altKey: false,
+          ctrlKey: false,
+          metaKey: false,
+          code: key === ' ' ? 'Space' : 'Key',
+          key,
+        },
+      });
+    }
+    terminal.keyHandler?.({
+      domEvent: {
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        code: 'Enter',
+        key: 'Enter',
+      },
+    });
+  }
 
   beforeEach(async () => {
     sendMock = vi.fn().mockReturnValue(of(undefined));
@@ -87,6 +146,56 @@ describe('TerminalViewComponent', () => {
         `${coerceLsForSerialListing('i2cdetect -y 1')}\n`,
       );
     });
+  });
+
+  it('clears the display for a trimmed clear command and keeps accepting input', async () => {
+    const clearSpy = vi.spyOn(fixture.componentInstance.xterminal, 'clear');
+
+    typeCommand(' clear ');
+
+    await vi.waitFor(() => {
+      expect(clearSpy).toHaveBeenCalledTimes(1);
+      expect(sendMock).toHaveBeenCalledWith('clear\n');
+    });
+
+    typeCommand('pwd');
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('pwd\n');
+    });
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not clear the display for commands containing clear', async () => {
+    const clearSpy = vi.spyOn(fixture.componentInstance.xterminal, 'clear');
+
+    typeCommand('clear logs');
+
+    await vi.waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith('clear logs\n');
+    });
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+
+  it('writes only new serial output after clearing the display', async () => {
+    const writeSpy = vi.spyOn(fixture.componentInstance.xterminal, 'write');
+    terminalTextSignal.set('previous output');
+    TestBed.flushEffects();
+    await vi.waitFor(() =>
+      expect(writeSpy).toHaveBeenCalledWith('previous output'),
+    );
+
+    typeCommand('clear');
+    await vi.waitFor(() => expect(sendMock).toHaveBeenCalledWith('clear\n'));
+    writeSpy.mockClear();
+
+    terminalTextSignal.set('previous outputnext output');
+    TestBed.flushEffects();
+
+    await vi.waitFor(() =>
+      expect(writeSpy).toHaveBeenCalledWith('next output'),
+    );
+    expect(writeSpy).not.toHaveBeenCalledWith('previous outputnext output');
   });
 
   it('skips bootstrap execution when already initialized', async () => {

--- a/libs/terminal/src/lib/component/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/src/lib/component/terminal-view/terminal-view.component.ts
@@ -145,10 +145,18 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
     attachTerminalInput(
       this.xterminal,
       async (command) => {
+        if (command === 'clear') {
+          this.clearTerminalDisplay();
+        }
         return this.console.runInteractiveCommand(command);
       },
       () => this.serialInputEnabled,
     );
+  }
+
+  private clearTerminalDisplay(): void {
+    this.xterminal.clear();
+    this.lastTerminalText = this.serial.terminalText();
   }
 
   private fitTerminal(): void {


### PR DESCRIPTION
## Summary

Terminal で `clear` コマンドを実行した際に、接続を維持したままブラウザ上の表示バッファをクリアできるようにします。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #724

## What changed?

- 前後の空白を除去した `clear` 完全一致時のみ xterm の表示バッファをクリアし、接続先にもコマンドを送信
- クリア時点の累積 Terminal テキストを描画基準に設定し、過去ログの再描画を防止
- 部分一致の誤検出、クリア後の入力継続、受信差分描画を回帰テストで検証

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details: 公開 API の変更はありません
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes: 移行作業は不要です

## How to test

1. `pnpm nx run libs-terminal:test` を実行する
2. `pnpm nx run libs-terminal:lint` を実行する
3. `pnpm nx run libs-terminal:build` を実行する

## Environment (if relevant)

- Browser: 単体テストのため該当なし
- OS: macOS
- Node version: v24.16.0
- pnpm version: 11.9.0

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed（更新不要）
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)