### PR TITLE
feat(wifi): revise wifi settings layout

### DIFF
--- a/libs/wifi/src/lib/component/wifi-info/wifi-info.component.html
+++ b/libs/wifi/src/lib/component/wifi-info/wifi-info.component.html
@@ -27,7 +27,7 @@
   }
 </div>
 
-<div class="justify-self-end" (click)="$event.stopPropagation()">
+<div class="justify-self-end">
   <choh-button
     [label]="'接続'"
     type="button"

--- a/libs/wifi/src/lib/component/wifi-info/wifi-info.component.html
+++ b/libs/wifi/src/lib/component/wifi-info/wifi-info.component.html
@@ -1,22 +1,37 @@
-<mat-card
-  appearance="outlined"
-  role="button"
-  tabindex="0"
-  class="w-[500px] max-h-[300px] overflow-y-auto cursor-pointer hover:bg-gray-50 focus-visible:ring-2"
-  (click)="onCardActivate()"
-  (keydown.enter)="onCardActivate()"
-  (keydown.space)="$event.preventDefault(); onCardActivate()"
+<div class="min-w-0">
+  <div class="truncate text-sm font-medium" [title]="fullSsidTitle()">
+    {{ ssidLabel() }}
+  </div>
+</div>
+
+<div class="truncate text-xs text-gray-700" [title]="wifiInfo().quality">
+  {{ signalLabel() }}
+</div>
+
+<div
+  class="hidden truncate text-xs text-gray-700 sm:block"
+  [title]="wifiInfo().spec"
 >
-  <mat-card-header>
-    <mat-card-title>SSID: {{ wifiInfo().ssid }}</mat-card-title>
-  </mat-card-header>
-  <mat-card-content>
-    <ul>
-      <li>address: {{ wifiInfo().address }}</li>
-      <li>channel: {{ wifiInfo().channel }}</li>
-      <li>frequency: {{ wifiInfo().frequency }}</li>
-      <li>quality: {{ wifiInfo().quality }}</li>
-      <li>spec: {{ wifiInfo().spec }}</li>
-    </ul>
-  </mat-card-content>
-</mat-card>
+  {{ securityLabel() }}
+</div>
+
+<div class="text-xs whitespace-nowrap">
+  @if (connected()) {
+    <span
+      class="rounded bg-green-100 px-1.5 py-0.5 font-medium text-green-800"
+    >
+      接続中
+    </span>
+  } @else {
+    <span class="text-gray-400">—</span>
+  }
+</div>
+
+<div class="justify-self-end" (click)="$event.stopPropagation()">
+  <choh-button
+    [label]="'接続'"
+    type="button"
+    [disabled]="connectDisabled()"
+    (clickEvent)="onConnectClick()"
+  />
+</div>

--- a/libs/wifi/src/lib/component/wifi-info/wifi-info.component.spec.ts
+++ b/libs/wifi/src/lib/component/wifi-info/wifi-info.component.spec.ts
@@ -1,7 +1,16 @@
 /// <reference types="vitest/globals" />
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { WiFiInfo } from '@libs-shared';
+import type { WiFiInfo } from '@libs-shared';
 import { WifiInfoComponent } from './wifi-info.component';
+
+const sample: WiFiInfo = {
+  ssid: 'test-ssid',
+  address: '00:00:00:00:00:00',
+  channel: 1,
+  frequency: '2.4 GHz',
+  quality: 'Quality=70/70  Signal level=-40 dBm',
+  spec: 'IEEE 802.11i/WPA2 Version 1',
+};
 
 describe('WifiInfoComponent', () => {
   let component: WifiInfoComponent;
@@ -14,18 +23,44 @@ describe('WifiInfoComponent', () => {
 
     fixture = TestBed.createComponent(WifiInfoComponent);
     component = fixture.componentInstance;
-    fixture.componentRef.setInput('wifiInfo', {
-      ssid: 'test-ssid',
-      address: '00:00:00:00:00:00',
-      channel: 1,
-      frequency: '2.4 GHz',
-      quality: '70/70',
-      spec: '802.11n',
-    } satisfies WiFiInfo);
+    fixture.componentRef.setInput('wifiInfo', sample);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('shows hidden label for empty ssid', () => {
+    fixture.componentRef.setInput('wifiInfo', { ...sample, ssid: '' });
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('（非公開）');
+  });
+
+  it('emits selectNetwork on Enter key', () => {
+    const selected: WiFiInfo[] = [];
+    component.selectNetwork.subscribe((info) => selected.push(info));
+
+    fixture.nativeElement.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+    );
+    expect(selected).toHaveLength(1);
+    expect(selected[0]?.ssid).toBe('test-ssid');
+  });
+
+  it('emits selectNetwork on Space key', () => {
+    const selected: WiFiInfo[] = [];
+    component.selectNetwork.subscribe((info) => selected.push(info));
+
+    fixture.nativeElement.dispatchEvent(
+      new KeyboardEvent('keydown', { key: ' ', bubbles: true }),
+    );
+    expect(selected).toHaveLength(1);
+  });
+
+  it('shows connected badge when connected input is true', () => {
+    fixture.componentRef.setInput('connected', true);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('接続中');
   });
 });

--- a/libs/wifi/src/lib/component/wifi-info/wifi-info.component.ts
+++ b/libs/wifi/src/lib/component/wifi-info/wifi-info.component.ts
@@ -1,22 +1,64 @@
-import { Component, input, output } from '@angular/core';
-import { MatCardModule } from '@angular/material/card';
+import { Component, computed, input, output } from '@angular/core';
 import type { WiFiInfo } from '@libs-shared';
+import { ButtonComponent } from '@libs-shared';
+import {
+  formatWifiSecurity,
+  formatWifiSignal,
+  formatWifiSsidLabel,
+} from '../../functions';
 
 /**
- * 1 件の WiFi ネットワーク情報を表示するカード
+ * 1 件の WiFi ネットワークを列揃えの行として表示する
  */
 @Component({
   selector: 'choh-wifi-info',
-  imports: [MatCardModule],
+  imports: [ButtonComponent],
   templateUrl: './wifi-info.component.html',
+  host: {
+    role: 'listitem',
+    tabindex: '0',
+    class:
+      'grid w-full grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto_auto] items-center gap-2 border-b border-gray-100 px-3 py-2 text-left hover:bg-gray-50 focus-visible:ring-2 focus-visible:outline-none sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_auto_auto]',
+    '[class.bg-blue-50]': 'selected()',
+    '[attr.aria-selected]': 'selected()',
+    '(click)': 'onRowActivate()',
+    '(keydown.enter)': 'onRowActivate()',
+    '(keydown.space)': 'onRowSpace($event)',
+  },
 })
 export class WifiInfoComponent {
   readonly wifiInfo = input.required<WiFiInfo>();
+  readonly selected = input(false);
+  readonly connected = input(false);
+  readonly connectDisabled = input(false);
 
-  /** カードクリックで接続ダイアログ用に選択 */
+  /** 行選択 */
   readonly selectNetwork = output<WiFiInfo>();
+  /** 接続ダイアログを開く */
+  readonly connectNetwork = output<WiFiInfo>();
 
-  onCardActivate(): void {
+  readonly ssidLabel = computed(() => formatWifiSsidLabel(this.wifiInfo().ssid));
+  readonly signalLabel = computed(() =>
+    formatWifiSignal(this.wifiInfo().quality),
+  );
+  readonly securityLabel = computed(() =>
+    formatWifiSecurity(this.wifiInfo().spec),
+  );
+  readonly fullSsidTitle = computed(() => {
+    const ssid = this.wifiInfo().ssid?.trim();
+    return ssid && ssid.length > 0 ? ssid : '（非公開）';
+  });
+
+  onRowActivate(): void {
     this.selectNetwork.emit(this.wifiInfo());
+  }
+
+  onRowSpace(event: Event): void {
+    event.preventDefault();
+    this.onRowActivate();
+  }
+
+  onConnectClick(): void {
+    this.connectNetwork.emit(this.wifiInfo());
   }
 }

--- a/libs/wifi/src/lib/component/wifi-info/wifi-info.component.ts
+++ b/libs/wifi/src/lib/component/wifi-info/wifi-info.component.ts
@@ -21,7 +21,7 @@ import {
       'grid w-full grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto_auto] items-center gap-2 border-b border-gray-100 px-3 py-2 text-left hover:bg-gray-50 focus-visible:ring-2 focus-visible:outline-none sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_auto_auto]',
     '[class.bg-blue-50]': 'selected()',
     '[attr.aria-selected]': 'selected()',
-    '(click)': 'onRowActivate()',
+    '(click)': 'onHostClick($event)',
     '(keydown.enter)': 'onRowActivate()',
     '(keydown.space)': 'onRowSpace($event)',
   },
@@ -48,6 +48,14 @@ export class WifiInfoComponent {
     const ssid = this.wifiInfo().ssid?.trim();
     return ssid && ssid.length > 0 ? ssid : '（非公開）';
   });
+
+  onHostClick(event: MouseEvent): void {
+    const target = event.target as HTMLElement | null;
+    if (target?.closest('button')) {
+      return;
+    }
+    this.onRowActivate();
+  }
 
   onRowActivate(): void {
     this.selectNetwork.emit(this.wifiInfo());

--- a/libs/wifi/src/lib/component/wifi-list/wifi-list.component.html
+++ b/libs/wifi/src/lib/component/wifi-list/wifi-list.component.html
@@ -1,13 +1,47 @@
-<div>
-  <h3>WiFi Scan Result</h3>
-</div>
-<div class="max-h-[620px] overflow-y-auto w-full">
-  @for (wifiInfo of wifiInfoList(); track wifiInfo.address + wifiInfo.ssid + $index) {
-    <choh-wifi-info
-      [wifiInfo]="wifiInfo"
-      (selectNetwork)="networkSelected.emit($event)"
-    />
-  } @empty {
-    <span>スキャン結果がありません。「Wifi Scan」で取得してください。</span>
-  }
+<div class="flex min-h-0 w-full flex-1 flex-col gap-2">
+  <div class="flex items-center justify-between gap-2">
+    <h3 class="text-base font-semibold">WiFi Scan Result</h3>
+  </div>
+
+  <div
+    class="min-h-0 flex-1 overflow-y-auto rounded border border-gray-200"
+    role="list"
+    [attr.aria-busy]="scanInProgress()"
+    [attr.aria-label]="'WiFi アクセスポイント一覧'"
+  >
+    <div
+      class="sticky top-0 z-10 grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto_auto] gap-2 border-b border-gray-200 bg-gray-50 px-3 py-2 text-xs font-semibold text-gray-600 sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_auto_auto]"
+      role="presentation"
+    >
+      <div>SSID</div>
+      <div>Signal</div>
+      <div class="hidden sm:block">Security</div>
+      <div>接続状態</div>
+      <div class="text-right">接続操作</div>
+    </div>
+
+    @if (scanInProgress()) {
+      <p class="p-3 text-sm text-gray-600" role="status">スキャン中…</p>
+    } @else if (scanError()) {
+      <p class="p-3 text-sm text-red-700" role="alert">{{ scanError() }}</p>
+    } @else {
+      @for (
+        wifiInfo of wifiInfoList();
+        track trackKey(wifiInfo, $index)
+      ) {
+        <choh-wifi-info
+          [wifiInfo]="wifiInfo"
+          [selected]="isSelected(wifiInfo)"
+          [connected]="isConnected(wifiInfo)"
+          [connectDisabled]="connectDisabled()"
+          (selectNetwork)="networkSelected.emit($event)"
+          (connectNetwork)="networkConnect.emit($event)"
+        />
+      } @empty {
+        <p class="p-3 text-sm text-gray-600">
+          スキャン結果がありません。「再スキャン」で取得してください。
+        </p>
+      }
+    }
+  </div>
 </div>

--- a/libs/wifi/src/lib/component/wifi-list/wifi-list.component.spec.ts
+++ b/libs/wifi/src/lib/component/wifi-list/wifi-list.component.spec.ts
@@ -1,6 +1,22 @@
 /// <reference types="vitest/globals" />
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import type { WiFiInfo } from '@libs-shared';
 import { WifiListComponent } from './wifi-list.component';
+
+const sampleNetwork: WiFiInfo = {
+  ssid: 'cafe-wifi',
+  address: 'AA:BB:CC:DD:EE:01',
+  channel: 1,
+  frequency: '2.412 GHz (Channel 1)',
+  quality: 'Quality=53/70  Signal level=-57 dBm',
+  spec: 'IEEE 802.11i/WPA2 Version 1,CCMP,CCMPPSK',
+};
+
+const longSsidNetwork: WiFiInfo = {
+  ...sampleNetwork,
+  ssid: 'a-very-long-ssid-name-that-should-truncate-in-the-list-ui',
+  address: 'AA:BB:CC:DD:EE:02',
+};
 
 describe('WifiListComponent', () => {
   let component: WifiListComponent;
@@ -18,5 +34,102 @@ describe('WifiListComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('shows empty state when list is empty and not scanning', () => {
+    fixture.componentRef.setInput('wifiInfoList', []);
+    fixture.componentRef.setInput('scanInProgress', false);
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('スキャン結果がありません');
+  });
+
+  it('shows loading state while scanning', () => {
+    fixture.componentRef.setInput('scanInProgress', true);
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('スキャン中');
+    const list = fixture.nativeElement.querySelector('[role="list"]');
+    expect(list?.getAttribute('aria-busy')).toBe('true');
+  });
+
+  it('shows error state when scanError is set', () => {
+    fixture.componentRef.setInput('scanInProgress', false);
+    fixture.componentRef.setInput('scanError', 'スキャンに失敗しました');
+    fixture.detectChanges();
+
+    const alert = fixture.nativeElement.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain('スキャンに失敗しました');
+  });
+
+  it('renders column headers and network rows', () => {
+    fixture.componentRef.setInput('wifiInfoList', [sampleNetwork]);
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('SSID');
+    expect(text).toContain('Signal');
+    expect(text).toContain('Security');
+    expect(text).toContain('接続状態');
+    expect(text).toContain('接続操作');
+    expect(text).toContain('cafe-wifi');
+    expect(text).toContain('-57 dBm');
+    expect(text).toContain('WPA2');
+  });
+
+  it('marks selected and connected rows', () => {
+    fixture.componentRef.setInput('wifiInfoList', [sampleNetwork]);
+    fixture.componentRef.setInput('selectedAddress', sampleNetwork.address);
+    fixture.componentRef.setInput('connectedSsid', sampleNetwork.ssid);
+    fixture.detectChanges();
+
+    const row = fixture.nativeElement.querySelector(
+      'choh-wifi-info',
+    ) as HTMLElement;
+    expect(row.getAttribute('aria-selected')).toBe('true');
+    expect(row.classList.contains('bg-blue-50')).toBe(true);
+    expect(fixture.nativeElement.textContent).toContain('接続中');
+  });
+
+  it('exposes full ssid via title for long names', () => {
+    fixture.componentRef.setInput('wifiInfoList', [longSsidNetwork]);
+    fixture.detectChanges();
+
+    const titled = fixture.nativeElement.querySelector(
+      `[title="${longSsidNetwork.ssid}"]`,
+    );
+    expect(titled).toBeTruthy();
+  });
+
+  it('emits networkSelected on row activation', () => {
+    fixture.componentRef.setInput('wifiInfoList', [sampleNetwork]);
+    fixture.detectChanges();
+
+    const selected: WiFiInfo[] = [];
+    component.networkSelected.subscribe((info) => selected.push(info));
+
+    const row = fixture.nativeElement.querySelector(
+      'choh-wifi-info',
+    ) as HTMLElement;
+    row.click();
+    expect(selected).toHaveLength(1);
+    expect(selected[0]?.address).toBe(sampleNetwork.address);
+  });
+
+  it('emits networkConnect from connect button without relying on row click alone', () => {
+    fixture.componentRef.setInput('wifiInfoList', [sampleNetwork]);
+    fixture.detectChanges();
+
+    const connected: WiFiInfo[] = [];
+    component.networkConnect.subscribe((info) => connected.push(info));
+
+    const button = fixture.nativeElement.querySelector(
+      'button',
+    ) as HTMLButtonElement;
+    button.click();
+    expect(connected).toHaveLength(1);
+    expect(connected[0]?.ssid).toBe('cafe-wifi');
   });
 });

--- a/libs/wifi/src/lib/component/wifi-list/wifi-list.component.ts
+++ b/libs/wifi/src/lib/component/wifi-list/wifi-list.component.ts
@@ -1,18 +1,40 @@
 import { Component, input, output } from '@angular/core';
-import { MatDividerModule } from '@angular/material/divider';
 import type { WiFiInfo } from '@libs-shared';
 import { WifiInfoComponent } from '../wifi-info/wifi-info.component';
 
 /**
- * WiFi スキャン結果の一覧表示
+ * WiFi スキャン結果の一覧表示（列ヘッダ付き）
  */
 @Component({
   selector: 'choh-wifi-list',
-  imports: [WifiInfoComponent, MatDividerModule],
+  imports: [WifiInfoComponent],
   templateUrl: './wifi-list.component.html',
 })
 export class WifiListComponent {
   readonly wifiInfoList = input<WiFiInfo[]>([]);
+  readonly scanInProgress = input(false);
+  readonly scanError = input<string | null>(null);
+  readonly selectedAddress = input<string | null>(null);
+  readonly connectedSsid = input<string | null>(null);
+  readonly connectDisabled = input(false);
 
   readonly networkSelected = output<WiFiInfo>();
+  readonly networkConnect = output<WiFiInfo>();
+
+  trackKey(info: WiFiInfo, index: number): string {
+    return `${info.address}\0${info.ssid}\0${index}`;
+  }
+
+  isSelected(info: WiFiInfo): boolean {
+    const address = this.selectedAddress();
+    return address !== null && address === info.address;
+  }
+
+  isConnected(info: WiFiInfo): boolean {
+    const connected = this.connectedSsid()?.trim();
+    if (!connected) {
+      return false;
+    }
+    return (info.ssid?.trim() ?? '') === connected;
+  }
 }

--- a/libs/wifi/src/lib/component/wifi-list/wifi-list.component.ts
+++ b/libs/wifi/src/lib/component/wifi-list/wifi-list.component.ts
@@ -9,6 +9,9 @@ import { WifiInfoComponent } from '../wifi-info/wifi-info.component';
   selector: 'choh-wifi-list',
   imports: [WifiInfoComponent],
   templateUrl: './wifi-list.component.html',
+  host: {
+    class: 'flex min-h-0 flex-1 flex-col',
+  },
 })
 export class WifiListComponent {
   readonly wifiInfoList = input<WiFiInfo[]>([]);

--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.html
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.html
@@ -1,28 +1,39 @@
-<div class="flex min-h-0 h-full justify-center items-center overflow-hidden">
+<div
+  class="flex min-h-0 h-full w-full flex-col items-stretch overflow-hidden p-3 sm:p-4"
+>
   <div
-    class="bg-white flex flex-col gap-4 justify-center items-center p-5 shadow-lg max-h-full min-h-0 w-[95%] overflow-auto"
+    class="flex min-h-0 w-full flex-1 flex-col gap-3 overflow-hidden rounded bg-white p-3 shadow-lg sm:p-5"
   >
-    <choh-wifi-list
-      [wifiInfoList]="wifiInfoList"
-      (networkSelected)="onNetworkSelected($event)"
-    />
-    <mat-divider />
-    <div class="flex flex-wrap gap-2 justify-center w-full">
+    <div class="flex flex-wrap items-center justify-between gap-2">
       <choh-button
-        [label]="'手動で接続'"
-        type="button"
-        (clickEvent)="openConnectDialog()"
-        [disabled]="actionInProgress()"
-      />
-    </div>
-    <mat-divider />
-    <div class="flex flex-wrap gap-2 justify-between w-full">
-      <choh-button
-        [label]="scanInProgress() ? 'スキャン中…' : 'Wifi Scan'"
+        [label]="scanInProgress() ? 'スキャン中…' : '再スキャン'"
         type="button"
         (clickEvent)="runWifiScan()"
         [disabled]="scanInProgress() || actionInProgress()"
       />
+      <choh-button
+        [label]="'手動で接続'"
+        type="button"
+        (clickEvent)="openManualConnectDialog()"
+        [disabled]="actionInProgress()"
+      />
+    </div>
+
+    <choh-wifi-list
+      class="flex min-h-0 flex-1 flex-col"
+      [wifiInfoList]="wifiInfoList()"
+      [scanInProgress]="scanInProgress()"
+      [scanError]="scanError()"
+      [selectedAddress]="selectedAddress()"
+      [connectedSsid]="connectedSsid()"
+      [connectDisabled]="scanInProgress() || actionInProgress()"
+      (networkSelected)="onNetworkSelected($event)"
+      (networkConnect)="onNetworkConnect($event)"
+    />
+
+    <mat-divider />
+
+    <div class="flex flex-wrap gap-2 justify-start w-full">
       <choh-button
         [label]="'Wifi Info'"
         type="button"

--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.spec.ts
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.spec.ts
@@ -1,4 +1,4 @@
-import { computed, signal } from '@angular/core';
+import { computed } from '@angular/core';
 import { Dialog } from '@angular/cdk/dialog';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';

--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.spec.ts
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.spec.ts
@@ -94,7 +94,8 @@ describe('WifiPageComponent', () => {
       wifiInfos,
     });
     await component.runWifiScan();
-    expect(component.wifiInfoList.length).toBe(1);
-    expect(component.wifiInfoList[0]?.ssid).toBe('x');
+    expect(component.wifiInfoList().length).toBe(1);
+    expect(component.wifiInfoList()[0]?.ssid).toBe('x');
   });
 });
+

--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.spec.ts
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.spec.ts
@@ -97,5 +97,47 @@ describe('WifiPageComponent', () => {
     expect(component.wifiInfoList().length).toBe(1);
     expect(component.wifiInfoList()[0]?.ssid).toBe('x');
   });
+
+  it('onNetworkSelected sets selectedAddress without opening dialog', () => {
+    const dialog = TestBed.inject(Dialog);
+    const openSpy = vi.spyOn(dialog, 'open');
+
+    component.onNetworkSelected({
+      ssid: 'home',
+      address: 'AA:BB:CC:DD:EE:FF',
+      channel: 1,
+      frequency: '2.4',
+      quality: '50',
+      spec: 'WPA2',
+    });
+
+    expect(component.selectedAddress()).toBe('AA:BB:CC:DD:EE:FF');
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('onNetworkConnect opens connect dialog with ssid', async () => {
+    const dialog = TestBed.inject(Dialog);
+    const openSpy = vi.spyOn(dialog, 'open');
+
+    component.onNetworkConnect({
+      ssid: 'home',
+      address: 'AA:BB:CC:DD:EE:FF',
+      channel: 1,
+      frequency: '2.4',
+      quality: '50',
+      spec: 'WPA2',
+    });
+
+    expect(component.selectedAddress()).toBe('AA:BB:CC:DD:EE:FF');
+    await fixture.whenStable();
+    expect(openSpy).toHaveBeenCalled();
+  });
+
+  it('runWifiScan sets scanError when scan fails', async () => {
+    scanNetworks.mockRejectedValueOnce(new Error('scan failed'));
+    await component.runWifiScan();
+    expect(component.scanError()).toBe('scan failed');
+  });
 });
+
 

--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.ts
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.ts
@@ -6,6 +6,7 @@ import type { WiFiInfo } from '@libs-shared';
 import { ButtonComponent, NotificationService } from '@libs-shared';
 import { SerialFacadeService } from '@libs-web-serial';
 import { firstValueFrom } from 'rxjs';
+import { parseConnectedSsid } from '../../functions';
 import type { WifiConnectDialogData } from '../../models';
 import { WifiRebootFlowService, WifiScanService } from '../../service';
 import { WifiConnectDialogComponent } from '../wifi-connect-dialog/wifi-connect-dialog.component';
@@ -20,11 +21,17 @@ import { WifiListComponent } from '../wifi-list/wifi-list.component';
   selector: 'choh-wifi-page',
   imports: [ButtonComponent, WifiListComponent, MatDividerModule],
   templateUrl: './wifi-page.component.html',
+  host: {
+    class: 'flex min-h-0 h-full w-full flex-col',
+  },
 })
 export class WifiPageComponent {
-  wifiInfoList: WiFiInfo[] = [];
+  readonly wifiInfoList = signal<WiFiInfo[]>([]);
   readonly scanInProgress = signal(false);
   readonly actionInProgress = signal(false);
+  readonly scanError = signal<string | null>(null);
+  readonly selectedAddress = signal<string | null>(null);
+  readonly connectedSsid = signal<string | null>(null);
 
   private readonly dialog = inject(Dialog);
   private readonly notify = inject(NotificationService);
@@ -41,20 +48,33 @@ export class WifiPageComponent {
     return true;
   }
 
+  private async refreshConnectedSsid(): Promise<void> {
+    try {
+      const { wlInfo } = await this.wifiScan.getWifiStatus();
+      this.connectedSsid.set(parseConnectedSsid(wlInfo));
+    } catch {
+      // 接続中 SSID は補助情報のため、失敗しても一覧表示は継続する
+    }
+  }
+
   async runWifiScan(): Promise<void> {
     if (!(await this.ensureSerial())) {
       return;
     }
     this.scanInProgress.set(true);
+    this.scanError.set(null);
     try {
       const { wifiInfos } = await this.wifiScan.scanNetworks();
-      this.wifiInfoList = wifiInfos;
+      this.wifiInfoList.set(wifiInfos);
+      this.selectedAddress.set(null);
+      await this.refreshConnectedSsid();
       this.notify.success(
         'WiFi',
         `ネットワークを ${wifiInfos.length} 件取得しました`,
       );
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : 'スキャンに失敗しました';
+      this.scanError.set(msg);
       this.notify.error('WiFi', msg);
     } finally {
       this.scanInProgress.set(false);
@@ -74,8 +94,24 @@ export class WifiPageComponent {
   }
 
   onNetworkSelected(info: WiFiInfo): void {
+    this.selectedAddress.set(info.address);
+  }
+
+  onNetworkConnect(info: WiFiInfo): void {
+    this.selectedAddress.set(info.address);
     const ssid = info.ssid?.trim();
     this.openConnectDialog(ssid || undefined);
+  }
+
+  openManualConnectDialog(): void {
+    const address = this.selectedAddress();
+    if (address) {
+      const selected = this.wifiInfoList().find((w) => w.address === address);
+      const ssid = selected?.ssid?.trim();
+      this.openConnectDialog(ssid || undefined);
+      return;
+    }
+    this.openConnectDialog();
   }
 
   async showWifiInfo(): Promise<void> {
@@ -85,6 +121,7 @@ export class WifiPageComponent {
     this.actionInProgress.set(true);
     try {
       const { ipInfo, wlInfo, ipaddr } = await this.wifiScan.getWifiStatus();
+      this.connectedSsid.set(parseConnectedSsid(wlInfo));
       const body = [ipInfo, wlInfo, ipaddr ? `IP: ${ipaddr}` : '']
         .filter(Boolean)
         .join('\n\n');

--- a/libs/wifi/src/lib/functions/wifi-parser.spec.ts
+++ b/libs/wifi/src/lib/functions/wifi-parser.spec.ts
@@ -1,5 +1,11 @@
 /// <reference types="vitest/globals" />
-import { parseWifiIwlistOutput } from './wifi-parser';
+import {
+  formatWifiSecurity,
+  formatWifiSignal,
+  formatWifiSsidLabel,
+  parseConnectedSsid,
+  parseWifiIwlistOutput,
+} from './wifi-parser';
 
 describe('parseWifiIwlistOutput', () => {
   it('parses a minimal iwlist scan fragment', () => {
@@ -17,5 +23,56 @@ describe('parseWifiIwlistOutput', () => {
     expect(first?.ssid).toBe('test-net');
     expect(first?.address).toBe('AA:BB:CC:DD:EE:FF');
     expect(first?.channel).toBe(1);
+  });
+});
+
+describe('parseConnectedSsid', () => {
+  it('extracts ESSID from iwconfig output', () => {
+    const sample = `wlan0     IEEE 802.11  ESSID:"home-net"
+          Mode:Managed  Frequency:2.412 GHz
+`;
+    expect(parseConnectedSsid(sample)).toBe('home-net');
+  });
+
+  it('returns null when ESSID is off/any or empty', () => {
+    expect(parseConnectedSsid('wlan0  ESSID:"off/any"')).toBeNull();
+    expect(parseConnectedSsid('wlan0  ESSID:""')).toBeNull();
+    expect(parseConnectedSsid('no essid here')).toBeNull();
+  });
+});
+
+describe('formatWifiSignal', () => {
+  it('prefers Signal level when present', () => {
+    expect(
+      formatWifiSignal('Quality=53/70  Signal level=-57 dBm'),
+    ).toBe('-57 dBm');
+  });
+
+  it('falls back to Quality fraction', () => {
+    expect(formatWifiSignal('Quality=50/70')).toBe('50/70');
+  });
+
+  it('returns em dash for empty quality', () => {
+    expect(formatWifiSignal('')).toBe('—');
+    expect(formatWifiSignal(null)).toBe('—');
+  });
+});
+
+describe('formatWifiSecurity', () => {
+  it('summarizes WPA2 / WPA / Open', () => {
+    expect(
+      formatWifiSecurity('IEEE 802.11i/WPA2 Version 1,CCMP,CCMPPSK'),
+    ).toBe('WPA2');
+    expect(formatWifiSecurity('WPA Version 1')).toBe('WPA');
+    expect(formatWifiSecurity('')).toBe('Open');
+    expect(formatWifiSecurity(null)).toBe('Open');
+  });
+});
+
+describe('formatWifiSsidLabel', () => {
+  it('returns ssid or hidden label', () => {
+    expect(formatWifiSsidLabel('cafe')).toBe('cafe');
+    expect(formatWifiSsidLabel('')).toBe('（非公開）');
+    expect(formatWifiSsidLabel('   ')).toBe('（非公開）');
   });
 });

--- a/libs/wifi/src/lib/functions/wifi-parser.ts
+++ b/libs/wifi/src/lib/functions/wifi-parser.ts
@@ -114,3 +114,74 @@ export function parseWifiIwconfigOutput(output: string): string {
 
   return wlInfo;
 }
+
+/**
+ * iwconfig 出力から接続中 ESSID を抽出する
+ *
+ * @param output iwconfigコマンドの出力（全体または wlan0 断片）
+ * @returns 接続中 SSID。未接続・不明時は null
+ */
+export function parseConnectedSsid(output: string): string | null {
+  const match = output.match(/ESSID:"([^"]*)"/);
+  if (!match) {
+    return null;
+  }
+  const ssid = match[1].trim();
+  if (!ssid || ssid === 'off/any') {
+    return null;
+  }
+  return ssid;
+}
+
+/**
+ * iwlist quality 行を短い Signal 表示に整形する
+ *
+ * @param quality 例: `Quality=53/70  Signal level=-57 dBm`
+ */
+export function formatWifiSignal(quality: string | undefined | null): string {
+  if (!quality?.trim()) {
+    return '—';
+  }
+  const signalMatch = quality.match(/Signal level=(-?\d+\s*dBm)/i);
+  if (signalMatch) {
+    return signalMatch[1].replace(/\s+/g, ' ').trim();
+  }
+  const qualityMatch = quality.match(/Quality=(\d+\/\d+)/i);
+  if (qualityMatch) {
+    return qualityMatch[1];
+  }
+  return quality.trim();
+}
+
+/**
+ * iwlist spec を短い Security 表示に整形する
+ *
+ * @param spec 例: `IEEE 802.11i/WPA2 Version 1,CCMP,CCMPPSK`
+ */
+export function formatWifiSecurity(spec: string | undefined | null): string {
+  if (!spec?.trim()) {
+    return 'Open';
+  }
+  const upper = spec.toUpperCase();
+  if (upper.includes('WPA3')) {
+    return 'WPA3';
+  }
+  if (upper.includes('WPA2')) {
+    return 'WPA2';
+  }
+  if (upper.includes('WPA')) {
+    return 'WPA';
+  }
+  if (upper.includes('WEP')) {
+    return 'WEP';
+  }
+  return 'Open';
+}
+
+/**
+ * 一覧表示用の SSID ラベル（空は非公開）
+ */
+export function formatWifiSsidLabel(ssid: string | undefined | null): string {
+  const trimmed = ssid?.trim() ?? '';
+  return trimmed.length > 0 ? trimmed : '（非公開）';
+}


### PR DESCRIPTION
## Summary

Wi-Fi 設定画面のアクセスポイント一覧を、固定幅カードの積み上げから列揃えの選択可能リストへ再設計しました。接続中 SSID の識別、スキャン中／空／エラー状態の一覧内表示、Console Shell 中央領域への追従、狭幅時の操作性を改善しています。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #730

## What changed?

- AP 一覧を SSID / Signal / Security / 接続状態 / 接続操作の列ヘッダ付き行 UI に変更
- 行クリックは選択、接続ボタンで既存の接続ダイアログを開くように分離
- スキャン中・空状態・エラー状態を一覧内に表示（`aria-busy` / `role="alert"`）
- 長い SSID の省略表示と接続中バッジを追加
- iwconfig から接続中 ESSID を抽出するヘルパーと Signal / Security 表示整形を追加
- ページパネルを中央領域幅に stretch（固定 `w-[500px]` カードを廃止）。狭幅では Security 列を非表示

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details: `parseConnectedSsid` / `formatWifiSignal` / `formatWifiSecurity` / `formatWifiSsidLabel` を追加（既存パーサの破壊的変更なし）
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. シリアル接続後、ツールバーから WiFi 画面を開き、一覧が中央領域幅に追従することを確認する
2. 「再スキャン」でスキャン中表示 → 結果または空／エラーが一覧内に出ることを確認する
3. 行を選択してハイライトされること、接続中 SSID に「接続中」バッジが出ること（接続済み環境）を確認する
4. 「接続」で既存の接続ダイアログが開くこと、長い SSID が省略され title で全文が見えることを確認する
5. 狭幅ビューポートでも再スキャンと接続操作ができること、キーボードで行フォーカス・選択・接続ボタン到達ができることを確認する
6. `pnpm nx test libs-wifi` / `pnpm nx lint libs-wifi` が通ることを確認する

## Environment (if relevant)

- Browser: Chromium 系（Web Serial）
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)