### PR TITLE
fix(dialogs): restore confirm dialog panel visibility

### DIFF
--- a/libs/dialogs/src/lib/dialogs/confirm-dialog/confirm-dialog.component.ts
+++ b/libs/dialogs/src/lib/dialogs/confirm-dialog/confirm-dialog.component.ts
@@ -16,13 +16,43 @@ export interface ConfirmDialogData {
   styles: [
     `
       .dialog-content {
-        padding: 1rem;
+        min-width: 280px;
+        max-width: 100%;
+        padding: 1.25rem 1.5rem;
+        background: #fff;
+        color: rgba(0, 0, 0, 0.87);
+        border-radius: 8px;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+      }
+      .dialog-content h2 {
+        margin: 0 0 0.75rem;
+        font-size: 1.125rem;
+        font-weight: 500;
+        line-height: 1.4;
+      }
+      .dialog-content p {
+        margin: 0;
+        white-space: pre-wrap;
+        word-break: break-word;
+        line-height: 1.5;
       }
       .dialog-actions {
         display: flex;
         gap: 0.5rem;
-        margin-top: 1rem;
+        margin-top: 1.25rem;
         justify-content: flex-end;
+      }
+      .dialog-actions button {
+        padding: 0.4rem 0.85rem;
+        border: 1px solid rgba(0, 0, 0, 0.24);
+        border-radius: 4px;
+        background: #fff;
+        color: inherit;
+        cursor: pointer;
+        font: inherit;
+      }
+      .dialog-actions button:hover {
+        background: rgba(0, 0, 0, 0.04);
       }
     `,
   ],

--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.spec.ts
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.spec.ts
@@ -3,6 +3,7 @@ import { Dialog } from '@angular/cdk/dialog';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of, Subject } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConfirmDialogComponent } from '@libs-dialogs';
 import { NotificationService } from '@libs-shared';
 import {
   WifiPostConnectRebootFlowService,
@@ -18,6 +19,7 @@ describe('WifiPageComponent', () => {
   let fixture: ComponentFixture<WifiPageComponent>;
 
   const scanNetworks = vi.fn();
+  const restartWifiService = vi.fn().mockResolvedValue(undefined);
   const postConnectRebootRun = vi.fn().mockResolvedValue(undefined);
   const rebootFlowInProgress = signal(false);
   const notify = {
@@ -36,6 +38,7 @@ describe('WifiPageComponent', () => {
       rawData: [] as string[],
     });
     dialogClosed = of(undefined);
+    restartWifiService.mockClear().mockResolvedValue(undefined);
     postConnectRebootRun.mockClear().mockResolvedValue(undefined);
     rebootFlowInProgress.set(false);
     notify.success.mockClear();
@@ -78,7 +81,7 @@ describe('WifiPageComponent', () => {
         {
           provide: WifiRebootFlowService,
           useValue: {
-            restartWifiService: vi.fn().mockResolvedValue(undefined),
+            restartWifiService,
             rebootDevice: vi.fn().mockResolvedValue('ok'),
           },
         },
@@ -208,6 +211,56 @@ describe('WifiPageComponent', () => {
     expect(postConnectRebootRun).toHaveBeenCalledWith({
       afterReconnect: expect.any(Function),
     });
+  });
+
+  it('resetWifi opens confirm dialog and restarts wifi when confirmed', async () => {
+    const closed$ = new Subject<boolean | undefined>();
+    const dialog = TestBed.inject(Dialog);
+    const openSpy = vi.spyOn(dialog, 'open').mockReturnValue({
+      closed: closed$.asObservable(),
+    } as ReturnType<Dialog['open']>);
+
+    const resetPromise = component.resetWifi();
+    await vi.waitFor(() => {
+      expect(openSpy).toHaveBeenCalledWith(
+        ConfirmDialogComponent,
+        expect.objectContaining({
+          data: expect.objectContaining({
+            title: 'WiFi をリセット',
+            confirmLabel: 'リセット',
+          }),
+        }),
+      );
+    });
+    closed$.next(true);
+    closed$.complete();
+    await resetPromise;
+
+    expect(restartWifiService).toHaveBeenCalled();
+    expect(notify.success).toHaveBeenCalledWith(
+      'WiFi',
+      'WiFi サービスを再起動しました',
+    );
+  });
+
+  it('resetWifi does not restart wifi when confirm dialog is cancelled', async () => {
+    const closed$ = new Subject<boolean | undefined>();
+    const dialog = TestBed.inject(Dialog);
+    const openSpy = vi.spyOn(dialog, 'open').mockReturnValue({
+      closed: closed$.asObservable(),
+    } as ReturnType<Dialog['open']>);
+    notify.success.mockClear();
+
+    const resetPromise = component.resetWifi();
+    await vi.waitFor(() => {
+      expect(openSpy).toHaveBeenCalled();
+    });
+    closed$.next(false);
+    closed$.complete();
+    await resetPromise;
+
+    expect(restartWifiService).not.toHaveBeenCalled();
+    expect(notify.success).not.toHaveBeenCalled();
   });
 
   it('does not refresh scan when connect dialog is cancelled', async () => {

--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.ts
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.ts
@@ -194,6 +194,20 @@ export class WifiPageComponent implements OnInit {
     if (!(await this.ensureSerial())) {
       return;
     }
+    const ref = this.dialog.open(ConfirmDialogComponent, {
+      width: '480px',
+      data: {
+        title: 'WiFi をリセット',
+        message:
+          'WiFi サービスを再起動します。接続中のネットワークが一時的に切断される場合があります。続行しますか？',
+        confirmLabel: 'リセット',
+        cancelLabel: 'キャンセル',
+      },
+    });
+    const confirmed = await firstValueFrom(ref.closed);
+    if (confirmed !== true) {
+      return;
+    }
     this.actionInProgress.set(true);
     try {
       await this.wifiReboot.restartWifiService();


### PR DESCRIPTION
## Summary

- CDK の ConfirmDialog に不透明なパネルスタイルを追加し、Wifi Info / 疎通確認 / Reboot などのダイアログが backdrop 上で見えるようにしました
- Reset Wifi に確認ダイアログを追加し、確認時のみ WiFi サービス再起動を実行するようにしました

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #749

## What changed?

- `ConfirmDialogComponent` に白背景・影・角丸・ボタン枠線を追加し、メッセージは `pre-wrap` で複数行表示に対応
- `WifiPageComponent.resetWifi()` で確認ダイアログを開き、キャンセル時は再起動しないように変更
- `resetWifi` の確認 / キャンセルのユニットテストを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx test libs-dialogs` と `pnpm nx test libs-wifi` が通ること
2. localhost:4200 でログイン後、Wifi アイコンから Wifi ページを開く
3. Wifi Info / 疎通確認 / Reset Wifi / Reboot を押し、各ダイアログが白パネルとして表示されること
4. Reset Wifi でキャンセルすると再起動されないこと、確認すると再起動トーストが出ること

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)