### PR TITLE
fix(terminal): handle tab and arrow keys for serial shell

### DIFF
--- a/libs/terminal/src/lib/component/terminal-input.spec.ts
+++ b/libs/terminal/src/lib/component/terminal-input.spec.ts
@@ -7,15 +7,31 @@ type DomEvent = {
   metaKey: boolean;
   code: string;
   key: string;
+  preventDefault: () => void;
 };
 
 type TerminalKeyEvent = {
   domEvent: DomEvent;
 };
 
+function createDomEvent(
+  partial: Pick<DomEvent, 'code' | 'key'> &
+    Partial<Pick<DomEvent, 'altKey' | 'ctrlKey' | 'metaKey'>>,
+): DomEvent {
+  return {
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    preventDefault: vi.fn(),
+    ...partial,
+  };
+}
+
 describe('attachTerminalInput', () => {
   it('ignores input when input is disabled', () => {
     let keyHandler: ((e: TerminalKeyEvent) => void) | undefined;
+    const onSend = vi.fn();
+    const onCommand = vi.fn();
 
     const terminal = {
       onKey: (cb: (e: TerminalKeyEvent) => void) => {
@@ -25,36 +41,23 @@ describe('attachTerminalInput', () => {
       writeln: vi.fn(),
     } as unknown as Parameters<typeof attachTerminalInput>[0];
 
-    const onCommand = vi.fn(async () => 'OK');
-
-    attachTerminalInput(terminal, onCommand, () => false);
+    attachTerminalInput(terminal, onCommand, () => false, onSend);
 
     keyHandler?.({
-      domEvent: {
-        altKey: false,
-        ctrlKey: false,
-        metaKey: false,
-        code: 'KeyL',
-        key: 'l',
-      },
+      domEvent: createDomEvent({ code: 'KeyL', key: 'l' }),
     });
     keyHandler?.({
-      domEvent: {
-        altKey: false,
-        ctrlKey: false,
-        metaKey: false,
-        code: 'Enter',
-        key: 'Enter',
-      },
+      domEvent: createDomEvent({ code: 'Enter', key: 'Enter' }),
     });
 
     expect(onCommand).not.toHaveBeenCalled();
+    expect(onSend).not.toHaveBeenCalled();
     expect(terminal.write).not.toHaveBeenCalled();
-    expect(terminal.writeln).not.toHaveBeenCalled();
   });
 
-  it('trims and executes command when input is enabled', async () => {
+  it('sends printable characters without local echo', () => {
     let keyHandler: ((e: TerminalKeyEvent) => void) | undefined;
+    const onSend = vi.fn();
 
     const terminal = {
       onKey: (cb: (e: TerminalKeyEvent) => void) => {
@@ -64,68 +67,151 @@ describe('attachTerminalInput', () => {
       writeln: vi.fn(),
     } as unknown as Parameters<typeof attachTerminalInput>[0];
 
-    let resolveCommand: ((value: string) => void) | undefined;
-    const onCommand = vi.fn(
-      () =>
-        new Promise<string>((resolve) => {
-          resolveCommand = resolve;
-        }),
-    );
-
-    attachTerminalInput(terminal, onCommand, () => true);
+    attachTerminalInput(terminal, undefined, () => true, onSend);
 
     keyHandler?.({
-      domEvent: {
-        altKey: false,
-        ctrlKey: false,
-        metaKey: false,
-        code: 'Space',
-        key: ' ',
-      },
+      domEvent: createDomEvent({ code: 'KeyL', key: 'l' }),
     });
     keyHandler?.({
-      domEvent: {
-        altKey: false,
-        ctrlKey: false,
-        metaKey: false,
-        code: 'KeyL',
-        key: 'l',
-      },
-    });
-    keyHandler?.({
-      domEvent: {
-        altKey: false,
-        ctrlKey: false,
-        metaKey: false,
-        code: 'KeyS',
-        key: 's',
-      },
-    });
-    keyHandler?.({
-      domEvent: {
-        altKey: false,
-        ctrlKey: false,
-        metaKey: false,
-        code: 'Space',
-        key: ' ',
-      },
-    });
-    keyHandler?.({
-      domEvent: {
-        altKey: false,
-        ctrlKey: false,
-        metaKey: false,
-        code: 'Enter',
-        key: 'Enter',
-      },
+      domEvent: createDomEvent({ code: 'KeyS', key: 's' }),
     });
 
+    expect(onSend).toHaveBeenCalledWith('l');
+    expect(onSend).toHaveBeenCalledWith('s');
+    expect(terminal.write).not.toHaveBeenCalled();
+  });
+
+  it('sends carriage return and notifies command on Enter', () => {
+    let keyHandler: ((e: TerminalKeyEvent) => void) | undefined;
+    const onSend = vi.fn();
+    const onCommand = vi.fn();
+
+    const terminal = {
+      onKey: (cb: (e: TerminalKeyEvent) => void) => {
+        keyHandler = cb;
+      },
+      write: vi.fn(),
+      writeln: vi.fn(),
+    } as unknown as Parameters<typeof attachTerminalInput>[0];
+
+    attachTerminalInput(terminal, onCommand, () => true, onSend);
+
+    keyHandler?.({
+      domEvent: createDomEvent({ code: 'KeyL', key: 'l' }),
+    });
+    keyHandler?.({
+      domEvent: createDomEvent({ code: 'KeyS', key: 's' }),
+    });
+    keyHandler?.({
+      domEvent: createDomEvent({ code: 'Enter', key: 'Enter' }),
+    });
+
+    expect(onSend).toHaveBeenCalledWith('l');
+    expect(onSend).toHaveBeenCalledWith('s');
+    expect(onSend).toHaveBeenCalledWith('\r');
     expect(onCommand).toHaveBeenCalledWith('ls');
+    expect(terminal.write).not.toHaveBeenCalled();
+  });
 
-    resolveCommand?.('OK');
-    await new Promise((r) => setTimeout(r, 0));
+  it('sends tab as \\t and does not write key name', () => {
+    let keyHandler: ((e: TerminalKeyEvent) => void) | undefined;
+    const onSend = vi.fn();
 
-    expect(terminal.write).toHaveBeenCalledWith('OK');
+    const terminal = {
+      onKey: (cb: (e: TerminalKeyEvent) => void) => {
+        keyHandler = cb;
+      },
+      write: vi.fn(),
+      writeln: vi.fn(),
+    } as unknown as Parameters<typeof attachTerminalInput>[0];
+
+    attachTerminalInput(terminal, undefined, () => true, onSend);
+
+    keyHandler?.({
+      domEvent: createDomEvent({ code: 'Tab', key: 'Tab' }),
+    });
+
+    expect(onSend).toHaveBeenCalledWith('\t');
+    expect(onSend).not.toHaveBeenCalledWith('Tab');
+    expect(terminal.write).not.toHaveBeenCalled();
+  });
+
+  it('sends CSI sequences for up/down arrows', () => {
+    let keyHandler: ((e: TerminalKeyEvent) => void) | undefined;
+    const onSend = vi.fn();
+
+    const terminal = {
+      onKey: (cb: (e: TerminalKeyEvent) => void) => {
+        keyHandler = cb;
+      },
+      write: vi.fn(),
+      writeln: vi.fn(),
+    } as unknown as Parameters<typeof attachTerminalInput>[0];
+
+    attachTerminalInput(terminal, undefined, () => true, onSend);
+
+    keyHandler?.({
+      domEvent: createDomEvent({ code: 'ArrowUp', key: 'ArrowUp' }),
+    });
+    keyHandler?.({
+      domEvent: createDomEvent({ code: 'ArrowDown', key: 'ArrowDown' }),
+    });
+
+    expect(onSend).toHaveBeenCalledWith('\x1b[A');
+    expect(onSend).toHaveBeenCalledWith('\x1b[B');
+    expect(onSend).not.toHaveBeenCalledWith('ArrowUp');
+    expect(onSend).not.toHaveBeenCalledWith('ArrowDown');
+    expect(terminal.write).not.toHaveBeenCalled();
+  });
+
+  it('ignores left/right arrows', () => {
+    let keyHandler: ((e: TerminalKeyEvent) => void) | undefined;
+    const onSend = vi.fn();
+
+    const terminal = {
+      onKey: (cb: (e: TerminalKeyEvent) => void) => {
+        keyHandler = cb;
+      },
+      write: vi.fn(),
+      writeln: vi.fn(),
+    } as unknown as Parameters<typeof attachTerminalInput>[0];
+
+    attachTerminalInput(terminal, undefined, () => true, onSend);
+
+    keyHandler?.({
+      domEvent: createDomEvent({ code: 'ArrowLeft', key: 'ArrowLeft' }),
+    });
+    keyHandler?.({
+      domEvent: createDomEvent({ code: 'ArrowRight', key: 'ArrowRight' }),
+    });
+
+    expect(onSend).not.toHaveBeenCalled();
+    expect(terminal.write).not.toHaveBeenCalled();
+  });
+
+  it('sends DEL for Backspace', () => {
+    let keyHandler: ((e: TerminalKeyEvent) => void) | undefined;
+    const onSend = vi.fn();
+
+    const terminal = {
+      onKey: (cb: (e: TerminalKeyEvent) => void) => {
+        keyHandler = cb;
+      },
+      write: vi.fn(),
+      writeln: vi.fn(),
+    } as unknown as Parameters<typeof attachTerminalInput>[0];
+
+    attachTerminalInput(terminal, undefined, () => true, onSend);
+
+    keyHandler?.({
+      domEvent: createDomEvent({ code: 'KeyA', key: 'a' }),
+    });
+    keyHandler?.({
+      domEvent: createDomEvent({ code: 'Backspace', key: 'Backspace' }),
+    });
+
+    expect(onSend).toHaveBeenCalledWith('a');
+    expect(onSend).toHaveBeenCalledWith('\x7f');
+    expect(terminal.write).not.toHaveBeenCalled();
   });
 });
-

--- a/libs/terminal/src/lib/component/terminal-input.ts
+++ b/libs/terminal/src/lib/component/terminal-input.ts
@@ -1,63 +1,95 @@
 import { Terminal } from '@xterm/xterm';
 
-type CommandHandler = (command: string) => Promise<string>;
+type CommandHandler = (command: string) => void | Promise<void>;
 type InputEnabledHandler = () => boolean;
+type SendHandler = (data: string) => void;
+
+const CSI_ARROW_UP = '\x1b[A';
+const CSI_ARROW_DOWN = '\x1b[B';
+const DEL_BACKSPACE = '\x7f';
 
 /**
  * Attaches key input handling to an xterm Terminal instance.
- * Handles Enter, Backspace, and printable characters.
+ * Sends keystrokes via {@link onSend} for remote shell interaction (no local echo).
+ * Left/Right arrows are ignored per interactive console UX.
  */
 export function attachTerminalInput(
   terminal: Terminal,
   onCommand?: CommandHandler,
   isInputEnabled?: InputEnabledHandler,
+  onSend?: SendHandler,
 ): void {
   let inputBuffer = '';
+
+  const send = (data: string): void => {
+    onSend?.(data);
+  };
 
   terminal.onKey((e) => {
     const ev = e.domEvent;
     const inputEnabled = isInputEnabled ? isInputEnabled() : true;
-    const printable = !ev.altKey && !ev.ctrlKey && !ev.metaKey;
 
-    // 未接続時は入力を完全に無視する（xterm 側の入力も出さない）
     if (!inputEnabled) {
       inputBuffer = '';
       return;
     }
 
-    if (ev.code === 'Enter') {
-      const command = inputBuffer.trim();
-      terminal.write('\r\n');
+    if (ev.code === 'ArrowLeft' || ev.code === 'ArrowRight') {
+      ev.preventDefault();
+      return;
+    }
+
+    if (ev.code === 'ArrowUp') {
+      ev.preventDefault();
+      // Remote shell owns the line after history/completion; drop local tracking.
       inputBuffer = '';
+      send(CSI_ARROW_UP);
+      return;
+    }
 
-      if (!command) {
-        return;
+    if (ev.code === 'ArrowDown') {
+      ev.preventDefault();
+      inputBuffer = '';
+      send(CSI_ARROW_DOWN);
+      return;
+    }
+
+    if (ev.code === 'Tab') {
+      ev.preventDefault();
+      inputBuffer = '';
+      send('\t');
+      return;
+    }
+
+    if (ev.code === 'Enter') {
+      ev.preventDefault();
+      const command = inputBuffer.trim();
+      inputBuffer = '';
+      send('\r');
+      if (command && onCommand) {
+        void onCommand(command);
       }
+      return;
+    }
 
-      if (!onCommand) {
-        terminal.writeln('(No command handler)');
-        return;
-      }
-
-      void onCommand(command)
-        .then((stdout) => {
-          if (stdout) {
-            terminal.write(stdout);
-          }
-        })
-        .catch((error) => {
-          const message =
-            error instanceof Error ? error.message : String(error);
-          terminal.writeln(`\r\nCommand failed: ${message}`);
-        });
-    } else if (ev.code === 'Backspace') {
+    if (ev.code === 'Backspace') {
+      ev.preventDefault();
       if (inputBuffer.length > 0) {
         inputBuffer = inputBuffer.slice(0, -1);
       }
-      terminal.write('\b \b'); // erase one char
-    } else if (printable) {
+      send(DEL_BACKSPACE);
+      return;
+    }
+
+    const printable =
+      !ev.altKey &&
+      !ev.ctrlKey &&
+      !ev.metaKey &&
+      ev.key.length === 1;
+
+    if (printable) {
       inputBuffer += ev.key;
-      terminal.write(ev.key);
+      send(ev.key);
     }
   });
 }

--- a/libs/terminal/src/lib/component/terminal-input.ts
+++ b/libs/terminal/src/lib/component/terminal-input.ts
@@ -35,12 +35,12 @@ export function attachTerminalInput(
     }
 
     if (ev.code === 'ArrowLeft' || ev.code === 'ArrowRight') {
-      ev.preventDefault();
+      ev.preventDefault?.();
       return;
     }
 
     if (ev.code === 'ArrowUp') {
-      ev.preventDefault();
+      ev.preventDefault?.();
       // Remote shell owns the line after history/completion; drop local tracking.
       inputBuffer = '';
       send(CSI_ARROW_UP);
@@ -48,21 +48,21 @@ export function attachTerminalInput(
     }
 
     if (ev.code === 'ArrowDown') {
-      ev.preventDefault();
+      ev.preventDefault?.();
       inputBuffer = '';
       send(CSI_ARROW_DOWN);
       return;
     }
 
     if (ev.code === 'Tab') {
-      ev.preventDefault();
+      ev.preventDefault?.();
       inputBuffer = '';
       send('\t');
       return;
     }
 
     if (ev.code === 'Enter') {
-      ev.preventDefault();
+      ev.preventDefault?.();
       const command = inputBuffer.trim();
       inputBuffer = '';
       send('\r');
@@ -73,7 +73,7 @@ export function attachTerminalInput(
     }
 
     if (ev.code === 'Backspace') {
-      ev.preventDefault();
+      ev.preventDefault?.();
       if (inputBuffer.length > 0) {
         inputBuffer = inputBuffer.slice(0, -1);
       }

--- a/libs/terminal/src/lib/component/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/src/lib/component/terminal-view/terminal-view.component.spec.ts
@@ -84,6 +84,10 @@ describe('TerminalViewComponent', () => {
     };
   }
 
+  function expectSentKeystrokes(...chunks: string[]): void {
+    expect(sendMock.mock.calls.map((call) => call[0])).toEqual(chunks);
+  }
+
   function typeCommand(command: string): void {
     const terminal = fixture.componentInstance.xterminal as unknown as {
       keyHandler?: (event: {
@@ -93,6 +97,7 @@ describe('TerminalViewComponent', () => {
           metaKey: boolean;
           code: string;
           key: string;
+          preventDefault?: () => void;
         };
       }) => void;
     };
@@ -105,6 +110,7 @@ describe('TerminalViewComponent', () => {
           metaKey: false,
           code: key === ' ' ? 'Space' : 'Key',
           key,
+          preventDefault: vi.fn(),
         },
       });
     }
@@ -115,6 +121,7 @@ describe('TerminalViewComponent', () => {
         metaKey: false,
         code: 'Enter',
         key: 'Enter',
+        preventDefault: vi.fn(),
       },
     });
   }
@@ -199,13 +206,14 @@ describe('TerminalViewComponent', () => {
 
     await vi.waitFor(() => {
       expect(clearSpy).toHaveBeenCalledTimes(1);
-      expect(sendMock).toHaveBeenCalledWith('clear\n');
+      expectSentKeystrokes(' ', 'c', 'l', 'e', 'a', 'r', ' ', '\r');
     });
 
+    sendMock.mockClear();
     typeCommand('pwd');
 
     await vi.waitFor(() => {
-      expect(sendMock).toHaveBeenCalledWith('pwd\n');
+      expectSentKeystrokes('p', 'w', 'd', '\r');
     });
     expect(clearSpy).toHaveBeenCalledTimes(1);
   });
@@ -252,7 +260,7 @@ describe('TerminalViewComponent', () => {
     typeCommand('pwd');
 
     await vi.waitFor(() => {
-      expect(sendMock).toHaveBeenCalledWith('pwd\n');
+      expectSentKeystrokes('p', 'w', 'd', '\r');
     });
   });
 
@@ -262,7 +270,19 @@ describe('TerminalViewComponent', () => {
     typeCommand('clear logs');
 
     await vi.waitFor(() => {
-      expect(sendMock).toHaveBeenCalledWith('clear logs\n');
+      expectSentKeystrokes(
+        'c',
+        'l',
+        'e',
+        'a',
+        'r',
+        ' ',
+        'l',
+        'o',
+        'g',
+        's',
+        '\r',
+      );
     });
     expect(clearSpy).not.toHaveBeenCalled();
   });
@@ -276,7 +296,9 @@ describe('TerminalViewComponent', () => {
     );
 
     typeCommand('clear');
-    await vi.waitFor(() => expect(sendMock).toHaveBeenCalledWith('clear\n'));
+    await vi.waitFor(() =>
+      expectSentKeystrokes('c', 'l', 'e', 'a', 'r', '\r'),
+    );
     writeSpy.mockClear();
 
     terminalTextSignal.set('previous outputnext output');

--- a/libs/terminal/src/lib/component/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/src/lib/component/terminal-view/terminal-view.component.ts
@@ -159,13 +159,14 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
 
     attachTerminalInput(
       this.xterminal,
-      async (command) => {
+      (command) => {
         if (command === 'clear') {
           this.clearTerminalDisplay();
         }
-        return this.console.runInteractiveCommand(command);
+        this.console.notifyInteractiveCommand(command);
       },
       () => this.serialInputEnabled,
+      (data) => this.console.sendInteractiveData(data),
     );
   }
 

--- a/libs/terminal/src/lib/service/terminal-console-orchestration.service.spec.ts
+++ b/libs/terminal/src/lib/service/terminal-console-orchestration.service.spec.ts
@@ -59,39 +59,36 @@ describe('TerminalConsoleOrchestrationService', () => {
     TestBed.resetTestingModule();
   });
 
-  it('delegates interactive input to send$ with newline', async () => {
+  it('sendInteractiveData forwards keystrokes to send$', () => {
     const svc = TestBed.inject(TerminalConsoleOrchestrationService);
-    await svc.runInteractiveCommand('uname');
-    expect(sendMock).toHaveBeenCalledWith('uname\n');
+    svc.sendInteractiveData('l');
+    svc.sendInteractiveData('\t');
+    svc.sendInteractiveData('\x1b[A');
+    expect(sendMock).toHaveBeenCalledWith('l');
+    expect(sendMock).toHaveBeenCalledWith('\t');
+    expect(sendMock).toHaveBeenCalledWith('\x1b[A');
     expect(beginLogoutPending).not.toHaveBeenCalled();
   });
 
-  it('marks logout pending before sending logout', async () => {
+  it('notifyInteractiveCommand marks logout pending for logout', () => {
     const svc = TestBed.inject(TerminalConsoleOrchestrationService);
-    await svc.runInteractiveCommand('logout');
+    svc.notifyInteractiveCommand('logout');
     expect(beginLogoutPending).toHaveBeenCalledTimes(1);
-    expect(sendMock).toHaveBeenCalledWith('logout\n');
+    expect(sendMock).not.toHaveBeenCalled();
   });
 
-  it('marks logout pending before sending exit', async () => {
+  it('notifyInteractiveCommand marks logout pending for exit', () => {
     const svc = TestBed.inject(TerminalConsoleOrchestrationService);
-    await svc.runInteractiveCommand('exit');
+    svc.notifyInteractiveCommand('exit');
     expect(beginLogoutPending).toHaveBeenCalledTimes(1);
-    expect(sendMock).toHaveBeenCalledWith('exit\n');
+    expect(sendMock).not.toHaveBeenCalled();
   });
 
-  it('runInteractiveCommand returns empty string (no stdout capture)', async () => {
+  it('notifyInteractiveCommand does not mark logout for other commands', () => {
     const svc = TestBed.inject(TerminalConsoleOrchestrationService);
-    const out = await svc.runInteractiveCommand('uname -a');
-    expect(out).toBe('');
-  });
-
-  it('coerces ls to dumb TERM and single-column for serial send', async () => {
-    const svc = TestBed.inject(TerminalConsoleOrchestrationService);
-    await svc.runInteractiveCommand('ls -la');
-    expect(sendMock).toHaveBeenCalledWith(
-      "LC_ALL=C LANG=C TERM=dumb LS_COLORS= ls -1 -la </dev/null 2>&1 | sed 's/^[[:blank:]]*//' | cat\n",
-    );
+    svc.notifyInteractiveCommand('uname');
+    expect(beginLogoutPending).not.toHaveBeenCalled();
+    expect(sendMock).not.toHaveBeenCalled();
   });
 
   it('runToolbarCommand reports not_connected when serial is down', async () => {

--- a/libs/terminal/src/lib/service/terminal-console-orchestration.service.ts
+++ b/libs/terminal/src/lib/service/terminal-console-orchestration.service.ts
@@ -34,11 +34,18 @@ export class TerminalConsoleOrchestrationService {
   readonly isConnected = this.serial.isConnected;
   readonly connectionEpoch = this.serial.connectionEpoch;
 
-  async runInteractiveCommand(command: string): Promise<string> {
+  /**
+   * 対話キーストロークをそのままシリアルへ送る（表示は terminalText 側）。
+   */
+  sendInteractiveData(data: string): void {
+    void firstValueFrom(this.serial.send$(data));
+  }
+
+  /**
+   * Enter 確定時の副作用のみ（logout 検知など）。行内容の再送はしない。
+   */
+  notifyInteractiveCommand(command: string): void {
     this.markLogoutPendingIfNeeded(command);
-    const payload = `${coerceLsForSerialListing(command)}\n`;
-    await firstValueFrom(this.serial.send$(payload));
-    return '';
   }
 
   async runToolbarCommand(cmd: string): Promise<


### PR DESCRIPTION
## Summary

- Tab / 矢印キーが `ev.key` 文字列として xterm に描画される不具合を修正しました
- 対話入力をキーストローク単位の `send$` パススルーに切り替え、リモートシェルの Tab 補完・上下履歴を有効化しました
- 左右矢印は送信せず無反応にしています

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #765

## What changed?

- `attachTerminalInput` で Tab / ↑↓ / Backspace / 印字文字をシリアルバイトへマップし、ローカルエコーを廃止
- `TerminalConsoleOrchestrationService` に `sendInteractiveData` / `notifyInteractiveCommand` を追加（対話では行全体の再送と `coerceLs` を行わない）
- Tab・矢印・パススルー送信の回帰テストを追加し、view / orchestration の期待値を更新

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details: `attachTerminalInput` に `onSend` 引数を追加。`runInteractiveCommand` を `sendInteractiveData` / `notifyInteractiveCommand` に置換
- [ ] This change is backward compatible
- [x] This change introduces a breaking change
 - Migration notes: 対話入力のエコーは `terminalText` 経由のみ。呼び出し側は `onSend` で `send$` に接続すること

## How to test

1. `pnpm nx test libs-terminal` が通ること
2. アプリを起動しデバイスにログインする
3. ファイル名の途中まで入力して Tab → 補完されること
4. ↑↓ → 前後のコマンド履歴が表示されること
5. ←→ → 文字が出ず無反応であること
6. 通常の文字入力で二重エコーにならないこと

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)