### PR TITLE
feat(wifi): add reboot flow after wifi connect success

### DIFF
--- a/libs/web-serial/src/index.ts
+++ b/libs/web-serial/src/index.ts
@@ -11,6 +11,7 @@ export * from './lib/service/pi-zero-session.service';
 export * from './lib/service/pi-zero-serial-bootstrap.service';
 export * from './lib/service/pi-zero-shell-readiness.service';
 export * from './lib/service/serial-facade.service';
+export * from './lib/service/serial-expected-disconnect.service';
 export * from './lib/service/serial-notification.service';
 export * from './lib/service/serial-connection-view-model.facade';
 export * from './lib/service/terminal-command-request.service';

--- a/libs/web-serial/src/lib/service/index.ts
+++ b/libs/web-serial/src/lib/service/index.ts
@@ -7,6 +7,7 @@ export * from './serial-command/serial-command-pipeline.service';
 export * from './serial-command/serial-prompt-match';
 export * from './serial-connection-orchestration.service';
 export * from './serial-connection-view-model.facade';
+export * from './serial-expected-disconnect.service';
 export * from './serial-facade.service';
 export * from './serial-notification.service';
 export * from './serial-transport.service';

--- a/libs/web-serial/src/lib/service/serial-connection-view-model.facade.ts
+++ b/libs/web-serial/src/lib/service/serial-connection-view-model.facade.ts
@@ -14,6 +14,7 @@ import { firstValueFrom } from 'rxjs';
 import { PiZeroSessionService } from './pi-zero-session.service';
 import { PiZeroShellReadinessService } from './pi-zero-shell-readiness.service';
 import type { SerialSetupStatus } from '../models';
+import { SerialExpectedDisconnectService } from './serial-expected-disconnect.service';
 import { SerialFacadeService } from './serial-facade.service';
 import { SerialNotificationService } from './serial-notification.service';
 
@@ -46,6 +47,9 @@ export class SerialConnectionViewModelFacade {
   private readonly piZero = inject(PiZeroSessionService);
   private readonly shellReadiness = inject(PiZeroShellReadinessService);
   private readonly notifications = inject(SerialNotificationService);
+  private readonly expectedDisconnect = inject(
+    SerialExpectedDisconnectService,
+  );
   private readonly terminalCommandRequests = inject(
     TerminalCommandRequestService,
   );
@@ -118,6 +122,8 @@ export class SerialConnectionViewModelFacade {
       const result = await firstValueFrom(this.serial.connect$(baudRate));
       if (result.ok) {
         this.errorMessageSignal.set(null);
+        // 再接続成功で想定切断フラグを解除（#732）
+        this.expectedDisconnect.clearExpectedDisconnect();
         this.notifications.notifyConnectionSuccess();
       } else {
         this.errorMessageSignal.set(result.errorMessage);

--- a/libs/web-serial/src/lib/service/serial-expected-disconnect.service.spec.ts
+++ b/libs/web-serial/src/lib/service/serial-expected-disconnect.service.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { SerialExpectedDisconnectService } from './serial-expected-disconnect.service';
+
+describe('SerialExpectedDisconnectService', () => {
+  it('beginExpectedDisconnect sets reason and isExpectedDisconnect', () => {
+    const service = new SerialExpectedDisconnectService();
+
+    expect(service.isExpectedDisconnect()).toBe(false);
+    expect(service.reason()).toBeNull();
+
+    service.beginExpectedDisconnect('reboot');
+
+    expect(service.isExpectedDisconnect()).toBe(true);
+    expect(service.isExpectedDisconnect('reboot')).toBe(true);
+    expect(service.reason()).toBe('reboot');
+  });
+
+  it('clearExpectedDisconnect clears the flag', () => {
+    const service = new SerialExpectedDisconnectService();
+    service.beginExpectedDisconnect('reboot');
+    service.clearExpectedDisconnect();
+
+    expect(service.isExpectedDisconnect()).toBe(false);
+    expect(service.reason()).toBeNull();
+  });
+});

--- a/libs/web-serial/src/lib/service/serial-expected-disconnect.service.ts
+++ b/libs/web-serial/src/lib/service/serial-expected-disconnect.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, signal } from '@angular/core';
+
+/** アプリが意図して切断を待つ理由（再起動など）。 */
+export type SerialExpectedDisconnectReason = 'reboot';
+
+/**
+ * 意図した切断と通信エラーを区別するための共有フラグ（#732）。
+ *
+ * 再起動コマンド送信前に {@link beginExpectedDisconnect} し、
+ * クリーンアップ完了後に {@link clearExpectedDisconnect} する。
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class SerialExpectedDisconnectService {
+  private readonly reasonSignal =
+    signal<SerialExpectedDisconnectReason | null>(null);
+
+  readonly reason = this.reasonSignal.asReadonly();
+
+  beginExpectedDisconnect(reason: SerialExpectedDisconnectReason): void {
+    this.reasonSignal.set(reason);
+  }
+
+  clearExpectedDisconnect(): void {
+    this.reasonSignal.set(null);
+  }
+
+  isExpectedDisconnect(
+    reason?: SerialExpectedDisconnectReason,
+  ): boolean {
+    const current = this.reasonSignal();
+    if (current === null) {
+      return false;
+    }
+    return reason === undefined ? true : current === reason;
+  }
+}

--- a/libs/web-serial/src/lib/service/serial-notification.service.spec.ts
+++ b/libs/web-serial/src/lib/service/serial-notification.service.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { SerialExpectedDisconnectService } from './serial-expected-disconnect.service';
 import { SerialNotificationService } from './serial-notification.service';
 
 describe('SerialNotificationService', () => {
@@ -10,6 +11,11 @@ describe('SerialNotificationService', () => {
     (
       service as unknown as { toastr: { error: typeof error } }
     ).toastr = { error };
+    (
+      service as unknown as {
+        expectedDisconnect: SerialExpectedDisconnectService;
+      }
+    ).expectedDisconnect = new SerialExpectedDisconnectService();
 
     service.notifyAutoLoginFailed('Shell readiness timeout');
 
@@ -17,6 +23,51 @@ describe('SerialNotificationService', () => {
       'オートログインに失敗しました: Shell readiness timeout',
       'ログインエラー',
       { timeOut: 8000 },
+    );
+  });
+
+  it('notifyConnectionError is suppressed during expected disconnect', () => {
+    const error = vi.fn();
+    const expectedDisconnect = new SerialExpectedDisconnectService();
+    expectedDisconnect.beginExpectedDisconnect('reboot');
+
+    const service = Object.create(
+      SerialNotificationService.prototype,
+    ) as SerialNotificationService;
+    (
+      service as unknown as { toastr: { error: typeof error } }
+    ).toastr = { error };
+    (
+      service as unknown as {
+        expectedDisconnect: SerialExpectedDisconnectService;
+      }
+    ).expectedDisconnect = expectedDisconnect;
+
+    service.notifyConnectionError('port closed');
+
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('notifyConnectionError shows toast when disconnect is not expected', () => {
+    const error = vi.fn();
+    const service = Object.create(
+      SerialNotificationService.prototype,
+    ) as SerialNotificationService;
+    (
+      service as unknown as { toastr: { error: typeof error } }
+    ).toastr = { error };
+    (
+      service as unknown as {
+        expectedDisconnect: SerialExpectedDisconnectService;
+      }
+    ).expectedDisconnect = new SerialExpectedDisconnectService();
+
+    service.notifyConnectionError('port busy');
+
+    expect(error).toHaveBeenCalledWith(
+      'Web Serial接続エラー: port busy',
+      '接続エラー',
+      { timeOut: 5000 },
     );
   });
 });

--- a/libs/web-serial/src/lib/service/serial-notification.service.ts
+++ b/libs/web-serial/src/lib/service/serial-notification.service.ts
@@ -1,12 +1,16 @@
 /** Full rewrite (#606). Toasts only; I/O stays in {@link SerialFacadeService}. */
 import { inject, Injectable } from '@angular/core';
 import { ToastrService } from 'ngx-toastr';
+import { SerialExpectedDisconnectService } from './serial-expected-disconnect.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class SerialNotificationService {
   private toastr = inject(ToastrService);
+  private readonly expectedDisconnect = inject(
+    SerialExpectedDisconnectService,
+  );
 
   /**
    * Web Serial接続成功時の通知
@@ -22,6 +26,10 @@ export class SerialNotificationService {
    * @param errorMessage エラーメッセージ
    */
   notifyConnectionError(errorMessage: string): void {
+    // 再起動など意図した切断中はエラー扱いしない（#732）
+    if (this.expectedDisconnect.isExpectedDisconnect()) {
+      return;
+    }
     this.toastr.error(
       `Web Serial接続エラー: ${errorMessage}`,
       '接続エラー',

--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.html
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.html
@@ -9,13 +9,13 @@
         [label]="scanInProgress() ? 'スキャン中…' : '再スキャン'"
         type="button"
         (clickEvent)="runWifiScan()"
-        [disabled]="scanInProgress() || actionInProgress()"
+        [disabled]="scanInProgress() || busy()"
       />
       <choh-button
         [label]="'手動で接続'"
         type="button"
         (clickEvent)="openManualConnectDialog()"
-        [disabled]="actionInProgress()"
+        [disabled]="busy()"
       />
     </div>
 
@@ -26,7 +26,7 @@
       [scanError]="scanError()"
       [selectedAddress]="selectedAddress()"
       [connectedSsid]="connectedSsid()"
-      [connectDisabled]="scanInProgress() || actionInProgress()"
+      [connectDisabled]="scanInProgress() || busy()"
       (networkSelected)="onNetworkSelected($event)"
       (networkConnect)="onNetworkConnect($event)"
     />
@@ -38,25 +38,25 @@
         [label]="'Wifi Info'"
         type="button"
         (clickEvent)="showWifiInfo()"
-        [disabled]="scanInProgress() || actionInProgress()"
+        [disabled]="scanInProgress() || busy()"
       />
       <choh-button
         [label]="'疎通確認'"
         type="button"
         (clickEvent)="checkConnectivity()"
-        [disabled]="scanInProgress() || actionInProgress()"
+        [disabled]="scanInProgress() || busy()"
       />
       <choh-button
         [label]="'Reset Wifi'"
         type="button"
         (clickEvent)="resetWifi()"
-        [disabled]="scanInProgress() || actionInProgress()"
+        [disabled]="scanInProgress() || busy()"
       />
       <choh-button
         [label]="'Reboot'"
         type="button"
         (clickEvent)="rebootDevice()"
-        [disabled]="scanInProgress() || actionInProgress()"
+        [disabled]="scanInProgress() || busy()"
       />
     </div>
   </div>

--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.spec.ts
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.spec.ts
@@ -1,11 +1,14 @@
-import { computed } from '@angular/core';
+import { computed, signal } from '@angular/core';
 import { Dialog } from '@angular/cdk/dialog';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of, Subject } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NotificationService } from '@libs-shared';
-import { WifiRebootFlowService } from '../../service';
-import { WifiScanService } from '../../service';
+import {
+  WifiPostConnectRebootFlowService,
+  WifiRebootFlowService,
+  WifiScanService,
+} from '../../service';
 import type { WiFiInfo } from '@libs-shared';
 import { SerialFacadeService } from '@libs-web-serial';
 import { WifiPageComponent } from './wifi-page.component';
@@ -15,6 +18,8 @@ describe('WifiPageComponent', () => {
   let fixture: ComponentFixture<WifiPageComponent>;
 
   const scanNetworks = vi.fn();
+  const postConnectRebootRun = vi.fn().mockResolvedValue(undefined);
+  const rebootFlowInProgress = signal(false);
 
   let dialogClosed: ReturnType<typeof of>;
 
@@ -24,6 +29,8 @@ describe('WifiPageComponent', () => {
       rawData: [] as string[],
     });
     dialogClosed = of(undefined);
+    postConnectRebootRun.mockClear().mockResolvedValue(undefined);
+    rebootFlowInProgress.set(false);
 
     await TestBed.configureTestingModule({
       imports: [WifiPageComponent],
@@ -66,7 +73,14 @@ describe('WifiPageComponent', () => {
           provide: WifiRebootFlowService,
           useValue: {
             restartWifiService: vi.fn().mockResolvedValue(undefined),
-            rebootDevice: vi.fn().mockResolvedValue(undefined),
+            rebootDevice: vi.fn().mockResolvedValue('ok'),
+          },
+        },
+        {
+          provide: WifiPostConnectRebootFlowService,
+          useValue: {
+            inProgress: rebootFlowInProgress.asReadonly(),
+            run: postConnectRebootRun,
           },
         },
       ],
@@ -173,6 +187,16 @@ describe('WifiPageComponent', () => {
       expect(component.wifiInfoList()).toEqual(wifiInfos);
     });
     expect(scanNetworks).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(postConnectRebootRun).toHaveBeenCalled();
+    });
+  });
+
+  it('rebootDevice delegates to post-connect reboot flow', async () => {
+    await component.rebootDevice();
+    expect(postConnectRebootRun).toHaveBeenCalledWith({
+      afterReconnect: expect.any(Function),
+    });
   });
 
   it('does not refresh scan when connect dialog is cancelled', async () => {

--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.ts
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.ts
@@ -1,5 +1,5 @@
 import { Dialog } from '@angular/cdk/dialog';
-import { Component, inject, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { MatDividerModule } from '@angular/material/divider';
 import { ConfirmDialogComponent } from '@libs-dialogs';
 import type { WiFiInfo } from '@libs-shared';
@@ -8,7 +8,11 @@ import { SerialFacadeService } from '@libs-web-serial';
 import { firstValueFrom } from 'rxjs';
 import { parseConnectedSsid } from '../../functions';
 import type { WifiConnectDialogData } from '../../models';
-import { WifiRebootFlowService, WifiScanService } from '../../service';
+import {
+  WifiPostConnectRebootFlowService,
+  WifiRebootFlowService,
+  WifiScanService,
+} from '../../service';
 import { WifiConnectDialogComponent } from '../wifi-connect-dialog/wifi-connect-dialog.component';
 import { WifiListComponent } from '../wifi-list/wifi-list.component';
 
@@ -38,6 +42,12 @@ export class WifiPageComponent {
   private readonly serial = inject(SerialFacadeService);
   private readonly wifiScan = inject(WifiScanService);
   private readonly wifiReboot = inject(WifiRebootFlowService);
+  private readonly postConnectReboot = inject(WifiPostConnectRebootFlowService);
+
+  /** 通常アクションまたは再起動フロー中は操作をロックする（#732）。 */
+  readonly busy = computed(
+    () => this.actionInProgress() || this.postConnectReboot.inProgress(),
+  );
 
   private async ensureSerial(): Promise<boolean> {
     const ok = this.serial.isConnected();
@@ -94,6 +104,9 @@ export class WifiPageComponent {
       const ok = await firstValueFrom(ref.closed);
       if (ok) {
         await this.refreshAfterConnect();
+        await this.postConnectReboot.run({
+          afterReconnect: () => this.refreshAfterConnect(),
+        });
       }
     })();
   }
@@ -187,28 +200,9 @@ export class WifiPageComponent {
     if (!(await this.ensureSerial())) {
       return;
     }
-    const ref = this.dialog.open(ConfirmDialogComponent, {
-      data: {
-        title: 'デバイスを再起動',
-        message: 'シリアル接続が切れる場合があります。続行しますか？',
-        confirmLabel: '再起動',
-        cancelLabel: 'キャンセル',
-      },
+    await this.postConnectReboot.run({
+      afterReconnect: () => this.refreshAfterConnect(),
     });
-    const confirmed = await firstValueFrom(ref.closed);
-    if (!confirmed) {
-      return;
-    }
-    this.actionInProgress.set(true);
-    try {
-      await this.wifiReboot.rebootDevice();
-      this.notify.info('WiFi', '再起動を送信しました');
-    } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : '再起動に失敗しました';
-      this.notify.error('WiFi', msg);
-    } finally {
-      this.actionInProgress.set(false);
-    }
   }
 
   async checkConnectivity(): Promise<void> {

--- a/libs/wifi/src/lib/service/index.ts
+++ b/libs/wifi/src/lib/service/index.ts
@@ -1,4 +1,5 @@
 export * from './file-content.service';
 export * from './wifi-config.service';
+export * from './wifi-post-connect-reboot-flow.service';
 export * from './wifi-reboot-flow.service';
 export * from './wifi-scan.service';

--- a/libs/wifi/src/lib/service/wifi-post-connect-reboot-flow.service.spec.ts
+++ b/libs/wifi/src/lib/service/wifi-post-connect-reboot-flow.service.spec.ts
@@ -1,0 +1,153 @@
+import { computed, signal } from '@angular/core';
+import { Dialog } from '@angular/cdk/dialog';
+import { TestBed } from '@angular/core/testing';
+import { NotificationService } from '@libs-shared';
+import { SerialExpectedDisconnectService } from '@libs-web-serial';
+import { SerialFacadeService } from '@libs-web-serial';
+import { Subject, of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WifiPostConnectRebootFlowService } from './wifi-post-connect-reboot-flow.service';
+import { WifiRebootFlowService } from './wifi-reboot-flow.service';
+
+describe('WifiPostConnectRebootFlowService', () => {
+  let service: WifiPostConnectRebootFlowService;
+  let rebootDevice: ReturnType<typeof vi.fn>;
+  let disconnect$: ReturnType<typeof vi.fn>;
+  let notifyError: ReturnType<typeof vi.fn>;
+  let notifyInfo: ReturnType<typeof vi.fn>;
+  let notifyWarning: ReturnType<typeof vi.fn>;
+  let expectedDisconnect: SerialExpectedDisconnectService;
+  let isConnectedSignal: ReturnType<typeof signal<boolean>>;
+  let openSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    rebootDevice = vi.fn().mockResolvedValue('ok');
+    disconnect$ = vi.fn().mockReturnValue(of(undefined));
+    notifyError = vi.fn();
+    notifyInfo = vi.fn();
+    notifyWarning = vi.fn();
+    isConnectedSignal = signal(true);
+    expectedDisconnect = new SerialExpectedDisconnectService();
+
+    openSpy = vi.fn().mockImplementation(() => ({
+      closed: of(true),
+    }));
+
+    TestBed.configureTestingModule({
+      providers: [
+        WifiPostConnectRebootFlowService,
+        {
+          provide: Dialog,
+          useValue: { open: openSpy },
+        },
+        {
+          provide: NotificationService,
+          useValue: {
+            error: notifyError,
+            info: notifyInfo,
+            warning: notifyWarning,
+            success: vi.fn(),
+          },
+        },
+        {
+          provide: SerialFacadeService,
+          useValue: {
+            isConnected: computed(() => isConnectedSignal()),
+            disconnect$,
+          },
+        },
+        {
+          provide: WifiRebootFlowService,
+          useValue: { rebootDevice },
+        },
+        {
+          provide: SerialExpectedDisconnectService,
+          useValue: expectedDisconnect,
+        },
+      ],
+    });
+
+    service = TestBed.inject(WifiPostConnectRebootFlowService);
+  });
+
+  it('does nothing when user cancels reboot confirmation', async () => {
+    openSpy.mockImplementationOnce(() => ({
+      closed: of(false),
+    }));
+
+    await service.run();
+
+    expect(rebootDevice).not.toHaveBeenCalled();
+    expect(expectedDisconnect.isExpectedDisconnect()).toBe(false);
+    expect(service.inProgress()).toBe(false);
+  });
+
+  it('shows error and clears expected disconnect when reboot fails while connected', async () => {
+    rebootDevice.mockResolvedValueOnce('failed');
+    isConnectedSignal.set(true);
+
+    await service.run();
+
+    expect(rebootDevice).toHaveBeenCalled();
+    expect(notifyError).toHaveBeenCalledWith(
+      'WiFi',
+      expect.stringContaining('再起動コマンド'),
+    );
+    expect(expectedDisconnect.isExpectedDisconnect()).toBe(false);
+    expect(disconnect$).not.toHaveBeenCalled();
+  });
+
+  it('prevents double execution while a flow is in progress', async () => {
+    const confirmClosed = new Subject<boolean>();
+    openSpy.mockImplementationOnce(() => ({
+      closed: confirmClosed.asObservable(),
+    }));
+
+    const first = service.run();
+    await vi.waitFor(() => {
+      expect(service.inProgress()).toBe(true);
+    });
+
+    await service.run();
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(rebootDevice).not.toHaveBeenCalled();
+
+    confirmClosed.next(false);
+    confirmClosed.complete();
+    await first;
+    expect(service.inProgress()).toBe(false);
+  });
+
+  it('cleans up serial and shows reconnect guidance after successful reboot', async () => {
+    const afterReconnect = vi.fn().mockResolvedValue(undefined);
+    isConnectedSignal.set(true);
+
+    // confirm → reboot → disconnect → info ×2 → wait (already connected after cleanup?)
+    // After rebootDevice returns ok, isConnected should be false then disconnect$ runs.
+    rebootDevice.mockImplementationOnce(async () => {
+      isConnectedSignal.set(false);
+      return 'ok' as const;
+    });
+
+    // After guidance dialogs, simulate user reconnect
+    let dialogCount = 0;
+    openSpy.mockImplementation(() => {
+      dialogCount += 1;
+      if (dialogCount === 3) {
+        // third dialog (reconnect guidance) closed → then waitForReconnect
+        queueMicrotask(() => {
+          isConnectedSignal.set(true);
+        });
+      }
+      return { closed: of(true) };
+    });
+
+    await service.run({ afterReconnect });
+
+    expect(disconnect$).toHaveBeenCalled();
+    expect(notifyInfo).toHaveBeenCalledWith('WiFi', '再起動を送信しました');
+    expect(afterReconnect).toHaveBeenCalled();
+    expect(expectedDisconnect.isExpectedDisconnect()).toBe(false);
+    expect(dialogCount).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/libs/wifi/src/lib/service/wifi-post-connect-reboot-flow.service.ts
+++ b/libs/wifi/src/lib/service/wifi-post-connect-reboot-flow.service.ts
@@ -1,0 +1,160 @@
+import { Dialog } from '@angular/cdk/dialog';
+import { Injectable, inject, signal } from '@angular/core';
+import { ConfirmDialogComponent } from '@libs-dialogs';
+import { NotificationService } from '@libs-shared';
+import {
+  SerialExpectedDisconnectService,
+  SerialFacadeService,
+} from '@libs-web-serial';
+import { firstValueFrom } from 'rxjs';
+import { WifiRebootFlowService } from './wifi-reboot-flow.service';
+
+const RECONNECT_POLL_MS = 500;
+/** 再接続待ちの上限（ブラウザ操作が必要なため長め）。 */
+const RECONNECT_WAIT_MS = 10 * 60 * 1000;
+
+export interface WifiPostConnectRebootFlowOptions {
+  /** 再接続成功後に Wi-Fi 状態を再取得するコールバック */
+  afterReconnect?: () => Promise<void>;
+}
+
+/**
+ * Wi-Fi 設定成功後（および手動 Reboot）の確認付き再起動〜再接続案内フロー（#732）。
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class WifiPostConnectRebootFlowService {
+  private readonly dialog = inject(Dialog);
+  private readonly notify = inject(NotificationService);
+  private readonly serial = inject(SerialFacadeService);
+  private readonly wifiReboot = inject(WifiRebootFlowService);
+  private readonly expectedDisconnect = inject(
+    SerialExpectedDisconnectService,
+  );
+
+  private readonly inProgressSignal = signal(false);
+  readonly inProgress = this.inProgressSignal.asReadonly();
+
+  /**
+   * 再起動確認 → コマンド送信 → 切断クリーンアップ → 再接続案内 → 再取得。
+   * 二重実行時は何もしない。ユーザーがキャンセルした場合も正常終了。
+   */
+  async run(options: WifiPostConnectRebootFlowOptions = {}): Promise<void> {
+    if (this.inProgressSignal()) {
+      return;
+    }
+
+    this.inProgressSignal.set(true);
+    try {
+      const confirmed = await this.confirmReboot();
+      if (!confirmed) {
+        return;
+      }
+
+      this.expectedDisconnect.beginExpectedDisconnect('reboot');
+
+      const result = await this.wifiReboot.rebootDevice();
+      if (result === 'failed') {
+        this.expectedDisconnect.clearExpectedDisconnect();
+        this.notify.error(
+          'WiFi',
+          '再起動コマンドの実行に失敗しました。シリアル接続を確認してください',
+        );
+        return;
+      }
+
+      await this.cleanupSerialAfterReboot();
+      this.notify.info('WiFi', '再起動を送信しました');
+
+      await this.showInfoDialog(
+        'デバイス再起動中',
+        'Raspberry Pi が再起動しています。電源ランプなどが安定するまでしばらくお待ちください。',
+      );
+
+      await this.showInfoDialog(
+        'Web Serial の再接続',
+        '再起動が完了したら、ツールバーの Connect からシリアルポートを選び直してください。ブラウザの権限制約により、再接続にはユーザー操作が必要です。再接続後はオートログインが実行されます。',
+      );
+
+      const reconnected = await this.waitForReconnect();
+      this.expectedDisconnect.clearExpectedDisconnect();
+
+      if (!reconnected) {
+        this.notify.warning(
+          'WiFi',
+          '再接続が確認できませんでした。Connect 後に Wi-Fi 画面で再スキャンしてください',
+        );
+        return;
+      }
+
+      if (options.afterReconnect) {
+        try {
+          await options.afterReconnect();
+        } catch (e: unknown) {
+          const msg =
+            e instanceof Error ? e.message : '再接続後の状態取得に失敗しました';
+          this.notify.error('WiFi', msg);
+        }
+      }
+    } finally {
+      this.inProgressSignal.set(false);
+    }
+  }
+
+  private async confirmReboot(): Promise<boolean> {
+    const ref = this.dialog.open(ConfirmDialogComponent, {
+      data: {
+        title: 'デバイスを再起動',
+        message:
+          'Wi-Fi 設定を反映するためデバイスを再起動します。シリアル接続が切れます。Editor の未保存内容は同一タブの下書きとして保持されます（タブを閉じると消える場合があります）。続行しますか？',
+        confirmLabel: '再起動',
+        cancelLabel: 'キャンセル',
+      },
+    });
+    const confirmed = await firstValueFrom(ref.closed);
+    return confirmed === true;
+  }
+
+  private async showInfoDialog(title: string, message: string): Promise<void> {
+    const ref = this.dialog.open(ConfirmDialogComponent, {
+      width: '480px',
+      data: {
+        title,
+        message,
+        confirmLabel: '次へ',
+        hideCancel: true,
+      },
+    });
+    await firstValueFrom(ref.closed);
+  }
+
+  private async cleanupSerialAfterReboot(): Promise<void> {
+    try {
+      await firstValueFrom(this.serial.disconnect$());
+    } catch {
+      // 既に切断済みでもセッション掃除を試みるだけなので無視
+    }
+  }
+
+  private async waitForReconnect(): Promise<boolean> {
+    if (this.serial.isConnected()) {
+      return true;
+    }
+
+    const deadline = Date.now() + RECONNECT_WAIT_MS;
+    while (Date.now() < deadline) {
+      await delay(RECONNECT_POLL_MS);
+      if (this.serial.isConnected()) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/libs/wifi/src/lib/service/wifi-reboot-flow.service.spec.ts
+++ b/libs/wifi/src/lib/service/wifi-reboot-flow.service.spec.ts
@@ -1,0 +1,48 @@
+import { computed, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { SerialFacadeService } from '@libs-web-serial';
+import { of, throwError } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WifiRebootFlowService } from './wifi-reboot-flow.service';
+
+describe('WifiRebootFlowService', () => {
+  let service: WifiRebootFlowService;
+  let exec$: ReturnType<typeof vi.fn>;
+  let isConnectedSignal: ReturnType<typeof signal<boolean>>;
+
+  beforeEach(() => {
+    isConnectedSignal = signal(true);
+    exec$ = vi.fn();
+
+    TestBed.configureTestingModule({
+      providers: [
+        WifiRebootFlowService,
+        {
+          provide: SerialFacadeService,
+          useValue: {
+            isConnected: computed(() => isConnectedSignal()),
+            exec$,
+          },
+        },
+      ],
+    });
+
+    service = TestBed.inject(WifiRebootFlowService);
+  });
+
+  it('rebootDevice returns ok when serial disconnects after reboot', async () => {
+    exec$.mockReturnValue(
+      throwError(() => new Error('timeout')),
+    );
+    isConnectedSignal.set(false);
+
+    await expect(service.rebootDevice()).resolves.toBe('ok');
+  });
+
+  it('rebootDevice returns failed when serial stays connected', async () => {
+    exec$.mockReturnValue(of({ stdout: 'sudo: reboot: command not found' }));
+    isConnectedSignal.set(true);
+
+    await expect(service.rebootDevice()).resolves.toBe('failed');
+  });
+});

--- a/libs/wifi/src/lib/service/wifi-reboot-flow.service.ts
+++ b/libs/wifi/src/lib/service/wifi-reboot-flow.service.ts
@@ -7,6 +7,9 @@ import {
 } from '@libs-web-serial';
 import { firstValueFrom } from 'rxjs';
 
+/** デバイス再起動コマンドの結果（#732）。 */
+export type WifiRebootDeviceResult = 'ok' | 'failed';
+
 /**
  * WiFi 再起動・有効/無効のフローを担当
  */
@@ -64,9 +67,12 @@ export class WifiRebootFlowService {
   }
 
   /**
-   * デバイスを再起動（プロンプトが返らない場合があるため短めのタイムアウト）
+   * デバイスを再起動する。
+   *
+   * 再起動でシリアルが切れるとタイムアウトや切断エラーになり得る。
+   * 切断されていれば成功、接続が残っていればコマンド失敗とみなす。
    */
-  async rebootDevice(): Promise<void> {
+  async rebootDevice(): Promise<WifiRebootDeviceResult> {
     try {
       await firstValueFrom(this.serial.exec$('sudo reboot', {
         prompt: PI_ZERO_PROMPT,
@@ -75,5 +81,10 @@ export class WifiRebootFlowService {
     } catch {
       // 再起動でシリアルが切れるとタイムアウトや切断エラーになり得る
     }
+
+    if (!this.serial.isConnected()) {
+      return 'ok';
+    }
+    return 'failed';
   }
 }


### PR DESCRIPTION
## Summary

- Wi-Fi 設定成功後に、キャンセル可能なデバイス再起動確認フローを追加しました
- 再起動によるシリアル切断を意図した切断として扱い、再接続案内と再接続後の Wi-Fi 状態再取得まで案内します

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #732

## What changed?

- `SerialExpectedDisconnectService` を追加し、再起動時の想定切断中は接続エラー通知を抑止
- `WifiPostConnectRebootFlowService` で確認 → 再起動 → セッション掃除 → 再起動中／再接続案内 → 再接続待ち → Wi-Fi 再取得をオーケストレーション
- Wi-Fi 接続成功後と手動 Reboot ボタンの両方から同フローを呼び出し、二重実行を防止
- Editor 未保存内容は同一タブの sessionStorage 下書きとして保持される旨を確認ダイアログで明示（ブロックはしない）

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details: `WifiRebootFlowService.rebootDevice()` の戻り値を `Promise<WifiRebootDeviceResult>`（`'ok' | 'failed'`）に変更。`SerialExpectedDisconnectService` / `WifiPostConnectRebootFlowService` を新規公開
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes: 呼び出し側で `rebootDevice()` の戻り値を利用する場合は `'ok' | 'failed'` を扱うこと

## How to test

1. シリアル接続後、Wi-Fi 画面でネットワーク接続を成功させる
2. 再起動確認ダイアログでキャンセルできること、および再起動を選ぶと切断後に再起動中／再接続案内が出ることを確認する
3. ツールバーの Connect で再接続し、オートログイン後に Wi-Fi 一覧／接続 SSID が再取得されることを確認する
4. 手動 Reboot ボタンでも同じ案内フローになること、フロー中に操作が二重起動しないことを確認する
5. `pnpm nx test libs-wifi` および想定切断関連の `pnpm nx test libs-web-serial` が通ること

## Environment (if relevant)

- Browser: Chromium 系（Web Serial 対応）
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)