### PR TITLE
fix(wifi): restore connect dialog panel visibility

### DIFF
--- a/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.html
+++ b/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.html
@@ -1,4 +1,6 @@
-<div class="flex flex-col gap-4 p-4 min-w-[280px]">
+<div
+  class="flex min-w-[280px] flex-col gap-4 rounded-lg bg-white p-4 text-gray-900 shadow-lg"
+>
   <h2 class="text-lg font-medium m-0">WiFi に接続</h2>
   <form class="flex flex-col gap-3" (ngSubmit)="$event.preventDefault(); connect()">
     <mat-form-field appearance="outline">

--- a/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.spec.ts
+++ b/libs/wifi/src/lib/component/wifi-connect-dialog/wifi-connect-dialog.component.spec.ts
@@ -55,6 +55,15 @@ describe('WifiConnectDialogComponent', () => {
     expect(component.ssidReadonly()).toBe(true);
   });
 
+  it('renders opaque panel surface for CDK backdrop', () => {
+    const panel = fixture.nativeElement.querySelector(
+      ':scope > div',
+    ) as HTMLElement | null;
+    expect(panel).toBeTruthy();
+    expect(panel!.classList.contains('bg-white')).toBe(true);
+    expect(panel!.classList.contains('shadow-lg')).toBe(true);
+  });
+
   it('toggles password visibility', () => {
     expect(component.passwordVisible()).toBe(false);
     component.togglePasswordVisibility();


### PR DESCRIPTION
## Summary

- CDK の Wifi 接続ダイアログに不透明なパネルスタイルを追加し、リスト／手動接続時にダイアログが backdrop 上で見えるようにしました
- 不透明パネル（`bg-white` / `shadow-lg`）の回帰テストを追加しました

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #751

## What changed?

- `WifiConnectDialogComponent` のルート要素に白背景・影・角丸を追加し、CDK backdrop 上でもパネルとして視認できるように変更
- ルート要素が不透明パネルクラスを持つことを検証するユニットテストを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `localhost:4200` でログインしシリアル接続する
2. Wifi アイコン → リストのいずれかの「接続」をクリックする
3. 「WiFi に接続」ダイアログが暗い backdrop 上に白パネルとして表示されることを確認する
4. 「手動で接続」でも同様に見えることを確認する
5. キャンセルでダイアログが閉じられることを確認する
6. （任意）`pnpm nx test libs-wifi` が成功することを確認する

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)