### PR TITLE
feat(wifi): block console ui during device reboot

### DIFF
--- a/libs/console-shell/src/lib/component/console-shell/console-shell.component.html
+++ b/libs/console-shell/src/lib/component/console-shell/console-shell.component.html
@@ -1,5 +1,6 @@
 @let isConnected = connected();
 @let isLogoutPending = logoutPending();
+@let isRebootPending = rebootPending();
 @let isConnectionBusy = connectionBusy();
 
 <div
@@ -90,6 +91,25 @@
       />
       <p class="rounded bg-white px-4 py-2 text-sm text-gray-800 shadow">
         ログアウト処理中です。完了までお待ちください…
+      </p>
+    </div>
+  }
+
+  @if (isRebootPending) {
+    <div
+      class="absolute inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-black/40"
+      role="alertdialog"
+      aria-modal="true"
+      aria-busy="true"
+      aria-label="再起動処理中"
+    >
+      <mat-progress-spinner
+        mode="indeterminate"
+        diameter="64"
+        aria-label="再起動処理中"
+      />
+      <p class="rounded bg-white px-4 py-2 text-sm text-gray-800 shadow">
+        再起動処理中です。完了までお待ちください…
       </p>
     </div>
   }

--- a/libs/console-shell/src/lib/component/console-shell/console-shell.component.spec.ts
+++ b/libs/console-shell/src/lib/component/console-shell/console-shell.component.spec.ts
@@ -6,6 +6,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import {
   PiZeroShellReadinessService,
   SerialConnectionViewModelFacade,
+  SerialExpectedDisconnectService,
   SerialNotificationService,
   type SerialConnectionViewModel,
 } from '@libs-web-serial';
@@ -63,6 +64,20 @@ function createShellReadinessMock(initialEpoch = 0) {
     logoutPendingSignal,
     clearLogoutPending: vi.fn(() => logoutPendingSignal.set(false)),
     beginLogoutPending: vi.fn(() => logoutPendingSignal.set(true)),
+  };
+}
+
+function createExpectedDisconnectMock() {
+  const rebootPendingSignal = signal(false);
+  return {
+    rebootPending: rebootPendingSignal.asReadonly(),
+    rebootPendingSignal,
+    beginRebootPending: vi.fn(() => rebootPendingSignal.set(true)),
+    clearRebootPending: vi.fn(() => rebootPendingSignal.set(false)),
+    beginExpectedDisconnect: vi.fn(),
+    clearExpectedDisconnect: vi.fn(),
+    isExpectedDisconnect: vi.fn(() => false),
+    reason: signal(null).asReadonly(),
   };
 }
 
@@ -131,6 +146,7 @@ describe('ConsoleShellComponent', () => {
   let vmSignal: ReturnType<typeof signal<SerialConnectionViewModel>>;
   let logoutCompletedEpochSignal: ReturnType<typeof signal<number>>;
   let logoutPendingSignal: ReturnType<typeof signal<boolean>>;
+  let rebootPendingSignal: ReturnType<typeof signal<boolean>>;
   let openDialog: ReturnType<typeof vi.fn>;
   let closeAllDialog: ReturnType<typeof vi.fn>;
   let setActivePanel: ReturnType<typeof vi.fn>;
@@ -152,9 +168,11 @@ describe('ConsoleShellComponent', () => {
 
     const { facade, vmSignal: vm } = createConnectionFacadeMock(false);
     const shellReadiness = createShellReadinessMock();
+    const expectedDisconnect = createExpectedDisconnectMock();
     vmSignal = vm;
     logoutCompletedEpochSignal = shellReadiness.logoutCompletedEpochSignal;
     logoutPendingSignal = shellReadiness.logoutPendingSignal;
+    rebootPendingSignal = expectedDisconnect.rebootPendingSignal;
     connect = facade.connect;
     disconnect = facade.disconnect;
     sendCommand = facade.sendCommand;
@@ -187,6 +205,10 @@ describe('ConsoleShellComponent', () => {
         {
           provide: PiZeroShellReadinessService,
           useValue: shellReadiness,
+        },
+        {
+          provide: SerialExpectedDisconnectService,
+          useValue: expectedDisconnect,
         },
         {
           provide: SerialNotificationService,
@@ -262,6 +284,18 @@ describe('ConsoleShellComponent', () => {
     vmSignal.set(vmDefaults({ isConnected: true }));
     TestBed.flushEffects();
     logoutPendingSignal.set(true);
+    TestBed.flushEffects();
+    disconnect.mockClear();
+
+    component.onDisConnect();
+
+    expect(disconnect).not.toHaveBeenCalled();
+  });
+
+  it('does not disconnect when onDisConnect is called while rebootPending', () => {
+    vmSignal.set(vmDefaults({ isConnected: true }));
+    TestBed.flushEffects();
+    rebootPendingSignal.set(true);
     TestBed.flushEffects();
     disconnect.mockClear();
 
@@ -433,6 +467,37 @@ describe('ConsoleShellComponent', () => {
     expect(navigateSpy).not.toHaveBeenCalled();
   });
 
+  it('shows a blocking reboot loader while rebootPending is true', () => {
+    vmSignal.set(vmDefaults({ isConnected: true }));
+    fixture.detectChanges();
+
+    expect(
+      fixture.nativeElement.querySelector('[aria-label="再起動処理中"]'),
+    ).toBeNull();
+
+    rebootPendingSignal.set(true);
+    fixture.detectChanges();
+
+    const overlay = fixture.nativeElement.querySelector(
+      '[aria-label="再起動処理中"]',
+    ) as HTMLElement | null;
+    expect(overlay).toBeTruthy();
+    expect(overlay?.textContent).toContain('再起動処理中');
+    expect(fixture.nativeElement.querySelector('mat-progress-spinner')).toBeTruthy();
+  });
+
+  it('blocks toolbar actions while rebootPending is true', () => {
+    vmSignal.set(vmDefaults({ isConnected: true }));
+    TestBed.flushEffects();
+    rebootPendingSignal.set(true);
+    TestBed.flushEffects();
+    navigateSpy.mockClear();
+
+    component.onToolbarAction('editor');
+
+    expect(navigateSpy).not.toHaveBeenCalled();
+  });
+
   it('shows a blocking connect loader while isConnecting is true', () => {
     expect(
       fixture.nativeElement.querySelector('[aria-label="オートログイン中"]'),
@@ -537,6 +602,10 @@ describe('ConsoleShellComponent gridTemplateColumns when right nav closed', () =
           useValue: createShellReadinessMock(),
         },
         {
+          provide: SerialExpectedDisconnectService,
+          useValue: createExpectedDisconnectMock(),
+        },
+        {
           provide: SerialNotificationService,
           useValue: {
             notifyLogoutDetected: vi.fn(),
@@ -627,6 +696,10 @@ describe('ConsoleShellComponent responsive layout', () => {
         {
           provide: PiZeroShellReadinessService,
           useValue: createShellReadinessMock(),
+        },
+        {
+          provide: SerialExpectedDisconnectService,
+          useValue: createExpectedDisconnectMock(),
         },
         {
           provide: SerialNotificationService,
@@ -799,6 +872,10 @@ describe('ConsoleShellComponent layout DOM (connected vs disconnected)', () => {
         {
           provide: PiZeroShellReadinessService,
           useValue: createShellReadinessMock(),
+        },
+        {
+          provide: SerialExpectedDisconnectService,
+          useValue: createExpectedDisconnectMock(),
         },
         {
           provide: SerialNotificationService,

--- a/libs/console-shell/src/lib/component/console-shell/console-shell.component.ts
+++ b/libs/console-shell/src/lib/component/console-shell/console-shell.component.ts
@@ -31,6 +31,7 @@ import { RemotePageComponent } from '@libs-remote';
 import {
   PiZeroShellReadinessService,
   SerialConnectionViewModelFacade,
+  SerialExpectedDisconnectService,
   SerialNotificationService,
 } from '@libs-web-serial';
 import { DialogService } from '@libs-dialogs';
@@ -61,6 +62,7 @@ export class ConsoleShellComponent implements OnInit, OnDestroy {
 
   private connectionVm = inject(SerialConnectionViewModelFacade);
   private shellReadiness = inject(PiZeroShellReadinessService);
+  private expectedDisconnect = inject(SerialExpectedDisconnectService);
   private notifications = inject(SerialNotificationService);
   private shellStore = inject(ConsoleShellStore);
   private dialogService = inject(DialogService);
@@ -73,6 +75,11 @@ export class ConsoleShellComponent implements OnInit, OnDestroy {
 
   /** logout / exit 送信後〜切断完了までの入力ブロック用ローダー。 */
   readonly logoutPending = this.shellReadiness.logoutPending;
+
+  /**
+   * デバイス再起動コマンド〜切断クリーンアップ完了までの入力ブロック用ローダー（#754）。
+   */
+  readonly rebootPending = this.expectedDisconnect.rebootPending;
 
   /**
    * Web Serial 接続〜シェル準備完了までの入力ブロック用ローダー（issue #755）。
@@ -280,6 +287,7 @@ export class ConsoleShellComponent implements OnInit, OnDestroy {
     if (
       this.logoutDisconnectInFlight ||
       this.logoutPending() ||
+      this.rebootPending() ||
       this.connectionBusy() ||
       !this.connectionVm.vm().isConnected
     ) {
@@ -360,7 +368,7 @@ export class ConsoleShellComponent implements OnInit, OnDestroy {
   }
 
   onToolbarAction(action: ToolbarAction): void {
-    if (this.logoutPending() || this.connectionBusy()) {
+    if (this.logoutPending() || this.rebootPending() || this.connectionBusy()) {
       return;
     }
 

--- a/libs/terminal/src/lib/component/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/src/lib/component/terminal-view/terminal-view.component.spec.ts
@@ -49,6 +49,7 @@ import {
   PiZeroSessionService,
   PiZeroShellReadinessService,
   SerialConnectionViewModelFacade,
+  SerialExpectedDisconnectService,
   SerialFacadeService,
   TerminalCommandRequestService,
   type SerialConnectionViewModel,
@@ -65,6 +66,7 @@ describe('TerminalViewComponent', () => {
   let isConnectedSignal: ReturnType<typeof signal<boolean>>;
   let connectionEpochSignal: ReturnType<typeof signal<number>>;
   let logoutPendingSignal: ReturnType<typeof signal<boolean>>;
+  let rebootPendingSignal: ReturnType<typeof signal<boolean>>;
   let connectionVmSignal: ReturnType<typeof signal<SerialConnectionViewModel>>;
 
   function vmDefaults(
@@ -123,6 +125,7 @@ describe('TerminalViewComponent', () => {
     isConnectedSignal = signal(true);
     connectionEpochSignal = signal(1);
     logoutPendingSignal = signal(false);
+    rebootPendingSignal = signal(false);
     connectionVmSignal = signal(vmDefaults());
     shouldRunAfterConnectMock = vi.fn(() => of(true));
     runAfterConnectMock = vi.fn(() => of(undefined));
@@ -149,6 +152,13 @@ describe('TerminalViewComponent', () => {
           logoutPending: logoutPendingSignal.asReadonly(),
           beginLogoutPending: vi.fn(() => logoutPendingSignal.set(true)),
           clearLogoutPending: vi.fn(() => logoutPendingSignal.set(false)),
+        },
+      })
+      .overrideProvider(SerialExpectedDisconnectService, {
+        useValue: {
+          rebootPending: rebootPendingSignal.asReadonly(),
+          beginRebootPending: vi.fn(() => rebootPendingSignal.set(true)),
+          clearRebootPending: vi.fn(() => rebootPendingSignal.set(false)),
         },
       })
       .overrideProvider(SerialConnectionViewModelFacade, {
@@ -208,6 +218,17 @@ describe('TerminalViewComponent', () => {
         setupStatus: 'waiting-login',
       }),
     );
+    TestBed.flushEffects();
+    sendMock.mockClear();
+
+    typeCommand('pwd');
+
+    await Promise.resolve();
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores typed input while rebootPending is true', async () => {
+    rebootPendingSignal.set(true);
     TestBed.flushEffects();
     sendMock.mockClear();
 

--- a/libs/terminal/src/lib/component/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/src/lib/component/terminal-view/terminal-view.component.ts
@@ -15,6 +15,7 @@ import { Terminal } from '@xterm/xterm';
 import {
   PiZeroShellReadinessService,
   SerialConnectionViewModelFacade,
+  SerialExpectedDisconnectService,
   SerialFacadeService,
   TerminalCommandRequestService,
 } from '@libs-web-serial';
@@ -43,6 +44,7 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
   private console = inject(TerminalConsoleOrchestrationService);
   private serial = inject(SerialFacadeService);
   private shellReadiness = inject(PiZeroShellReadinessService);
+  private expectedDisconnect = inject(SerialExpectedDisconnectService);
   private connectionVm = inject(SerialConnectionViewModelFacade);
   private commandRequests = inject(TerminalCommandRequestService);
   private destroyRef = inject(DestroyRef);
@@ -67,12 +69,13 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
     effect(() => {
       const connected = this.serial.isConnected();
       const logoutPending = this.shellReadiness.logoutPending();
+      const rebootPending = this.expectedDisconnect.rebootPending();
       const vm = this.connectionVm.vm();
       const connectionBusy =
         vm.isConnecting ||
         (vm.isConnected && !vm.isLoggedIn && vm.setupStatus !== 'failed');
       this.serialInputEnabled =
-        connected && !logoutPending && !connectionBusy;
+        connected && !logoutPending && !rebootPending && !connectionBusy;
       if (!connected) {
         this.lastTerminalText = '';
       }

--- a/libs/web-serial/src/lib/service/serial-expected-disconnect.service.spec.ts
+++ b/libs/web-serial/src/lib/service/serial-expected-disconnect.service.spec.ts
@@ -23,4 +23,31 @@ describe('SerialExpectedDisconnectService', () => {
     expect(service.isExpectedDisconnect()).toBe(false);
     expect(service.reason()).toBeNull();
   });
+
+  it('beginRebootPending and clearRebootPending toggle ui block flag', () => {
+    const service = new SerialExpectedDisconnectService();
+
+    expect(service.rebootPending()).toBe(false);
+
+    service.beginRebootPending();
+    expect(service.rebootPending()).toBe(true);
+
+    service.clearRebootPending();
+    expect(service.rebootPending()).toBe(false);
+  });
+
+  it('rebootPending is independent from expected disconnect reason', () => {
+    const service = new SerialExpectedDisconnectService();
+
+    service.beginExpectedDisconnect('reboot');
+    expect(service.rebootPending()).toBe(false);
+
+    service.beginRebootPending();
+    service.clearExpectedDisconnect();
+    expect(service.rebootPending()).toBe(true);
+    expect(service.isExpectedDisconnect()).toBe(false);
+
+    service.clearRebootPending();
+    expect(service.rebootPending()).toBe(false);
+  });
 });

--- a/libs/web-serial/src/lib/service/serial-expected-disconnect.service.ts
+++ b/libs/web-serial/src/lib/service/serial-expected-disconnect.service.ts
@@ -7,7 +7,11 @@ export type SerialExpectedDisconnectReason = 'reboot';
  * 意図した切断と通信エラーを区別するための共有フラグ（#732）。
  *
  * 再起動コマンド送信前に {@link beginExpectedDisconnect} し、
- * クリーンアップ完了後に {@link clearExpectedDisconnect} する。
+ * 再接続完了後に {@link clearExpectedDisconnect} する。
+ *
+ * UI ブロック用の {@link rebootPending} はライフサイクルが異なる（#754）。
+ * 再起動コマンド〜シリアル切断クリーンアップ完了までに限定し、
+ * 再接続待ちでは立てない（Connect 操作を妨げないため）。
  */
 @Injectable({
   providedIn: 'root',
@@ -15,8 +19,15 @@ export type SerialExpectedDisconnectReason = 'reboot';
 export class SerialExpectedDisconnectService {
   private readonly reasonSignal =
     signal<SerialExpectedDisconnectReason | null>(null);
+  private readonly rebootPendingSignal = signal(false);
 
   readonly reason = this.reasonSignal.asReadonly();
+
+  /**
+   * デバイス再起動コマンド送信後〜切断クリーンアップ完了までの UI ブロック用。
+   * {@link reason}（トースト抑制・再接続待ち）とは独立したライフサイクル。
+   */
+  readonly rebootPending = this.rebootPendingSignal.asReadonly();
 
   beginExpectedDisconnect(reason: SerialExpectedDisconnectReason): void {
     this.reasonSignal.set(reason);
@@ -24,6 +35,14 @@ export class SerialExpectedDisconnectService {
 
   clearExpectedDisconnect(): void {
     this.reasonSignal.set(null);
+  }
+
+  beginRebootPending(): void {
+    this.rebootPendingSignal.set(true);
+  }
+
+  clearRebootPending(): void {
+    this.rebootPendingSignal.set(false);
   }
 
   isExpectedDisconnect(

--- a/libs/wifi/src/lib/service/wifi-post-connect-reboot-flow.service.spec.ts
+++ b/libs/wifi/src/lib/service/wifi-post-connect-reboot-flow.service.spec.ts
@@ -79,6 +79,7 @@ describe('WifiPostConnectRebootFlowService', () => {
 
     expect(rebootDevice).not.toHaveBeenCalled();
     expect(expectedDisconnect.isExpectedDisconnect()).toBe(false);
+    expect(expectedDisconnect.rebootPending()).toBe(false);
     expect(service.inProgress()).toBe(false);
   });
 
@@ -94,7 +95,40 @@ describe('WifiPostConnectRebootFlowService', () => {
       expect.stringContaining('再起動コマンド'),
     );
     expect(expectedDisconnect.isExpectedDisconnect()).toBe(false);
+    expect(expectedDisconnect.rebootPending()).toBe(false);
     expect(disconnect$).not.toHaveBeenCalled();
+  });
+
+  it('raises rebootPending during reboot cleanup and clears before guidance dialogs', async () => {
+    isConnectedSignal.set(true);
+    rebootDevice.mockImplementationOnce(async () => {
+      expect(expectedDisconnect.rebootPending()).toBe(true);
+      isConnectedSignal.set(false);
+      return 'ok' as const;
+    });
+    disconnect$.mockImplementationOnce(() => {
+      expect(expectedDisconnect.rebootPending()).toBe(true);
+      return of(undefined);
+    });
+
+    let sawPendingDuringGuidance = false;
+    let dialogCount = 0;
+    openSpy.mockImplementation(() => {
+      dialogCount += 1;
+      if (dialogCount >= 2) {
+        // confirm の後 = 案内ダイアログ。この時点では UI pending は解除済み。
+        sawPendingDuringGuidance = expectedDisconnect.rebootPending();
+        queueMicrotask(() => {
+          isConnectedSignal.set(true);
+        });
+      }
+      return { closed: of(true) };
+    });
+
+    await service.run();
+
+    expect(sawPendingDuringGuidance).toBe(false);
+    expect(expectedDisconnect.rebootPending()).toBe(false);
   });
 
   it('prevents double execution while a flow is in progress', async () => {
@@ -148,6 +182,7 @@ describe('WifiPostConnectRebootFlowService', () => {
     expect(notifyInfo).toHaveBeenCalledWith('WiFi', '再起動を送信しました');
     expect(afterReconnect).toHaveBeenCalled();
     expect(expectedDisconnect.isExpectedDisconnect()).toBe(false);
+    expect(expectedDisconnect.rebootPending()).toBe(false);
     expect(dialogCount).toBeGreaterThanOrEqual(3);
   });
 });

--- a/libs/wifi/src/lib/service/wifi-post-connect-reboot-flow.service.ts
+++ b/libs/wifi/src/lib/service/wifi-post-connect-reboot-flow.service.ts
@@ -53,19 +53,24 @@ export class WifiPostConnectRebootFlowService {
       }
 
       this.expectedDisconnect.beginExpectedDisconnect('reboot');
+      this.expectedDisconnect.beginRebootPending();
+      try {
+        const result = await this.wifiReboot.rebootDevice();
+        if (result === 'failed') {
+          this.expectedDisconnect.clearExpectedDisconnect();
+          this.notify.error(
+            'WiFi',
+            '再起動コマンドの実行に失敗しました。シリアル接続を確認してください',
+          );
+          return;
+        }
 
-      const result = await this.wifiReboot.rebootDevice();
-      if (result === 'failed') {
-        this.expectedDisconnect.clearExpectedDisconnect();
-        this.notify.error(
-          'WiFi',
-          '再起動コマンドの実行に失敗しました。シリアル接続を確認してください',
-        );
-        return;
+        await this.cleanupSerialAfterReboot();
+        this.notify.info('WiFi', '再起動を送信しました');
+      } finally {
+        // 再接続案内中は Connect 操作を妨げないよう、切断完了時点で UI ブロックを解除する（#754）
+        this.expectedDisconnect.clearRebootPending();
       }
-
-      await this.cleanupSerialAfterReboot();
-      this.notify.info('WiFi', '再起動を送信しました');
 
       await this.showInfoDialog(
         'デバイス再起動中',


### PR DESCRIPTION
## Summary

- Wi‑Fi デバイスリブート中に、ログアウトと同様の全画面オーバーレイと操作ガードを追加し、誤操作を防ぎます
- `rebootPending` は再起動コマンド〜シリアル切断完了までに限定し、再接続案内中は Connect 操作を妨げません

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #754

## What changed?

- `SerialExpectedDisconnectService` に UI ブロック用 `rebootPending`（begin/clear）を追加（トースト抑制用 `reason` とは別ライフサイクル）
- Wi‑Fi 再起動フローで確認後〜切断クリーンアップ完了まで `rebootPending` を立てる
- console-shell に「再起動処理中」オーバーレイとツールバー / DisConnect ガードを追加
- terminal 入力を `rebootPending` 中は無効化
- 再接続案内ダイアログは従来どおり維持

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details: `SerialExpectedDisconnectService` に `rebootPending` / `beginRebootPending` / `clearRebootPending` を追加
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. Wi‑Fi 画面で Reboot（または接続成功後の再起動フロー）を実行し、確認ダイアログで「再起動」を押す
2. 「再起動処理中です。完了までお待ちください…」オーバーレイが表示され、ツールバー操作・Terminal 入力・DisConnect が効かないことを確認する
3. 切断後にオーバーレイが消え、Connect 画面と再接続案内ダイアログが表示され、Connect できることを確認する
4. ローカルで `pnpm nx run-many -t test -p libs-web-serial,libs-wifi,libs-console-shell,libs-terminal` が通ることを確認する

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)