### PR TITLE
feat(wifi): complete ssid password connect dialog

### DIFF
--- a/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.html
+++ b/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.html
@@ -3,7 +3,13 @@
   <form class="flex flex-col gap-3" (ngSubmit)="$event.preventDefault(); connect()">
     <mat-form-field appearance="outline">
       <mat-label>SSID</mat-label>
-      <input matInput name="ssid" [(ngModel)]="ssid" [disabled]="connecting()" />
+      <input
+        matInput
+        name="ssid"
+        [(ngModel)]="ssid"
+        [disabled]="connecting()"
+        [readonly]="ssidReadonly()"
+      />
     </mat-form-field>
     <mat-form-field appearance="outline">
       <mat-label>パスワード</mat-label>

--- a/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.html
+++ b/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.html
@@ -9,12 +9,27 @@
       <mat-label>パスワード</mat-label>
       <input
         matInput
-        type="password"
+        [type]="passwordVisible() ? 'text' : 'password'"
         name="password"
         [(ngModel)]="password"
         [disabled]="connecting()"
         autocomplete="off"
       />
+      <button
+        mat-icon-button
+        matSuffix
+        type="button"
+        (click)="togglePasswordVisibility()"
+        [disabled]="connecting()"
+        [attr.aria-label]="
+          passwordVisible() ? 'パスワードを隠す' : 'パスワードを表示'
+        "
+        [attr.aria-pressed]="passwordVisible()"
+      >
+        <mat-icon>{{
+          passwordVisible() ? 'visibility_off' : 'visibility'
+        }}</mat-icon>
+      </button>
     </mat-form-field>
     <div class="flex justify-end gap-2">
       <button

--- a/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.html
+++ b/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.html
@@ -31,6 +31,16 @@
         }}</mat-icon>
       </button>
     </mat-form-field>
+    @if (feedback(); as fb) {
+      <p
+        class="m-0 text-sm"
+        [class.text-red-700]="fb.kind === 'error'"
+        [class.text-green-700]="fb.kind === 'success'"
+        role="status"
+      >
+        {{ fb.message }}
+      </p>
+    }
     <div class="flex justify-end gap-2">
       <button
         mat-stroked-button

--- a/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.spec.ts
+++ b/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.spec.ts
@@ -1,0 +1,128 @@
+/// <reference types="vitest/globals" />
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { NotificationService } from '@libs-shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WifiConnectError } from '../../functions';
+import { WifiConfigService } from '../../service';
+import { WifiConnectDialogComponent } from './wifi-connect-dialog.component';
+
+describe('WifiConnectDialogComponent', () => {
+  let component: WifiConnectDialogComponent;
+  let fixture: ComponentFixture<WifiConnectDialogComponent>;
+  let setWiFi: ReturnType<typeof vi.fn>;
+  let dialogRef: {
+    close: ReturnType<typeof vi.fn>;
+    disableClose: boolean;
+  };
+  let notify: {
+    success: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    setWiFi = vi.fn().mockResolvedValue(undefined);
+    dialogRef = {
+      close: vi.fn(),
+      disableClose: false,
+    };
+    notify = {
+      success: vi.fn(),
+      error: vi.fn(),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [WifiConnectDialogComponent, NoopAnimationsModule],
+      providers: [
+        { provide: DialogRef, useValue: dialogRef },
+        {
+          provide: DIALOG_DATA,
+          useValue: { initialSsid: 'home-net', ssidReadonly: true },
+        },
+        { provide: WifiConfigService, useValue: { setWiFi } },
+        { provide: NotificationService, useValue: notify },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WifiConnectDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create with initial ssid readonly', () => {
+    expect(component.ssid).toBe('home-net');
+    expect(component.ssidReadonly()).toBe(true);
+  });
+
+  it('toggles password visibility', () => {
+    expect(component.passwordVisible()).toBe(false);
+    component.togglePasswordVisibility();
+    expect(component.passwordVisible()).toBe(true);
+    component.togglePasswordVisibility();
+    expect(component.passwordVisible()).toBe(false);
+  });
+
+  it('clears password and closes on cancel', () => {
+    component.password = 'secret';
+    component.cancel();
+    expect(component.password).toBe('');
+    expect(dialogRef.close).toHaveBeenCalledWith(false);
+  });
+
+  it('does not cancel while connecting', () => {
+    component.connecting.set(true);
+    component.password = 'secret';
+    component.cancel();
+    expect(component.password).toBe('secret');
+    expect(dialogRef.close).not.toHaveBeenCalled();
+  });
+
+  it('prevents double submit while connecting', async () => {
+    let resolveSet!: () => void;
+    setWiFi.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveSet = resolve;
+      }),
+    );
+    component.password = 'pw';
+    const first = component.connect();
+    const second = component.connect();
+    await Promise.resolve();
+    expect(setWiFi).toHaveBeenCalledTimes(1);
+    resolveSet();
+    await first;
+    await second;
+  });
+
+  it('shows auth failure message without closing', async () => {
+    setWiFi.mockRejectedValueOnce(
+      new WifiConnectError(
+        'auth',
+        '認証に失敗しました。パスワードを確認してください',
+      ),
+    );
+    component.password = 'bad';
+    await component.connect();
+    expect(component.feedback()?.kind).toBe('error');
+    expect(component.feedback()?.message).toContain('認証に失敗');
+    expect(dialogRef.close).not.toHaveBeenCalled();
+    expect(dialogRef.disableClose).toBe(false);
+  });
+
+  it('shows command failure message', async () => {
+    setWiFi.mockRejectedValueOnce(
+      new WifiConnectError('command', '接続コマンドの実行に失敗しました'),
+    );
+    await component.connect();
+    expect(component.feedback()?.message).toContain('接続コマンド');
+  });
+
+  it('closes with true and clears password on success', async () => {
+    component.password = 'ok';
+    await component.connect();
+    expect(notify.success).toHaveBeenCalled();
+    expect(dialogRef.close).toHaveBeenCalledWith(true);
+    expect(component.password).toBe('');
+  });
+});

--- a/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.ts
+++ b/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.ts
@@ -36,6 +36,7 @@ export class WifiConnectDialogComponent implements OnInit {
 
   ssid = '';
   password = '';
+  readonly ssidReadonly = signal(false);
   readonly connecting = signal(false);
   readonly passwordVisible = signal(false);
   readonly feedback = signal<{
@@ -45,6 +46,7 @@ export class WifiConnectDialogComponent implements OnInit {
 
   ngOnInit(): void {
     this.ssid = this.data?.initialSsid?.trim() ?? '';
+    this.ssidReadonly.set(Boolean(this.data?.ssidReadonly && this.ssid));
   }
 
   togglePasswordVisibility(): void {
@@ -52,6 +54,11 @@ export class WifiConnectDialogComponent implements OnInit {
   }
 
   cancel(): void {
+    if (this.connecting()) {
+      return;
+    }
+    this.password = '';
+    this.feedback.set(null);
     this.dialogRef.close(false);
   }
 
@@ -68,12 +75,14 @@ export class WifiConnectDialogComponent implements OnInit {
       return;
     }
     this.connecting.set(true);
+    this.dialogRef.disableClose = true;
     this.feedback.set(null);
     try {
       await this.wifiConfig.setWiFi(trimmed, this.password);
       const successMessage = '接続処理が完了しました';
       this.feedback.set({ kind: 'success', message: successMessage });
       this.notify.success('WiFi', successMessage);
+      this.password = '';
       this.dialogRef.close(true);
     } catch (e: unknown) {
       const wifiError =
@@ -83,6 +92,7 @@ export class WifiConnectDialogComponent implements OnInit {
       this.notify.error('WiFi', msg);
     } finally {
       this.connecting.set(false);
+      this.dialogRef.disableClose = false;
     }
   }
 }

--- a/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.ts
+++ b/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.ts
@@ -1,8 +1,9 @@
 import { Component, inject, OnInit, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
-import { MatButtonModule } from '@angular/material/button';
+import { MatButtonModule, MatIconButton } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIcon } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { NotificationService } from '@libs-shared';
 import type { WifiConnectDialogData } from '../../models';
@@ -10,7 +11,14 @@ import { WifiConfigService } from '../../service';
 
 @Component({
   selector: 'choh-wifi-connect-dialog',
-  imports: [FormsModule, MatFormFieldModule, MatInputModule, MatButtonModule],
+  imports: [
+    FormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconButton,
+    MatIcon,
+  ],
   templateUrl: './wifi-connect-dialog.component.html',
 })
 export class WifiConnectDialogComponent implements OnInit {
@@ -24,9 +32,14 @@ export class WifiConnectDialogComponent implements OnInit {
   ssid = '';
   password = '';
   readonly connecting = signal(false);
+  readonly passwordVisible = signal(false);
 
   ngOnInit(): void {
     this.ssid = this.data?.initialSsid?.trim() ?? '';
+  }
+
+  togglePasswordVisibility(): void {
+    this.passwordVisible.update((v) => !v);
   }
 
   cancel(): void {

--- a/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.ts
+++ b/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.ts
@@ -6,6 +6,11 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIcon } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { NotificationService } from '@libs-shared';
+import {
+  messageForWifiConnectKind,
+  toWifiConnectError,
+  WifiConnectError,
+} from '../../functions';
 import type { WifiConnectDialogData } from '../../models';
 import { WifiConfigService } from '../../service';
 
@@ -33,6 +38,10 @@ export class WifiConnectDialogComponent implements OnInit {
   password = '';
   readonly connecting = signal(false);
   readonly passwordVisible = signal(false);
+  readonly feedback = signal<{
+    kind: 'success' | 'error';
+    message: string;
+  } | null>(null);
 
   ngOnInit(): void {
     this.ssid = this.data?.initialSsid?.trim() ?? '';
@@ -49,16 +58,28 @@ export class WifiConnectDialogComponent implements OnInit {
   async connect(): Promise<void> {
     const trimmed = this.ssid.trim();
     if (!trimmed) {
-      this.notify.error('WiFi', 'SSID を入力してください');
+      this.feedback.set({
+        kind: 'error',
+        message: 'SSID を入力してください',
+      });
+      return;
+    }
+    if (this.connecting()) {
       return;
     }
     this.connecting.set(true);
+    this.feedback.set(null);
     try {
       await this.wifiConfig.setWiFi(trimmed, this.password);
-      this.notify.success('WiFi', '接続処理が完了しました');
+      const successMessage = '接続処理が完了しました';
+      this.feedback.set({ kind: 'success', message: successMessage });
+      this.notify.success('WiFi', successMessage);
       this.dialogRef.close(true);
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : '接続に失敗しました';
+      const wifiError =
+        e instanceof WifiConnectError ? e : toWifiConnectError(e);
+      const msg = messageForWifiConnectKind(wifiError.kind);
+      this.feedback.set({ kind: 'error', message: msg });
       this.notify.error('WiFi', msg);
     } finally {
       this.connecting.set(false);

--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.spec.ts
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.spec.ts
@@ -1,7 +1,7 @@
 import { computed } from '@angular/core';
 import { Dialog } from '@angular/cdk/dialog';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NotificationService } from '@libs-shared';
 import { WifiRebootFlowService } from '../../service';
@@ -16,11 +16,14 @@ describe('WifiPageComponent', () => {
 
   const scanNetworks = vi.fn();
 
+  let dialogClosed: ReturnType<typeof of>;
+
   beforeEach(async () => {
     scanNetworks.mockResolvedValue({
       wifiInfos: [] as WiFiInfo[],
       rawData: [] as string[],
     });
+    dialogClosed = of(undefined);
 
     await TestBed.configureTestingModule({
       imports: [WifiPageComponent],
@@ -28,7 +31,7 @@ describe('WifiPageComponent', () => {
         {
           provide: Dialog,
           useValue: {
-            open: vi.fn().mockReturnValue({ closed: of(undefined) }),
+            open: vi.fn().mockImplementation(() => ({ closed: dialogClosed })),
           },
         },
         {
@@ -131,6 +134,64 @@ describe('WifiPageComponent', () => {
     expect(component.selectedAddress()).toBe('AA:BB:CC:DD:EE:FF');
     await fixture.whenStable();
     expect(openSpy).toHaveBeenCalled();
+    expect(openSpy.mock.calls[0]?.[1]?.data).toEqual({
+      initialSsid: 'home',
+      ssidReadonly: true,
+    });
+  });
+
+  it('refreshes scan after successful connect dialog close', async () => {
+    const closed$ = new Subject<boolean | undefined>();
+    const dialog = TestBed.inject(Dialog);
+    const openSpy = vi.spyOn(dialog, 'open').mockReturnValue({
+      closed: closed$.asObservable(),
+    } as ReturnType<Dialog['open']>);
+
+    const wifiInfos: WiFiInfo[] = [
+      {
+        ssid: 'home',
+        address: 'AA:BB:CC:DD:EE:FF',
+        channel: 1,
+        frequency: '2.4',
+        quality: '50',
+        spec: 'WPA2',
+      },
+    ];
+    scanNetworks.mockClear();
+    scanNetworks.mockResolvedValue({
+      rawData: [] as string[],
+      wifiInfos,
+    });
+
+    component.openConnectDialog('home', true);
+    await vi.waitFor(() => {
+      expect(openSpy).toHaveBeenCalled();
+    });
+    closed$.next(true);
+    closed$.complete();
+    await vi.waitFor(() => {
+      expect(component.wifiInfoList()).toEqual(wifiInfos);
+    });
+    expect(scanNetworks).toHaveBeenCalled();
+  });
+
+  it('does not refresh scan when connect dialog is cancelled', async () => {
+    const closed$ = new Subject<boolean | undefined>();
+    const dialog = TestBed.inject(Dialog);
+    const openSpy = vi.spyOn(dialog, 'open').mockReturnValue({
+      closed: closed$.asObservable(),
+    } as ReturnType<Dialog['open']>);
+    scanNetworks.mockClear();
+
+    component.openConnectDialog('home');
+    await vi.waitFor(() => {
+      expect(openSpy).toHaveBeenCalled();
+    });
+    closed$.next(false);
+    closed$.complete();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(scanNetworks).not.toHaveBeenCalled();
   });
 
   it('runWifiScan sets scanError when scan fails', async () => {

--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.ts
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.ts
@@ -81,14 +81,15 @@ export class WifiPageComponent {
     }
   }
 
-  openConnectDialog(initialSsid?: string): void {
+  openConnectDialog(initialSsid?: string, ssidReadonly = false): void {
     void (async () => {
       if (!(await this.ensureSerial())) {
         return;
       }
       const ref = this.dialog.open(WifiConnectDialogComponent, {
         width: '400px',
-        data: { initialSsid } satisfies WifiConnectDialogData,
+        disableClose: false,
+        data: { initialSsid, ssidReadonly } satisfies WifiConnectDialogData,
       });
       const ok = await firstValueFrom(ref.closed);
       if (ok) {
@@ -124,7 +125,7 @@ export class WifiPageComponent {
   onNetworkConnect(info: WiFiInfo): void {
     this.selectedAddress.set(info.address);
     const ssid = info.ssid?.trim();
-    this.openConnectDialog(ssid || undefined);
+    this.openConnectDialog(ssid || undefined, Boolean(ssid));
   }
 
   openManualConnectDialog(): void {
@@ -132,7 +133,7 @@ export class WifiPageComponent {
     if (address) {
       const selected = this.wifiInfoList().find((w) => w.address === address);
       const ssid = selected?.ssid?.trim();
-      this.openConnectDialog(ssid || undefined);
+      this.openConnectDialog(ssid || undefined, Boolean(ssid));
       return;
     }
     this.openConnectDialog();

--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.ts
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.ts
@@ -86,11 +86,35 @@ export class WifiPageComponent {
       if (!(await this.ensureSerial())) {
         return;
       }
-      this.dialog.open(WifiConnectDialogComponent, {
+      const ref = this.dialog.open(WifiConnectDialogComponent, {
         width: '400px',
         data: { initialSsid } satisfies WifiConnectDialogData,
       });
+      const ok = await firstValueFrom(ref.closed);
+      if (ok) {
+        await this.refreshAfterConnect();
+      }
     })();
+  }
+
+  /**
+   * 接続成功後に一覧と接続中 SSID を更新する（成功トーストはダイアログ側）。
+   */
+  private async refreshAfterConnect(): Promise<void> {
+    this.scanInProgress.set(true);
+    this.scanError.set(null);
+    try {
+      const { wifiInfos } = await this.wifiScan.scanNetworks();
+      this.wifiInfoList.set(wifiInfos);
+      await this.refreshConnectedSsid();
+    } catch (e: unknown) {
+      const msg =
+        e instanceof Error ? e.message : '接続後の一覧更新に失敗しました';
+      this.scanError.set(msg);
+      this.notify.error('WiFi', msg);
+    } finally {
+      this.scanInProgress.set(false);
+    }
   }
 
   onNetworkSelected(info: WiFiInfo): void {

--- a/libs/wifi/src/lib/functions/index.ts
+++ b/libs/wifi/src/lib/functions/index.ts
@@ -1,3 +1,4 @@
 export * from './file.utils';
 export * from './shell-quote';
+export * from './wifi-connect-error';
 export * from './wifi-parser';

--- a/libs/wifi/src/lib/functions/wifi-connect-error.spec.ts
+++ b/libs/wifi/src/lib/functions/wifi-connect-error.spec.ts
@@ -1,0 +1,67 @@
+/// <reference types="vitest/globals" />
+import {
+  classifyWifiConnectFailure,
+  messageForWifiConnectKind,
+  toWifiConnectError,
+  WifiConnectError,
+  wifiConnectErrorFromOutput,
+} from './wifi-connect-error';
+
+describe('classifyWifiConnectFailure', () => {
+  it('detects nmcli secrets / auth style messages as auth', () => {
+    expect(
+      classifyWifiConnectFailure(
+        'Error: Connection activation failed: Secrets were required, but not provided.',
+      ),
+    ).toBe('auth');
+    expect(
+      classifyWifiConnectFailure('802-11-wireless-security property invalid'),
+    ).toBe('auth');
+    expect(classifyWifiConnectFailure('wrong password')).toBe('auth');
+  });
+
+  it('treats generic failures as command', () => {
+    expect(classifyWifiConnectFailure('WIFI_CONNECT_FAILED')).toBe('command');
+    expect(classifyWifiConnectFailure('Command execution timeout')).toBe(
+      'command',
+    );
+  });
+});
+
+describe('wifiConnectErrorFromOutput', () => {
+  it('returns null when output has no failure markers', () => {
+    expect(wifiConnectErrorFromOutput('Device wlan0 successfully activated')).toBeNull();
+    expect(wifiConnectErrorFromOutput('')).toBeNull();
+  });
+
+  it('returns auth error for secrets required', () => {
+    const err = wifiConnectErrorFromOutput(
+      'Error: Connection activation failed: Secrets were required, but not provided.\nWIFI_CONNECT_FAILED',
+    );
+    expect(err).toBeInstanceOf(WifiConnectError);
+    expect(err?.kind).toBe('auth');
+    expect(err?.message).toBe(messageForWifiConnectKind('auth'));
+  });
+
+  it('returns command error for WIFI_CONNECT_FAILED alone', () => {
+    const err = wifiConnectErrorFromOutput('WIFI_CONNECT_FAILED');
+    expect(err?.kind).toBe('command');
+    expect(err?.message).toBe(messageForWifiConnectKind('command'));
+  });
+});
+
+describe('toWifiConnectError', () => {
+  it('preserves WifiConnectError instances', () => {
+    const original = new WifiConnectError('auth', 'x');
+    expect(toWifiConnectError(original)).toBe(original);
+  });
+
+  it('maps unknown errors without leaking raw secrets into message', () => {
+    const err = toWifiConnectError(
+      new Error('Failed to set WiFi: password=supersecret timeout'),
+    );
+    expect(err.kind).toBe('command');
+    expect(err.message).toBe(messageForWifiConnectKind('command'));
+    expect(err.message).not.toContain('supersecret');
+  });
+});

--- a/libs/wifi/src/lib/functions/wifi-connect-error.ts
+++ b/libs/wifi/src/lib/functions/wifi-connect-error.ts
@@ -1,0 +1,72 @@
+export type WifiConnectErrorKind = 'auth' | 'command';
+
+export class WifiConnectError extends Error {
+  readonly kind: WifiConnectErrorKind;
+
+  constructor(kind: WifiConnectErrorKind, message: string) {
+    super(message);
+    this.name = 'WifiConnectError';
+    this.kind = kind;
+  }
+}
+
+const AUTH_PATTERNS: RegExp[] = [
+  /secrets were required/i,
+  /802-11-wireless-security/i,
+  /wrong password/i,
+  /authentication\s*(failed|error|reject)/i,
+  /invalid.*(?:password|psk)/i,
+  /psk.*(?:reject|fail)/i,
+  /(?:password|psk).*(?:incorrect|invalid|fail)/i,
+  /association timed? ?out/i,
+];
+
+const FAILURE_MARKERS: RegExp[] = [
+  /WIFI_CONNECT_FAILED/i,
+  /\bError:/i,
+  /Connection activation failed/i,
+];
+
+export function classifyWifiConnectFailure(raw: string): WifiConnectErrorKind {
+  if (AUTH_PATTERNS.some((pattern) => pattern.test(raw))) {
+    return 'auth';
+  }
+  return 'command';
+}
+
+export function isWifiConnectFailureOutput(raw: string): boolean {
+  return FAILURE_MARKERS.some((pattern) => pattern.test(raw));
+}
+
+export function messageForWifiConnectKind(kind: WifiConnectErrorKind): string {
+  if (kind === 'auth') {
+    return '認証に失敗しました。パスワードを確認してください';
+  }
+  return '接続コマンドの実行に失敗しました';
+}
+
+/**
+ * シリアル出力から接続失敗を検出する。失敗でなければ null。
+ * ユーザー向け文言に SSID / Password を含めない。
+ */
+export function wifiConnectErrorFromOutput(
+  output: string,
+): WifiConnectError | null {
+  if (!output.trim() || !isWifiConnectFailureOutput(output)) {
+    return null;
+  }
+  const kind = classifyWifiConnectFailure(output);
+  return new WifiConnectError(kind, messageForWifiConnectKind(kind));
+}
+
+/**
+ * catch した unknown を WifiConnectError に正規化する。
+ */
+export function toWifiConnectError(error: unknown): WifiConnectError {
+  if (error instanceof WifiConnectError) {
+    return error;
+  }
+  const raw = error instanceof Error ? error.message : String(error);
+  const kind = classifyWifiConnectFailure(raw);
+  return new WifiConnectError(kind, messageForWifiConnectKind(kind));
+}

--- a/libs/wifi/src/lib/models/wifi-connect-dialog.types.ts
+++ b/libs/wifi/src/lib/models/wifi-connect-dialog.types.ts
@@ -1,3 +1,5 @@
 export interface WifiConnectDialogData {
   initialSsid?: string;
+  /** 一覧から渡した SSID を読み取り専用にする */
+  ssidReadonly?: boolean;
 }

--- a/libs/wifi/src/lib/service/wifi-config.service.ts
+++ b/libs/wifi/src/lib/service/wifi-config.service.ts
@@ -3,6 +3,11 @@ import { FileContentService } from './file-content.service';
 import { SerialFacadeService } from '@libs-web-serial';
 import { FileUtils } from '../functions';
 import { shellSingleQuote } from '../functions';
+import {
+  toWifiConnectError,
+  WifiConnectError,
+  wifiConnectErrorFromOutput,
+} from '../functions';
 import { WifiRebootFlowService } from './wifi-reboot-flow.service';
 import {
   PI_ZERO_PROMPT,
@@ -42,15 +47,33 @@ export class WifiConfigService {
 
       const qSsid = shellSingleQuote(ssid);
       const qPass = shellSingleQuote(password);
-      await firstValueFrom(this.serial.exec$(
+      const result = await firstValueFrom(this.serial.exec$(
         `chmod +x wifi_setup.sh && ./wifi_setup.sh ${qSsid} ${qPass}`,
         {
           prompt: PI_ZERO_PROMPT,
           timeout: SERIAL_TIMEOUT.LONG,
         }
       ));
+
+      const output = [result.stdout, result.stderr]
+        .filter((part): part is string => Boolean(part))
+        .join('\n');
+      const fromOutput = wifiConnectErrorFromOutput(output);
+      if (fromOutput) {
+        throw fromOutput;
+      }
+      if (result.exitCode != null && result.exitCode !== 0) {
+        throw toWifiConnectError(
+          new Error(`wifi_setup.sh exited with code ${result.exitCode}`),
+        );
+      }
     } catch (error: unknown) {
-      throw wrapSerialError('Failed to set WiFi', error);
+      if (error instanceof WifiConnectError) {
+        throw error;
+      }
+      throw toWifiConnectError(
+        wrapSerialError('Failed to set WiFi', error),
+      );
     }
   }
 
@@ -88,9 +111,15 @@ network={
   psk="$PASSWORD"
 }
 EOL
-  sudo wpa_cli -i wlan0 reconfigure
+  if ! sudo wpa_cli -i wlan0 reconfigure; then
+    echo "WIFI_CONNECT_FAILED"
+    exit 1
+  fi
 else
-  sudo nmcli dev wifi connect "$SSID" password "$PASSWORD"
+  if ! sudo nmcli dev wifi connect "$SSID" password "$PASSWORD"; then
+    echo "WIFI_CONNECT_FAILED"
+    exit 1
+  fi
 fi
 `;
   }


### PR DESCRIPTION
## Summary

SSID 選択後の Wi-Fi 接続ダイアログを Issue #731 の要件まで完成させました。パスワード表示切替、認証失敗とコマンド失敗の区別、接続成功後の一覧・接続状態更新、busy 中の Escape 防止などを `libs/wifi` に実装しています。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #731

## What changed?

- 接続ダイアログにパスワード表示／非表示トグルを追加
- 一覧から渡した SSID を読み取り専用表示にし、キャンセル時はパスワードを破棄
- 接続処理中は二重送信を防ぎ、`disableClose` で Escape による中断を防止
- `nmcli` 等の出力から認証失敗とコマンド実行失敗を区別し、ダイアログ内とトーストで日本語メッセージを表示
- 接続成功後に AP 一覧と接続中 SSID を再取得
- Password をユーザー向けメッセージや永続ストレージに含めないよう維持
- 接続ダイアログ・エラー分類・成功後リフレッシュのユニットテストを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. シリアル接続後、Wi-Fi 画面で再スキャンする
2. 一覧の「接続」からダイアログを開き、SSID が読み取り専用で入っていることを確認する
3. パスワード表示切替、Enter での接続、キャンセルでの入力破棄を確認する
4. 誤ったパスワードで認証失敗メッセージが出ること、接続中に Escape で閉じられないことを確認する
5. 接続成功後、一覧の接続状態と接続中 SSID が更新されることを確認する
6. ローカルで `pnpm nx test libs-wifi` / `pnpm nx lint libs-wifi` を実行する

## Environment (if relevant)

- Browser: Chromium 系（Web Serial 対応）
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)