### PR TITLE
fix(web-serial): stabilize auto-login after serial connect

### DIFF
--- a/libs/example/src/lib/component/example/example.component.spec.ts
+++ b/libs/example/src/lib/component/example/example.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SerialNotificationService } from '@libs-web-serial';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { ExampleComponent } from './example.component';
 
@@ -10,6 +11,18 @@ describe('ExampleComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ExampleComponent, HttpClientTestingModule],
+      providers: [
+        {
+          provide: SerialNotificationService,
+          useValue: {
+            notifyAutoLoginFailed: () => undefined,
+            notifyConnectionSuccess: () => undefined,
+            notifyConnectionError: () => undefined,
+            notifyLogoutDetected: () => undefined,
+            notifyLogoutCancelled: () => undefined,
+          },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ExampleComponent);

--- a/libs/terminal/src/lib/component/terminal-page/terminal-page.component.spec.ts
+++ b/libs/terminal/src/lib/component/terminal-page/terminal-page.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { SerialNotificationService } from '@libs-web-serial';
 import TerminalPageComponent from './terminal-page.component';
 
 describe('TerminalPageComponent', () => {
@@ -8,6 +9,18 @@ describe('TerminalPageComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TerminalPageComponent],
+      providers: [
+        {
+          provide: SerialNotificationService,
+          useValue: {
+            notifyAutoLoginFailed: () => undefined,
+            notifyConnectionSuccess: () => undefined,
+            notifyConnectionError: () => undefined,
+            notifyLogoutDetected: () => undefined,
+            notifyLogoutCancelled: () => undefined,
+          },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TerminalPageComponent);

--- a/libs/web-serial/src/lib/service/pi-zero-prompt-detector.service.spec.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-prompt-detector.service.spec.ts
@@ -80,4 +80,38 @@ describe('PiZeroPromptDetectorService', () => {
       detector.isAwaitingPasswordInput('foo login:\nPassword: '),
     ).toBe(true);
   });
+
+  it('isAwaitingLoginName ignores ANSI CSI and lone CR (#726)', () => {
+    expect(
+      detector.isAwaitingLoginName('raspberrypi login: \u001b[0m\r'),
+    ).toBe(true);
+    expect(
+      detector.isAwaitingLoginName('boot\nraspberrypi login:\u0000 '),
+    ).toBe(true);
+  });
+
+  it('isAwaitingPasswordInput ignores ANSI CSI and lone CR (#726)', () => {
+    expect(detector.isAwaitingPasswordInput('Password:\u001b[0m\r')).toBe(
+      true,
+    );
+    expect(
+      detector.isAwaitingPasswordInput('foo login:\nPassword: \u0007'),
+    ).toBe(true);
+  });
+
+  it('isAwaitingLoginName still prefers trailing password over scrollback login', () => {
+    expect(
+      detector.isAwaitingLoginName(
+        'raspberrypi login: \nPassword: \u001b[0m',
+      ),
+    ).toBe(false);
+  });
+
+  it('isLikelyLoggedInShellPrompt ignores ANSI before shell prompt (#726)', () => {
+    expect(
+      detector.isLikelyLoggedInShellPrompt(
+        'Last login: Mon Jan 01\n\u001b[0mpi@raspberrypi:~$ ',
+      ),
+    ).toBe(true);
+  });
 });

--- a/libs/web-serial/src/lib/service/pi-zero-prompt-detector.service.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-prompt-detector.service.ts
@@ -36,12 +36,23 @@ export class PiZeroPromptDetectorService {
    * CSI/OSC と、`\r` `\n` `\t` 以外の C0 制御文字を除去してから正規化する。
    */
   private sanitizeForPromptMatch(text: string): string {
-    return text
-      .replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, '')
-      .replace(/\u001b\][^\u0007]*(?:\u0007|\u001b\\)/g, '')
-      .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f]/g, '')
-      .replace(/\r\n/g, '\n')
-      .replace(/\r/g, '\n');
+    const esc = String.fromCharCode(0x1b);
+    const bel = String.fromCharCode(0x07);
+    const withoutAnsi = text
+      .replace(new RegExp(`${esc}\\[[0-9;?]*[ -/]*[@-~]`, 'g'), '')
+      .replace(new RegExp(`${esc}\\][^${bel}]*(?:${bel}|${esc}\\\\)`, 'g'), '');
+
+    let withoutC0 = '';
+    for (let i = 0; i < withoutAnsi.length; i++) {
+      const code = withoutAnsi.charCodeAt(i);
+      // keep TAB / LF / CR; strip other C0 controls
+      if (code <= 0x1f && code !== 0x09 && code !== 0x0a && code !== 0x0d) {
+        continue;
+      }
+      withoutC0 += withoutAnsi[i];
+    }
+
+    return withoutC0.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
   }
 
   /**

--- a/libs/web-serial/src/lib/service/pi-zero-prompt-detector.service.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-prompt-detector.service.ts
@@ -32,11 +32,24 @@ export class PiZeroPromptDetectorService {
   private readonly shellPromptLinePattern = /pi@[^:\r\n]+:/;
 
   /**
+   * getty / ANSI 制御シーケンス混入時に行判定が崩れるのを防ぐ。
+   * CSI/OSC と、`\r` `\n` `\t` 以外の C0 制御文字を除去してから正規化する。
+   */
+  private sanitizeForPromptMatch(text: string): string {
+    return text
+      .replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, '')
+      .replace(/\u001b\][^\u0007]*(?:\u0007|\u001b\\)/g, '')
+      .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f]/g, '')
+      .replace(/\r\n/g, '\n')
+      .replace(/\r/g, '\n');
+  }
+
+  /**
    * getty の入力待ちを **末尾の非空行** で見る（バッファ先頭に `login:` が残っていても
    * 実際には `Password:` 待ち、などを区別するため）。
    */
   private trailingNonEmptyLine(text: string): string {
-    const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    const normalized = this.sanitizeForPromptMatch(text);
     const lines = normalized.split('\n');
     for (let i = lines.length - 1; i >= 0; i--) {
       const t = lines[i]?.trim();
@@ -45,6 +58,20 @@ export class PiZeroPromptDetectorService {
       }
     }
     return '';
+  }
+
+  /**
+   * 末尾行が取れない場合のフォールバック。
+   * バッファ末尾が login / password プロンプトで終わるかだけを見る（scrollback 先頭は見ない）。
+   */
+  private bufferEndsWithLoginPrompt(text: string): boolean {
+    const normalized = this.sanitizeForPromptMatch(text).trimEnd();
+    return /(?:[Ll]ogin|ログイン)\s*:\s*$/.test(normalized);
+  }
+
+  private bufferEndsWithPasswordPrompt(text: string): boolean {
+    const normalized = this.sanitizeForPromptMatch(text).trimEnd();
+    return /[Pp]assword:\s*$/.test(normalized);
   }
 
   isLoginPrompt(text: string): boolean {
@@ -71,7 +98,7 @@ export class PiZeroPromptDetectorService {
     if (this.isShellPrompt(text)) {
       return true;
     }
-    const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    const normalized = this.sanitizeForPromptMatch(text);
     // パス省略で `pi@host:$` になるとき `.+` は一致しない（`.` は 0 回以上にする）
     if (/(?:^|[\n])[\t ]*[^\s]+@[^:]+:.*[$#%]/m.test(normalized)) {
       return true;
@@ -106,25 +133,28 @@ export class PiZeroPromptDetectorService {
   }
 
   /**
-   * 末尾行がユーザー名入力待ちの `login:` / `ログイン:`（getty の現在のプロンプト）
+   * 末尾行がユーザー名入力待ちの `login:` / `ログイン:`（getty の現在のプロンプト）。
+   * 末尾行が空のときはバッファ末尾一致にフォールバック（#726）。
    */
   isAwaitingLoginName(text: string): boolean {
     const line = this.trailingNonEmptyLine(text);
-    if (!line) {
-      return false;
+    if (line) {
+      // scrollback 先頭の古い login: を拾わない（末尾行優先）
+      return /(?:[Ll]ogin|ログイン)\s*:\s*$/.test(line);
     }
-    return /(?:[Ll]ogin|ログイン)\s*:\s*$/.test(line);
+    return this.bufferEndsWithLoginPrompt(text);
   }
 
   /**
    * 末尾がパスワード入力待ち（接続直後ですでに `Password:` のみ、など）。
+   * 末尾行が空のときはバッファ末尾一致にフォールバック（#726）。
    */
   isAwaitingPasswordInput(text: string): boolean {
     const line = this.trailingNonEmptyLine(text);
-    if (!line) {
-      return false;
+    if (line) {
+      return /[Pp]assword:\s*$/.test(line);
     }
-    return /[Pp]assword:\s*$/.test(line);
+    return this.bufferEndsWithPasswordPrompt(text);
   }
 
   /**
@@ -132,7 +162,7 @@ export class PiZeroPromptDetectorService {
    * `pi@host:~$ ls ...` のようなコマンドエコー行では一致させない（issue #717）。
    */
   isCommandCompleted(text: string): boolean {
-    const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    const normalized = this.sanitizeForPromptMatch(text);
     const lines = normalized.split('\n');
     const windowSize = Math.min(lines.length, 12);
     for (let j = lines.length - 1; j >= lines.length - windowSize; j--) {

--- a/libs/web-serial/src/lib/service/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-serial-bootstrap.service.spec.ts
@@ -222,6 +222,39 @@ describe('PiZeroSerialBootstrapService', () => {
     expect(send$).toHaveBeenCalledWith(`${PI_ZERO_LOGIN_USER}\r\n`);
   });
 
+  it('completes auth when prompts include ANSI CSI and lone CR (#726)', async () => {
+    const readUntilPrompt = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('probe timeout'))
+      .mockResolvedValueOnce({ stdout: 'stale' })
+      .mockResolvedValueOnce({
+        stdout: 'raspberrypi login: \u001b[0m\r',
+      })
+      .mockResolvedValueOnce({
+        stdout: 'Password:\u001b[0m\r',
+      })
+      .mockResolvedValueOnce({
+        stdout: `\u001b[0m${PI_ZERO_PROMPT} `,
+      });
+    const exec = vi.fn().mockResolvedValue({ stdout: '' });
+    const send$ = vi.fn().mockReturnValue(of(undefined));
+    const serial = {
+      readUntilPrompt$: (o: unknown) => from(readUntilPrompt(o)),
+      exec$: (c: string, o: unknown) => from(exec(c, o)),
+      send$,
+    } as unknown as SerialFacadeService;
+
+    const logs: string[] = [];
+    await firstValueFrom(
+      createBootstrap(serial).loginIfNeeded$((l) => logs.push(l)),
+    );
+
+    expect(send$).toHaveBeenCalledWith(`${PI_ZERO_LOGIN_USER}\r\n`);
+    expect(send$).toHaveBeenCalledWith(`${PI_ZERO_LOGIN_PASSWORD}\r\n`);
+    expect(logs.some((l) => l.includes('シェルプロンプトを待機中'))).toBe(true);
+    expect(logs.some((l) => l.includes('ログインが完了'))).toBe(true);
+  });
+
   it('keeps environment status logging', async () => {
     const readUntilPrompt = vi.fn().mockResolvedValue({
       stdout: `ready\r\n${PI_ZERO_PROMPT} `,

--- a/libs/web-serial/src/lib/service/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-serial-bootstrap.service.spec.ts
@@ -35,11 +35,15 @@ describe('PiZeroSerialBootstrapService', () => {
       send$,
     } as unknown as SerialFacadeService;
 
-    await firstValueFrom(createBootstrap(serial).runPostConnectPipeline$());
+    const logs: string[] = [];
+    await firstValueFrom(
+      createBootstrap(serial).runPostConnectPipeline$((l) => logs.push(l)),
+    );
 
     expect(send$).toHaveBeenCalledWith('\r\n');
     expect(send$).toHaveBeenCalledWith(`${PI_ZERO_LOGIN_USER}\r\n`);
     expect(send$).toHaveBeenCalledWith(`${PI_ZERO_LOGIN_PASSWORD}\r\n`);
+    expect(logs.some((l) => l.includes('シェルプロンプトを待機中'))).toBe(true);
     expect(exec).toHaveBeenCalledTimes(6); // environment setup steps
   });
 

--- a/libs/web-serial/src/lib/service/pi-zero-serial-bootstrap.service.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-serial-bootstrap.service.ts
@@ -317,6 +317,7 @@ export class PiZeroSerialBootstrapService {
         log('[コンソール] パスワードを送信中（画面には表示しません）...');
         return this.serial.send$(`${PI_ZERO_LOGIN_PASSWORD}\r\n`).pipe(
           switchMap(() => this.serial.send$('\r\n')),
+          tap(() => log('[コンソール] シェルプロンプトを待機中...')),
           switchMap(() =>
             this.runAuthLoop$(log, {
               stepCount: state.stepCount + 1,

--- a/libs/web-serial/src/lib/service/pi-zero-session.service.spec.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-session.service.spec.ts
@@ -341,7 +341,7 @@ describe('PiZeroSessionService', () => {
 
       const service = createSession(serial, createShellReadinessMock());
       await firstValueFrom(
-        service.runAfterConnect$((_line) => {
+        service.runAfterConnect$(() => {
           statuses.push(service.setupStatus());
         }),
       );

--- a/libs/web-serial/src/lib/service/pi-zero-session.service.spec.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-session.service.spec.ts
@@ -316,6 +316,45 @@ describe('PiZeroSessionService', () => {
       expect(send$).toHaveBeenCalledWith(`${PI_ZERO_LOGIN_USER}\r\n`);
       expect(exec).not.toHaveBeenCalled();
     });
+
+    it('sets waiting-shell after password is sent during runAfterConnect$', async () => {
+      const statuses: string[] = [];
+      const readUntilPrompt = vi
+        .fn()
+        .mockImplementationOnce(() =>
+          throwError(() => new Error('shell prompt timeout')),
+        )
+        .mockImplementationOnce(() => of({ stdout: 'stale buffer' }))
+        .mockImplementationOnce(() => of({ stdout: 'raspberrypi login: ' }))
+        .mockImplementationOnce(() => of({ stdout: 'Password: ' }))
+        .mockImplementationOnce(() =>
+          of({ stdout: `ready\n${PI_ZERO_PROMPT} ` }),
+        );
+      const exec = vi.fn().mockReturnValue(of({ stdout: `${PI_ZERO_PROMPT} ` }));
+      const serial = {
+        isConnected$: of(true),
+        connectionEstablished$: NEVER,
+        readUntilPrompt$: (o: unknown) => readUntilPrompt(o),
+        exec$: (c: string, o: unknown) => exec(c, o),
+        send$: () => of(undefined),
+      } as unknown as SerialFacadeService;
+
+      const service = createSession(serial, createShellReadinessMock());
+      await firstValueFrom(
+        service.runAfterConnect$((_line) => {
+          statuses.push(service.setupStatus());
+        }),
+      );
+      await vi.waitFor(() => {
+        expect(service.setupStatus()).toBe('ready');
+      });
+
+      expect(statuses).toContain('sending-password');
+      expect(statuses).toContain('waiting-shell');
+      expect(statuses.indexOf('sending-password')).toBeLessThan(
+        statuses.indexOf('waiting-shell'),
+      );
+    });
   });
 
   describe('setup flow (setupEnvironment$)', () => {

--- a/libs/web-serial/src/lib/service/pi-zero-session.service.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-session.service.ts
@@ -196,6 +196,8 @@ export class PiZeroSessionService {
             this.setupStatusSignal.set('sending-username');
           } else if (line.includes('パスワードを送信中')) {
             this.setupStatusSignal.set('sending-password');
+          } else if (line.includes('シェルプロンプトを待機中')) {
+            this.setupStatusSignal.set('waiting-shell');
           }
           log(line);
         };

--- a/libs/web-serial/src/lib/service/serial-connection-orchestration.service.spec.ts
+++ b/libs/web-serial/src/lib/service/serial-connection-orchestration.service.spec.ts
@@ -1,12 +1,13 @@
 import '@angular/compiler';
 import { Injector } from '@angular/core';
-import { BehaviorSubject, firstValueFrom, of } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, of, throwError } from 'rxjs';
 import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
 import { PiZeroSessionService } from './pi-zero-session.service';
 import { PiZeroPromptDetectorService } from './pi-zero-prompt-detector.service';
 import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
 import { SerialCommandPipelineService } from './serial-command/serial-command-pipeline.service';
 import { SerialConnectionOrchestrationService } from './serial-connection-orchestration.service';
+import { SerialNotificationService } from './serial-notification.service';
 import { SerialTransportService } from './serial-transport.service';
 
 describe('SerialConnectionOrchestrationService', () => {
@@ -19,6 +20,7 @@ describe('SerialConnectionOrchestrationService', () => {
   let shellReadiness: PiZeroShellReadinessService;
   let runAfterConnect$: Mock;
   let resetSession: Mock;
+  let notifyAutoLoginFailed: Mock;
 
   beforeEach(() => {
     isConnectedSubj = new BehaviorSubject(false);
@@ -50,6 +52,7 @@ describe('SerialConnectionOrchestrationService', () => {
     }).get(PiZeroShellReadinessService);
     runAfterConnect$ = vi.fn(() => of(undefined));
     resetSession = vi.fn();
+    notifyAutoLoginFailed = vi.fn();
 
     const injector = Injector.create({
       providers: [
@@ -57,6 +60,10 @@ describe('SerialConnectionOrchestrationService', () => {
         { provide: SerialTransportService, useValue: transport },
         { provide: SerialCommandPipelineService, useValue: command },
         { provide: PiZeroShellReadinessService, useValue: shellReadiness },
+        {
+          provide: SerialNotificationService,
+          useValue: { notifyAutoLoginFailed },
+        },
         {
           provide: PiZeroSessionService,
           useValue: { runAfterConnect$, resetSession },
@@ -89,6 +96,19 @@ describe('SerialConnectionOrchestrationService', () => {
     await firstValueFrom(service.connect$(115200));
     await vi.waitFor(() => {
       expect(runAfterConnect$).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('notifies user when post-connect bootstrap fails (#726)', async () => {
+    runAfterConnect$.mockReturnValue(
+      throwError(() => new Error('Shell readiness timeout while waiting for prompt')),
+    );
+
+    await firstValueFrom(service.connect$(115200));
+    await vi.waitFor(() => {
+      expect(notifyAutoLoginFailed).toHaveBeenCalledWith(
+        'Shell readiness timeout while waiting for prompt',
+      );
     });
   });
 

--- a/libs/web-serial/src/lib/service/serial-connection-orchestration.service.ts
+++ b/libs/web-serial/src/lib/service/serial-connection-orchestration.service.ts
@@ -15,6 +15,7 @@ import { getConnectionErrorMessage } from '../functions';
 import { PiZeroSessionService } from './pi-zero-session.service';
 import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
 import { SerialCommandPipelineService } from './serial-command/serial-command-pipeline.service';
+import { SerialNotificationService } from './serial-notification.service';
 import { SerialTransportService } from './serial-transport.service';
 
 /** {@link SerialConnectionOrchestrationService#connect$} の結果 */
@@ -33,6 +34,7 @@ export class SerialConnectionOrchestrationService {
   private readonly transport = inject(SerialTransportService);
   private readonly command = inject(SerialCommandPipelineService);
   private readonly shellReadiness = inject(PiZeroShellReadinessService);
+  private readonly notifications = inject(SerialNotificationService);
   private readonly injector = inject(Injector);
 
   /**
@@ -113,6 +115,7 @@ export class SerialConnectionOrchestrationService {
               '[SerialConnection] post-connect bootstrap failed:',
               message,
             );
+            this.notifications.notifyAutoLoginFailed(message);
             return EMPTY;
           }),
         )

--- a/libs/web-serial/src/lib/service/serial-notification.service.spec.ts
+++ b/libs/web-serial/src/lib/service/serial-notification.service.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SerialNotificationService } from './serial-notification.service';
+
+describe('SerialNotificationService', () => {
+  it('notifyAutoLoginFailed shows error toast with message', () => {
+    const error = vi.fn();
+    const service = Object.create(
+      SerialNotificationService.prototype,
+    ) as SerialNotificationService;
+    (
+      service as unknown as { toastr: { error: typeof error } }
+    ).toastr = { error };
+
+    service.notifyAutoLoginFailed('Shell readiness timeout');
+
+    expect(error).toHaveBeenCalledWith(
+      'オートログインに失敗しました: Shell readiness timeout',
+      'ログインエラー',
+      { timeOut: 8000 },
+    );
+  });
+});

--- a/libs/web-serial/src/lib/service/serial-notification.service.ts
+++ b/libs/web-serial/src/lib/service/serial-notification.service.ts
@@ -56,4 +56,17 @@ export class SerialNotificationService {
       timeOut: 5000,
     });
   }
+
+  /**
+   * 接続後オートログイン / bootstrap 失敗時の通知（#726）。
+   */
+  notifyAutoLoginFailed(errorMessage: string): void {
+    this.toastr.error(
+      `オートログインに失敗しました: ${errorMessage}`,
+      'ログインエラー',
+      {
+        timeOut: 8000,
+      },
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- Web Serial 接続後のオートログイン（プロンプト検出・認証状態判定）を堅牢化し、途中停止を防ぐ
- パスワード送信後に `waiting-shell` をセットし、進捗を可視化する
- オートログイン失敗時にトーストで原因をユーザーへ通知する

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #726

## What changed?

- getty 向け login / password / shell プロンプト検出のフォールバック強化（ANSI / C0 制御文字除去）
- `setupStatus` に `waiting-shell` を配線
- オートログイン失敗時の toast 通知を追加
- 回帰テストを追加（ANSI/lone-CR 認証フロー、失敗トースト配線）

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx test libs-web-serial` が通ること
2. console を起動し Raspberry Pi を Web Serial 接続する
3. オートログインが完了し Terminal が操作可能になること
4. File Manager がログイン完了後に初期化されること
5. 意図的に失敗させた場合（またはタイムアウト時）にエラー toast が出ること
6. 切断→再接続でも同様に動作すること

## Environment (if relevant)

- Browser: Chrome
- OS: macOS
- Node version: 22.x または 24.x
- pnpm version: 10.x

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)