### PR TITLE
feat(terminal): focus terminal after auto-login

### DIFF
--- a/libs/terminal/src/lib/component/terminal-view/terminal-view.component.spec.ts
+++ b/libs/terminal/src/lib/component/terminal-view/terminal-view.component.spec.ts
@@ -12,6 +12,7 @@ vi.mock('@xterm/xterm', () => {
     write = vi.fn();
     clear = vi.fn();
     reset = vi.fn();
+    focus = vi.fn();
     keyHandler?: (event: {
       domEvent: {
         altKey: boolean;
@@ -233,6 +234,52 @@ describe('TerminalViewComponent', () => {
 
     await Promise.resolve();
     expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it('focuses xterm when serial input becomes enabled after login', async () => {
+    connectionVmSignal.set(
+      vmDefaults({
+        isConnected: true,
+        isLoggedIn: false,
+        setupStatus: 'waiting-login',
+      }),
+    );
+    TestBed.flushEffects();
+    await Promise.resolve();
+
+    const focusSpy = vi.spyOn(fixture.componentInstance.xterminal, 'focus');
+    focusSpy.mockClear();
+
+    connectionVmSignal.set(
+      vmDefaults({
+        isConnected: true,
+        isLoggedIn: true,
+        setupStatus: 'setting-timezone',
+      }),
+    );
+    TestBed.flushEffects();
+    await Promise.resolve();
+
+    expect(focusSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refocus xterm when serial input stays enabled', async () => {
+    await Promise.resolve();
+    const focusSpy = vi.spyOn(fixture.componentInstance.xterminal, 'focus');
+    focusSpy.mockClear();
+
+    connectionVmSignal.set(
+      vmDefaults({
+        isConnected: true,
+        isLoggedIn: true,
+        setupStatus: 'ready',
+        errorMessage: null,
+      }),
+    );
+    TestBed.flushEffects();
+    await Promise.resolve();
+
+    expect(focusSpy).not.toHaveBeenCalled();
   });
 
   it('ignores typed input while rebootPending is true', async () => {

--- a/libs/terminal/src/lib/component/terminal-view/terminal-view.component.ts
+++ b/libs/terminal/src/lib/component/terminal-view/terminal-view.component.ts
@@ -74,8 +74,15 @@ export class TerminalViewComponent implements AfterViewInit, OnDestroy {
       const connectionBusy =
         vm.isConnecting ||
         (vm.isConnected && !vm.isLoggedIn && vm.setupStatus !== 'failed');
+      const wasEnabled = this.serialInputEnabled;
       this.serialInputEnabled =
         connected && !logoutPending && !rebootPending && !connectionBusy;
+      // オートログイン完了などで入力が解禁された直後に xterm へフォーカスする（#772）
+      if (!wasEnabled && this.serialInputEnabled) {
+        untracked(() => {
+          queueMicrotask(() => this.xterminal.focus());
+        });
+      }
       if (!connected) {
         this.lastTerminalText = '';
       }


### PR DESCRIPTION
## Summary

オートログイン完了後に xterm へフォーカスを移し、クリックなしでターミナルへキー入力できるようにします。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #772

## What changed?

- `TerminalViewComponent` で `serialInputEnabled` が `false → true` になったとき、`queueMicrotask` 経由で `xterminal.focus()` を呼ぶようにした
- 入力が既に有効なまま再評価された場合は再フォーカスしないことをユニットテストでカバーした

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. アプリを起動し、Connect からシリアル接続する
2. 「オートログイン中」オーバーレイが消えるのを待つ
3. ターミナルをクリックせずにキー入力し、シェルに文字が届くことを確認する
4. （任意）`pnpm nx test libs-terminal` / `pnpm nx lint libs-terminal` が通ることを確認する

## Environment (if relevant)

- Browser: Chromium 系（Web Serial 対応）
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)