### PR TITLE
feat(wifi): auto-scan networks when wifi page opens

### DIFF
--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.spec.ts
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.spec.ts
@@ -20,10 +20,17 @@ describe('WifiPageComponent', () => {
   const scanNetworks = vi.fn();
   const postConnectRebootRun = vi.fn().mockResolvedValue(undefined);
   const rebootFlowInProgress = signal(false);
+  const notify = {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  };
 
   let dialogClosed: ReturnType<typeof of>;
 
   beforeEach(async () => {
+    scanNetworks.mockClear();
     scanNetworks.mockResolvedValue({
       wifiInfos: [] as WiFiInfo[],
       rawData: [] as string[],
@@ -31,6 +38,10 @@ describe('WifiPageComponent', () => {
     dialogClosed = of(undefined);
     postConnectRebootRun.mockClear().mockResolvedValue(undefined);
     rebootFlowInProgress.set(false);
+    notify.success.mockClear();
+    notify.error.mockClear();
+    notify.warning.mockClear();
+    notify.info.mockClear();
 
     await TestBed.configureTestingModule({
       imports: [WifiPageComponent],
@@ -43,12 +54,7 @@ describe('WifiPageComponent', () => {
         },
         {
           provide: NotificationService,
-          useValue: {
-            success: vi.fn(),
-            error: vi.fn(),
-            warning: vi.fn(),
-            info: vi.fn(),
-          },
+          useValue: notify,
         },
         {
           provide: SerialFacadeService,
@@ -89,10 +95,15 @@ describe('WifiPageComponent', () => {
     fixture = TestBed.createComponent(WifiPageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    await fixture.whenStable();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('auto-scans networks when the page initializes', () => {
+    expect(scanNetworks).toHaveBeenCalled();
   });
 
   it('runWifiScan fills wifiInfoList when serial is connected', async () => {
@@ -222,6 +233,78 @@ describe('WifiPageComponent', () => {
     scanNetworks.mockRejectedValueOnce(new Error('scan failed'));
     await component.runWifiScan();
     expect(component.scanError()).toBe('scan failed');
+  });
+});
+
+describe('WifiPageComponent when serial is not connected', () => {
+  const scanNetworks = vi.fn();
+  const notify = {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+    scanNetworks.mockClear();
+    notify.warning.mockClear();
+
+    await TestBed.configureTestingModule({
+      imports: [WifiPageComponent],
+      providers: [
+        {
+          provide: Dialog,
+          useValue: {
+            open: vi.fn().mockReturnValue({ closed: of(undefined) }),
+          },
+        },
+        {
+          provide: NotificationService,
+          useValue: notify,
+        },
+        {
+          provide: SerialFacadeService,
+          useValue: {
+            isConnected: computed(() => false),
+          },
+        },
+        {
+          provide: WifiScanService,
+          useValue: {
+            scanNetworks,
+            getWifiStatus: vi.fn(),
+            checkChirimenTutorialReachability: vi.fn(),
+          },
+        },
+        {
+          provide: WifiRebootFlowService,
+          useValue: {
+            restartWifiService: vi.fn(),
+            rebootDevice: vi.fn(),
+          },
+        },
+        {
+          provide: WifiPostConnectRebootFlowService,
+          useValue: {
+            inProgress: signal(false).asReadonly(),
+            run: vi.fn(),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(WifiPageComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('warns and skips scan on init when serial is disconnected', () => {
+    expect(scanNetworks).not.toHaveBeenCalled();
+    expect(notify.warning).toHaveBeenCalledWith(
+      'WiFi',
+      'シリアル接続してください',
+    );
   });
 });
 

--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.ts
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.ts
@@ -1,5 +1,11 @@
 import { Dialog } from '@angular/cdk/dialog';
-import { Component, computed, inject, signal } from '@angular/core';
+import {
+  Component,
+  computed,
+  inject,
+  OnInit,
+  signal,
+} from '@angular/core';
 import { MatDividerModule } from '@angular/material/divider';
 import { ConfirmDialogComponent } from '@libs-dialogs';
 import type { WiFiInfo } from '@libs-shared';
@@ -29,7 +35,7 @@ import { WifiListComponent } from '../wifi-list/wifi-list.component';
     class: 'flex min-h-0 h-full w-full flex-col',
   },
 })
-export class WifiPageComponent {
+export class WifiPageComponent implements OnInit {
   readonly wifiInfoList = signal<WiFiInfo[]>([]);
   readonly scanInProgress = signal(false);
   readonly actionInProgress = signal(false);
@@ -48,6 +54,10 @@ export class WifiPageComponent {
   readonly busy = computed(
     () => this.actionInProgress() || this.postConnectReboot.inProgress(),
   );
+
+  ngOnInit(): void {
+    void this.runWifiScan();
+  }
 
   private async ensureSerial(): Promise<boolean> {
     const ok = this.serial.isConnected();


### PR DESCRIPTION
## Summary

- WiFi 画面（`/wifi`）表示時にネットワークを自動スキャンする
- 既存の `runWifiScan()` を `ngOnInit` から呼び出し、手動「再スキャン」と同じフローを再利用する

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #747

## What changed?

- `WifiPageComponent` が初期化時に `runWifiScan()` を実行するようにした
- 画面表示時の自動スキャンと、シリアル未接続時にスキャンをスキップして警告する回帰テストを追加した

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. シリアル接続した状態でコンソールを開き、ツールバーから WiFi を表示する
2. 「再スキャン」を押さなくてもスキャンが始まり、一覧が表示されることを確認する
3. シリアル未接続の状態で WiFi を表示し、「シリアル接続してください」の警告が出てスキャンが走らないことを確認する
4. 「再スキャン」ボタンで手動スキャンが引き続き動作することを確認する

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)