### PR TITLE
feat(terminal): apply vscode-like xterm theme

### DIFF
--- a/libs/terminal/src/lib/constants/index.ts
+++ b/libs/terminal/src/lib/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './xterm-theme';

--- a/libs/terminal/src/lib/constants/xterm-theme.ts
+++ b/libs/terminal/src/lib/constants/xterm-theme.ts
@@ -1,0 +1,32 @@
+import { ITheme } from '@xterm/xterm';
+
+/** VS Code 風ダークテーマ（Issue #767） */
+export const xtermConsoleTheme: ITheme = {
+  foreground: '#d4d4d4',
+  background: '#1e1e1e',
+
+  cursor: '#ffffff',
+  cursorAccent: '#1e1e1e',
+
+  selectionBackground: '#264f78',
+  selectionForeground: '#ffffff',
+  selectionInactiveBackground: '#3a3d41',
+
+  black: '#000000',
+  red: '#cd3131',
+  green: '#0dbc79',
+  yellow: '#e5e510',
+  blue: '#2472c8',
+  magenta: '#bc3fbc',
+  cyan: '#11a8cd',
+  white: '#e5e5e5',
+
+  brightBlack: '#666666',
+  brightRed: '#f14c4c',
+  brightGreen: '#23d18b',
+  brightYellow: '#f5f543',
+  brightBlue: '#3b8eea',
+  brightMagenta: '#d670d6',
+  brightCyan: '#29b8db',
+  brightWhite: '#ffffff',
+};

--- a/libs/terminal/src/lib/functions/coerce-ls-for-serial-listing.spec.ts
+++ b/libs/terminal/src/lib/functions/coerce-ls-for-serial-listing.spec.ts
@@ -3,13 +3,15 @@ import { coerceLsForSerialListing } from './coerce-ls-for-serial-listing';
 
 /** 端末幅列・段状スペース対策付きの ls パイプ */
 const lsSerialPipe = ' </dev/null 2>&1 | sed \'s/^[[:blank:]]*//\' | cat';
-const env = 'LC_ALL=C LANG=C TERM=dumb LS_COLORS= ';
+const env = 'LC_ALL=C LANG=C TERM=xterm-256color ';
 
 describe('coerceLsForSerialListing', () => {
-  it('prepends env, -1 where needed, and pipes through cat', () => {
-    expect(coerceLsForSerialListing('ls')).toBe(`${env}ls -1${lsSerialPipe}`);
+  it('prepends env, -1 where needed, color=always, and pipes through cat', () => {
+    expect(coerceLsForSerialListing('ls')).toBe(
+      `${env}ls --color=always -1${lsSerialPipe}`,
+    );
     expect(coerceLsForSerialListing('ls -la')).toBe(
-      `${env}ls -1 -la${lsSerialPipe}`,
+      `${env}ls --color=always -1 -la${lsSerialPipe}`,
     );
     expect(coerceLsForSerialListing('ls --color=never')).toBe(
       `${env}ls -1 --color=never${lsSerialPipe}`,
@@ -17,12 +19,14 @@ describe('coerceLsForSerialListing', () => {
   });
 
   it('does not double -1', () => {
-    expect(coerceLsForSerialListing('ls -1')).toBe(`${env}ls -1${lsSerialPipe}`);
+    expect(coerceLsForSerialListing('ls -1')).toBe(
+      `${env}ls --color=always -1${lsSerialPipe}`,
+    );
     expect(coerceLsForSerialListing('ls -1 /tmp')).toBe(
-      `${env}ls -1 /tmp${lsSerialPipe}`,
+      `${env}ls --color=always -1 /tmp${lsSerialPipe}`,
     );
     expect(coerceLsForSerialListing('ls -1la')).toBe(
-      `${env}ls -1la${lsSerialPipe}`,
+      `${env}ls --color=always -1la${lsSerialPipe}`,
     );
   });
 
@@ -34,10 +38,10 @@ describe('coerceLsForSerialListing', () => {
 
   it('pipes explicit single-column through cat', () => {
     expect(coerceLsForSerialListing('ls --format single-column')).toBe(
-      `${env}ls --format single-column${lsSerialPipe}`,
+      `${env}ls --color=always --format single-column${lsSerialPipe}`,
     );
     expect(coerceLsForSerialListing('ls --format=single-column')).toBe(
-      `${env}ls --format=single-column${lsSerialPipe}`,
+      `${env}ls --color=always --format=single-column${lsSerialPipe}`,
     );
   });
 });

--- a/libs/terminal/src/lib/functions/coerce-ls-for-serial-listing.ts
+++ b/libs/terminal/src/lib/functions/coerce-ls-for-serial-listing.ts
@@ -1,11 +1,25 @@
 /**
  * シリアル経由の擬似 TTY では `ls` が \\r / \\t / 端末幅で列を再描画し、xterm に階段状に見える。
- * `LC_ALL` / `TERM=dumb` / 単一列に加え、`</dev/null` でstdinを切り、パイプ経由で非 TTY とし、
+ * `LC_ALL` / 単一列に加え、`</dev/null` でstdinを切り、パイプ経由で非 TTY とし、
  * POSIX `sed` で行頭ホワイトのみ落とす（段状の先頭スペース）。
+ * 色は `--color=always`（未指定時）と `TERM=xterm-256color` で xterm テーマに渡す。
  */
 function wrapLsForSerial(innerLsCommand: string): string {
-  const env = 'LC_ALL=C LANG=C TERM=dumb LS_COLORS= ';
+  const env = 'LC_ALL=C LANG=C TERM=xterm-256color ';
   return `${env}${innerLsCommand} </dev/null 2>&1 | sed 's/^[[:blank:]]*//' | cat`;
+}
+
+/** ユーザーが既に `--color=...` を指定しているか */
+function hasColorOption(lsCommand: string): boolean {
+  return /(?:^|\s)--color(?:=|\s|$)/.test(lsCommand);
+}
+
+/** `--color` 未指定ならパイプ先でも色が出るよう `--color=always` を付与 */
+function withColorAlways(lsCommand: string): string {
+  if (hasColorOption(lsCommand)) {
+    return lsCommand;
+  }
+  return lsCommand.replace(/^ls\b/i, 'ls --color=always');
 }
 
 export function coerceLsForSerialListing(cmd: string): string {
@@ -16,14 +30,14 @@ export function coerceLsForSerialListing(cmd: string): string {
 
   let rest = t.replace(/^ls\s*/i, '');
   if (/^--format(=single-column|\s+)/i.test(rest)) {
-    return wrapLsForSerial(t);
+    return wrapLsForSerial(withColorAlways(t));
   }
 
   /** 既に `-1` が付いた形（単独フラグまたは `-1lah` などクラスタ） */
   if (rest.startsWith('-1')) {
-    return wrapLsForSerial(t);
+    return wrapLsForSerial(withColorAlways(t));
   }
 
   rest = rest.length > 0 ? `-1 ${rest}` : '-1';
-  return wrapLsForSerial(`ls ${rest}`);
+  return wrapLsForSerial(withColorAlways(`ls ${rest}`));
 }

--- a/libs/terminal/src/lib/functions/xterm-config.spec.ts
+++ b/libs/terminal/src/lib/functions/xterm-config.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { xtermConsoleTheme } from '../constants';
+import { xtermConsoleConfigOptions } from './xterm-config';
+
+describe('xtermConsoleConfigOptions', () => {
+  it('uses the shared vscode-like theme palette', () => {
+    expect(xtermConsoleConfigOptions.theme).toBe(xtermConsoleTheme);
+    expect(xtermConsoleConfigOptions.theme?.background).toBe('#1e1e1e');
+    expect(xtermConsoleConfigOptions.theme?.foreground).toBe('#d4d4d4');
+    expect(xtermConsoleConfigOptions.theme?.green).toBe('#0dbc79');
+    expect(xtermConsoleConfigOptions.theme?.brightBlue).toBe('#3b8eea');
+    expect(xtermConsoleConfigOptions.theme?.selectionBackground).toBe(
+      '#264f78',
+    );
+  });
+
+  it('sets minimumContrastRatio on terminal options', () => {
+    expect(xtermConsoleConfigOptions.minimumContrastRatio).toBe(4.5);
+  });
+
+  it('keeps existing cursor options', () => {
+    expect(xtermConsoleConfigOptions.cursorBlink).toBe(true);
+    expect(xtermConsoleConfigOptions.cursorStyle).toBe('underline');
+    expect(xtermConsoleConfigOptions.cursorWidth).toBe(2);
+  });
+});

--- a/libs/terminal/src/lib/functions/xterm-config.ts
+++ b/libs/terminal/src/lib/functions/xterm-config.ts
@@ -1,4 +1,5 @@
 import { ITerminalInitOnlyOptions, ITerminalOptions } from '@xterm/xterm';
+import { xtermConsoleTheme } from '../constants';
 
 export type XtermConsoleConfigOptions = ITerminalOptions &
   ITerminalInitOnlyOptions;
@@ -7,7 +8,6 @@ export const xtermConsoleConfigOptions: XtermConsoleConfigOptions = {
   cursorBlink: true,
   cursorStyle: 'underline',
   cursorWidth: 2,
-  theme: {
-    background: 'black',
-  },
+  minimumContrastRatio: 4.5,
+  theme: xtermConsoleTheme,
 };

--- a/libs/web-serial/src/lib/constants/pi-zero-bootstrap.config.ts
+++ b/libs/web-serial/src/lib/constants/pi-zero-bootstrap.config.ts
@@ -26,6 +26,11 @@ export const PI_ZERO_TZ_ENV = PI_ZERO_TIMEZONE;
 export const PI_ZERO_ENVIRONMENT_STEPS: readonly PiZeroEnvironmentStep[] = [
   {
     statusMessage:
+      '[コンソール] 端末種別 TERM=xterm-256color を設定しています...',
+    command: 'export TERM=xterm-256color',
+  },
+  {
+    statusMessage:
       `[コンソール] 言語環境変数 LANG=${PI_ZERO_LANG} / LC_ALL=${PI_ZERO_LC_ALL} を設定しています...`,
     command: `export LANG=${PI_ZERO_LANG} LC_ALL=${PI_ZERO_LC_ALL}`,
   },

--- a/libs/web-serial/src/lib/functions/sanitize-serial-stdout.spec.ts
+++ b/libs/web-serial/src/lib/functions/sanitize-serial-stdout.spec.ts
@@ -61,7 +61,7 @@ describe('sanitizeSerialStdout', () => {
       '合計 36\n       drwx------ 5 pi pi 4096 .\npi@raspberrypi:';
     const out = sanitizeSerialStdout(
       raw,
-      "LC_ALL=C LANG=C TERM=dumb LS_COLORS= ls -1 -la </dev/null 2>&1 | sed 's/^[[:blank:]]*//' | cat",
+      "LC_ALL=C LANG=C TERM=xterm-256color ls --color=always -1 -la </dev/null 2>&1 | sed 's/^[[:blank:]]*//' | cat",
       'pi@raspberrypi:',
     );
     expect(out).toBe('合計 36\ndrwx------ 5 pi pi 4096 .');
@@ -69,11 +69,11 @@ describe('sanitizeSerialStdout', () => {
 
   it('strips coerced ls even when UART splits the echoed command across line breaks', () => {
     const cmd =
-      "LC_ALL=C LANG=C TERM=dumb LS_COLORS= ls -1 -la </dev/null 2>&1 | sed 's/^[[:blank:]]*//' | cat";
+      "LC_ALL=C LANG=C TERM=xterm-256color ls --color=always -1 -la </dev/null 2>&1 | sed 's/^[[:blank:]]*//' | cat";
     const raw =
       'stale block before echo\ntotal 36\njunk\n' +
-      'LC_ALL=C LANG=C TERM=dumb\n' +
-      'LS_COLORS= ls -1 -la </dev/null 2>&1\n' +
+      'LC_ALL=C LANG=C TERM=xterm-256color\n' +
+      'ls --color=always -1 -la </dev/null 2>&1\n' +
       "| sed 's/^[[:blank:]]*//' | cat\n" +
       'total 36\ndrwx------ 5 pi\npi@raspberrypi:~$ ';
     const out = sanitizeSerialStdout(raw, cmd, 'pi@raspberrypi:~$ ');
@@ -97,7 +97,7 @@ describe('sanitizeSerialStdout', () => {
 
   it('trims leading spaces on every ls output line (CR jitter stairs)', () => {
     const cmd =
-      "LC_ALL=C LANG=C TERM=dumb LS_COLORS= ls -1 -la </dev/null 2>&1 | sed 's/^[[:blank:]]*//' | cat";
+      "LC_ALL=C LANG=C TERM=xterm-256color ls --color=always -1 -la </dev/null 2>&1 | sed 's/^[[:blank:]]*//' | cat";
     const raw =
       'total 40\n' +
       '        drwx------ 5 pi pi 4096 .\n' +
@@ -111,7 +111,7 @@ describe('sanitizeSerialStdout', () => {
 
   it('collapses intra-line \\r for ls before trim (TTY column redraw)', () => {
     const cmd =
-      "LC_ALL=C LANG=C TERM=dumb LS_COLORS= ls -1 -la </dev/null 2>&1 | sed 's/^[[:blank:]]*//' | cat";
+      "LC_ALL=C LANG=C TERM=xterm-256color ls --color=always -1 -la </dev/null 2>&1 | sed 's/^[[:blank:]]*//' | cat";
     const raw =
       'total 40\n' +
       '     drwx------\r        drwx------ 5 pi pi 4096 .\n' +

--- a/libs/web-serial/src/lib/service/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-serial-bootstrap.service.spec.ts
@@ -44,7 +44,7 @@ describe('PiZeroSerialBootstrapService', () => {
     expect(send$).toHaveBeenCalledWith(`${PI_ZERO_LOGIN_USER}\r\n`);
     expect(send$).toHaveBeenCalledWith(`${PI_ZERO_LOGIN_PASSWORD}\r\n`);
     expect(logs.some((l) => l.includes('シェルプロンプトを待機中'))).toBe(true);
-    expect(exec).toHaveBeenCalledTimes(6); // environment setup steps
+    expect(exec).toHaveBeenCalledTimes(7); // environment setup steps
   });
 
   it('skips login send when shell already visible after flush', async () => {

--- a/libs/web-serial/src/lib/service/pi-zero-session.service.spec.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-session.service.spec.ts
@@ -368,11 +368,12 @@ describe('PiZeroSessionService', () => {
       const service = createSession(serial, createShellReadinessMock());
       await firstValueFrom(service.setupEnvironment$());
 
-      expect(exec).toHaveBeenCalledTimes(6);
-      expect(exec.mock.calls[0]?.[0]).toContain('export LANG=');
-      expect(exec.mock.calls[2]?.[0]).toContain('timedatectl set-timezone');
-      expect(exec.mock.calls[3]?.[0]).toBe('timedatectl status');
-      expect(exec.mock.calls[4]?.[0]).toContain('export TZ=');
+      expect(exec).toHaveBeenCalledTimes(7);
+      expect(exec.mock.calls[0]?.[0]).toBe('export TERM=xterm-256color');
+      expect(exec.mock.calls[1]?.[0]).toContain('export LANG=');
+      expect(exec.mock.calls[3]?.[0]).toContain('timedatectl set-timezone');
+      expect(exec.mock.calls[4]?.[0]).toBe('timedatectl status');
+      expect(exec.mock.calls[5]?.[0]).toContain('export TZ=');
     });
   });
 

--- a/libs/web-serial/src/lib/service/serial-transport.service.spec.ts
+++ b/libs/web-serial/src/lib/service/serial-transport.service.spec.ts
@@ -28,7 +28,8 @@ vi.mock('@gurezo/web-serial-rxjs', async (importOriginal) => {
     await importOriginal<typeof import('@gurezo/web-serial-rxjs')>();
   return {
     ...actual,
-    createSerialSession: () => mockCreateSerialSession(),
+    createSerialSession: (...args: unknown[]) =>
+      mockCreateSerialSession(...args),
   };
 });
 
@@ -105,6 +106,20 @@ describe('SerialTransportService', () => {
     expect(service.isConnected()).toBe(true);
     expect(service.getPortInfo()).toEqual(portInfo);
     expect(session.connect$).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates session with stripAnsi disabled so xterm can render colors', async () => {
+    mockCreateSerialSession.mockReturnValue(
+      buildMockSession({} as SerialPortInfo),
+    );
+
+    await firstValueFrom(service.connect$());
+
+    expect(mockCreateSerialSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        terminalBuffer: { stripAnsi: false },
+      }),
+    );
   });
 
   it('should clear session and return to idle after disconnect', async () => {

--- a/libs/web-serial/src/lib/service/serial-transport.service.ts
+++ b/libs/web-serial/src/lib/service/serial-transport.service.ts
@@ -138,6 +138,10 @@ export class SerialTransportService {
             usbProductId: RASPBERRY_PI_ZERO_INFO.usbProductId,
           },
         ],
+        // xterm の ITheme / ANSI 色を効かせるため、表示用バッファでは ANSI を残す
+        terminalBuffer: {
+          stripAnsi: false,
+        },
       });
       this.active = session;
       this.activeSession$.next(session);


### PR DESCRIPTION
## Summary

黒背景・白文字だった xterm に、VS Code 風のダークテーマ（前景・背景・カーソル・選択・ANSI 16色）と `minimumContrastRatio` を適用しました。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #767

## What changed?

- `xtermConsoleTheme`（`ITheme`）を `libs/terminal` の constants に追加
- `xtermConsoleConfigOptions` でテーマと `minimumContrastRatio: 4.5` を配線（contrast は options ルートに配置）
- テーマ・contrast・カーソル設定の単体テストを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx test libs-terminal` / `pnpm nx lint libs-terminal` が通ることを確認
2. アプリを起動しターミナル画面を開く
3. 背景が `#1e1e1e`、前景が薄いグレー、ANSI 色・選択色が反映されていることを目視確認

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)