### PR TITLE
fix(web-serial): clear terminal text after logout

### DIFF
--- a/libs/web-serial/src/lib/service/serial-transport.service.spec.ts
+++ b/libs/web-serial/src/lib/service/serial-transport.service.spec.ts
@@ -189,6 +189,31 @@ describe('SerialTransportService', () => {
     });
   });
 
+  it('should clear terminalText and lines after disconnect', async () => {
+    const terminalText$ = new BehaviorSubject('previous-session-output');
+    const lines$ = new BehaviorSubject('previous-line');
+    mockCreateSerialSession.mockReturnValue(
+      buildMockSession(
+        {} as SerialPortInfo,
+        lines$.asObservable(),
+        terminalText$.asObservable(),
+      ),
+    );
+
+    await firstValueFrom(service.connect$());
+    await vi.waitFor(() => {
+      expect(service.terminalText()).toBe('previous-session-output');
+      expect(service.lines()).toBe('previous-line');
+    });
+
+    await firstValueFrom(service.disconnect$());
+
+    await vi.waitFor(() => {
+      expect(service.terminalText()).toBe('');
+      expect(service.lines()).toBe('');
+    });
+  });
+
   it('send$ should delegate to session send$', async () => {
     const session = buildMockSession({} as SerialPortInfo);
     mockCreateSerialSession.mockReturnValue(session);

--- a/libs/web-serial/src/lib/service/serial-transport.service.ts
+++ b/libs/web-serial/src/lib/service/serial-transport.service.ts
@@ -65,7 +65,10 @@ export class SerialTransportService {
     concat(of({ status: SerialSessionStatus.Idle }), NEVER),
   ).pipe(distinctUntilChanged());
 
-  private readonly linesSource$ = this.fromSession((s) => s.lines$, NEVER);
+  private readonly linesSource$ = this.fromSession(
+    (s) => s.lines$,
+    concat(of(''), NEVER),
+  );
 
   /**
    * {@link SerialSession.receive$}（UTF-8 デコード済みの生チャンク）。
@@ -76,7 +79,7 @@ export class SerialTransportService {
 
   private readonly terminalTextSource$ = this.fromSession(
     (s) => s.terminalText$,
-    NEVER,
+    concat(of(''), NEVER),
   );
 
   private readonly errorsSource$ = this.fromSession(


### PR DESCRIPTION
## Summary

- シリアル切断時に `terminalText` / `lines` を空文字へリセットし、再ログイン後に前回セッションのターミナル表示が残らないようにする
- Issue #763 の回帰テストを追加する

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #763

## What changed?

- `SerialTransportService` の idle 時ストリームを `concat(of(''), NEVER)` に変更し、切断後に表示用バッファをクリア
- disconnect 後に `terminalText()` が空になることを検証するテストを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. アプリを起動しシリアル接続（ログイン）する
2. ターミナルに出力が出ることを確認する
3. ログアウト（または DisConnect）する
4. 再接続し、前回セッションのターミナル出力が残っていないことを確認する
5. `pnpm nx test libs-web-serial` が通ることを確認する

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)