### PR TITLE
feat(example): download example js to current shell directory

### DIFF
--- a/libs/example/project.json
+++ b/libs/example/project.json
@@ -10,7 +10,8 @@
   ],
   "implicitDependencies": [
     "libs-editor",
-    "libs-shared"
+    "libs-shared",
+    "libs-web-serial"
   ],
   "targets": {
     "build": {

--- a/libs/example/src/lib/component/example-item/example-item.component.html
+++ b/libs/example/src/lib/component/example-item/example-item.component.html
@@ -34,6 +34,8 @@
         <mat-icon
           matTooltip="{{ element.id }} example Javascript Download"
           class="cursor-pointer"
+          [class.pointer-events-none]="downloadInProgress()"
+          [class.opacity-40]="downloadInProgress()"
           (click)="onSave(element)"
         >
           download

--- a/libs/example/src/lib/component/example-item/example-item.component.spec.ts
+++ b/libs/example/src/lib/component/example-item/example-item.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it, vi } from 'vitest';
 import { ExampleItemComponent } from './example-item.component';
 
 describe('ExampleItemComponent', () => {
@@ -13,11 +14,48 @@ describe('ExampleItemComponent', () => {
     fixture = TestBed.createComponent(ExampleItemComponent);
     component = fixture.componentInstance;
     fixture.componentRef.setInput('label', 'Test');
-    fixture.componentRef.setInput('exampleItem', []);
+    fixture.componentRef.setInput('exampleItem', [
+      {
+        id: 'hello-real-world',
+        title: 'Lチカ',
+        overview: 'blink',
+        js: '',
+        circuit: '',
+        link: '',
+      },
+    ]);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('emits saveExample when download is not in progress', () => {
+    const emitSpy = vi.spyOn(component.saveExample, 'emit');
+    component.onSave({
+      id: 'hello-real-world',
+      title: 'Lチカ',
+      overview: 'blink',
+      js: '',
+      circuit: '',
+      link: '',
+    });
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit saveExample while download is in progress', () => {
+    fixture.componentRef.setInput('downloadInProgress', true);
+    fixture.detectChanges();
+    const emitSpy = vi.spyOn(component.saveExample, 'emit');
+    component.onSave({
+      id: 'hello-real-world',
+      title: 'Lチカ',
+      overview: 'blink',
+      js: '',
+      circuit: '',
+      link: '',
+    });
+    expect(emitSpy).not.toHaveBeenCalled();
   });
 });

--- a/libs/example/src/lib/component/example-item/example-item.component.ts
+++ b/libs/example/src/lib/component/example-item/example-item.component.ts
@@ -12,6 +12,7 @@ import { ExampleItem } from '../../models';
 export class ExampleItemComponent {
   readonly label = input.required<string>();
   readonly exampleItem = input.required<ExampleItem[]>();
+  readonly downloadInProgress = input(false);
   readonly saveExample = output<ExampleItem>();
   displayedColumns: string[] = [
     'id',
@@ -23,6 +24,9 @@ export class ExampleItemComponent {
   ];
 
   onSave(element: ExampleItem): void {
+    if (this.downloadInProgress()) {
+      return;
+    }
     this.saveExample.emit(element);
   }
 }

--- a/libs/example/src/lib/component/example-list/example-list.component.html
+++ b/libs/example/src/lib/component/example-list/example-list.component.html
@@ -3,16 +3,19 @@
     <choh-example-item
       [label]="'GPIO'"
       [exampleItem]="gpioExample()"
+      [downloadInProgress]="downloadInProgress()"
       (saveExample)="saveExample.emit($event)"
     />
     <choh-example-item
       [label]="'I2C'"
       [exampleItem]="i2cExample()"
+      [downloadInProgress]="downloadInProgress()"
       (saveExample)="saveExample.emit($event)"
     />
     <choh-example-item
       [label]="'Remote'"
       [exampleItem]="remoteExample()"
+      [downloadInProgress]="downloadInProgress()"
       (saveExample)="saveExample.emit($event)"
     />
   </div>

--- a/libs/example/src/lib/component/example-list/example-list.component.ts
+++ b/libs/example/src/lib/component/example-list/example-list.component.ts
@@ -14,5 +14,6 @@ export class ExampleListComponent {
   readonly gpioExample = input.required<ExampleItem[]>();
   readonly i2cExample = input.required<ExampleItem[]>();
   readonly remoteExample = input.required<ExampleItem[]>();
+  readonly downloadInProgress = input(false);
   readonly saveExample = output<ExampleItem>();
 }

--- a/libs/example/src/lib/component/example/example.component.html
+++ b/libs/example/src/lib/component/example/example.component.html
@@ -11,6 +11,7 @@
         [gpioExample]="example[0]"
         [i2cExample]="example[1]"
         [remoteExample]="example[2]"
+        [downloadInProgress]="downloadInProgress()"
         (saveExample)="onSaveExample($event)"
       />
     }

--- a/libs/example/src/lib/component/example/example.component.spec.ts
+++ b/libs/example/src/lib/component/example/example.component.spec.ts
@@ -1,14 +1,24 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NotificationService } from '@libs-shared';
 import { SerialNotificationService } from '@libs-web-serial';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ExampleDownloadService } from '../../service';
 import { ExampleComponent } from './example.component';
 
 describe('ExampleComponent', () => {
   let component: ExampleComponent;
   let fixture: ComponentFixture<ExampleComponent>;
+  const downloadToShellCwd = vi.fn();
+  const notifySuccess = vi.fn();
+  const notifyError = vi.fn();
 
   beforeEach(async () => {
+    downloadToShellCwd.mockReset();
+    notifySuccess.mockReset();
+    notifyError.mockReset();
+    downloadToShellCwd.mockResolvedValue('main-hello-real-world.js');
+
     await TestBed.configureTestingModule({
       imports: [ExampleComponent, HttpClientTestingModule],
       providers: [
@@ -20,6 +30,18 @@ describe('ExampleComponent', () => {
             notifyConnectionError: () => undefined,
             notifyLogoutDetected: () => undefined,
             notifyLogoutCancelled: () => undefined,
+          },
+        },
+        {
+          provide: ExampleDownloadService,
+          useValue: { downloadToShellCwd },
+        },
+        {
+          provide: NotificationService,
+          useValue: {
+            success: notifySuccess,
+            error: notifyError,
+            warning: vi.fn(),
           },
         },
       ],
@@ -46,5 +68,74 @@ describe('ExampleComponent', () => {
     const card = outer?.querySelector(':scope > div');
     expect(card?.className).toMatch(/\bflex-1\b/);
     expect(card?.className).toMatch(/\boverflow-hidden\b/);
+  });
+
+  it('onSaveExample downloads via serial and notifies success', async () => {
+    await component.onSaveExample({
+      id: 'hello-real-world',
+      title: 'Lチカ',
+      overview: 'blink',
+      js: '',
+      circuit: '',
+      link: '',
+    });
+
+    expect(downloadToShellCwd).toHaveBeenCalledWith('hello-real-world');
+    expect(notifySuccess).toHaveBeenCalledWith(
+      'Example',
+      'main-hello-real-world.js をターミナルのカレントディレクトリに保存しました',
+    );
+    expect(component.downloadInProgress()).toBe(false);
+  });
+
+  it('onSaveExample notifies error on failure', async () => {
+    downloadToShellCwd.mockRejectedValue(new Error('Serial port is not connected'));
+
+    await component.onSaveExample({
+      id: 'hello-real-world',
+      title: 'Lチカ',
+      overview: 'blink',
+      js: '',
+      circuit: '',
+      link: '',
+    });
+
+    expect(notifyError).toHaveBeenCalledWith(
+      'Example',
+      'Serial port is not connected',
+    );
+    expect(component.downloadInProgress()).toBe(false);
+  });
+
+  it('onSaveExample ignores clicks while download is in progress', async () => {
+    let resolveDownload!: (value: string) => void;
+    downloadToShellCwd.mockReturnValue(
+      new Promise<string>((resolve) => {
+        resolveDownload = resolve;
+      }),
+    );
+
+    const first = component.onSaveExample({
+      id: 'hello-real-world',
+      title: 'Lチカ',
+      overview: 'blink',
+      js: '',
+      circuit: '',
+      link: '',
+    });
+    expect(component.downloadInProgress()).toBe(true);
+
+    await component.onSaveExample({
+      id: 'gpio-onchange',
+      title: 'スイッチ',
+      overview: 'switch',
+      js: '',
+      circuit: '',
+      link: '',
+    });
+
+    expect(downloadToShellCwd).toHaveBeenCalledTimes(1);
+    resolveDownload('main-hello-real-world.js');
+    await first;
   });
 });

--- a/libs/example/src/lib/component/example/example.component.ts
+++ b/libs/example/src/lib/component/example/example.component.ts
@@ -1,9 +1,9 @@
 import { AsyncPipe } from '@angular/common';
-import { Component, inject, OnInit } from '@angular/core';
-import { EditorService } from '@libs-editor';
-import { BehaviorSubject, firstValueFrom, forkJoin } from 'rxjs';
+import { Component, inject, OnInit, signal } from '@angular/core';
+import { NotificationService } from '@libs-shared';
+import { BehaviorSubject, forkJoin } from 'rxjs';
 import { ExampleItem } from '../../models';
-import { ExampleDataService, ExampleService } from '../../service';
+import { ExampleDataService, ExampleDownloadService } from '../../service';
 import { ExampleListComponent } from '../example-list/example-list.component';
 
 @Component({
@@ -16,8 +16,10 @@ import { ExampleListComponent } from '../example-list/example-list.component';
 })
 export class ExampleComponent implements OnInit {
   private exampleDataService = inject(ExampleDataService);
-  private exampleService = inject(ExampleService);
-  private editorService = inject(EditorService);
+  private exampleDownload = inject(ExampleDownloadService);
+  private notify = inject(NotificationService);
+
+  readonly downloadInProgress = signal(false);
 
   exampleSubject = new BehaviorSubject<
     [ExampleItem[], ExampleItem[], ExampleItem[]]
@@ -33,14 +35,24 @@ export class ExampleComponent implements OnInit {
   }
 
   async onSaveExample(example: ExampleItem): Promise<void> {
+    if (this.downloadInProgress()) {
+      return;
+    }
+
+    this.downloadInProgress.set(true);
     try {
-      const blob = await firstValueFrom(
-        this.exampleService.downloadMainJs(example.id),
+      const fileName = await this.exampleDownload.downloadToShellCwd(example.id);
+      this.notify.success(
+        'Example',
+        `${fileName} をターミナルのカレントディレクトリに保存しました`,
       );
-      const text = await blob.text();
-      await this.editorService.saveTextFile(`/home/pi/${example.id}.js`, text);
-    } catch (error) {
+    } catch (error: unknown) {
+      const msg =
+        error instanceof Error ? error.message : 'ソースのダウンロードに失敗しました';
+      this.notify.error('Example', msg);
       console.warn('Failed to save example', error);
+    } finally {
+      this.downloadInProgress.set(false);
     }
   }
 }

--- a/libs/example/src/lib/functions/example.util.spec.ts
+++ b/libs/example/src/lib/functions/example.util.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildExampleDownloadFileName,
+  buildExampleMainJsUrl,
+  convertExampleJsonToList,
+} from './example.util';
+
+describe('example.util', () => {
+  it('convertExampleJsonToList fills empty display fields', () => {
+    expect(
+      convertExampleJsonToList([
+        { id: 'hello-real-world', title: 'Lチカ', overview: 'blink' },
+      ]),
+    ).toEqual([
+      {
+        id: 'hello-real-world',
+        title: 'Lチカ',
+        overview: 'blink',
+        js: '',
+        circuit: '',
+        link: '',
+      },
+    ]);
+  });
+
+  it('buildExampleMainJsUrl joins id with /main.js', () => {
+    expect(buildExampleMainJsUrl('hello-real-world')).toBe(
+      'https://tutorial.chirimen.org/pizero/esm-examples/hello-real-world/main.js',
+    );
+  });
+
+  it('buildExampleDownloadFileName prefixes main-', () => {
+    expect(buildExampleDownloadFileName('hello-real-world')).toBe(
+      'main-hello-real-world.js',
+    );
+  });
+});

--- a/libs/example/src/lib/functions/example.util.ts
+++ b/libs/example/src/lib/functions/example.util.ts
@@ -1,5 +1,8 @@
 import type { ExampleJson, ExampleItem } from '../models';
 
+const EXAMPLE_MAIN_JS_BASE_URL =
+  'https://tutorial.chirimen.org/pizero/esm-examples';
+
 export function convertExampleJsonToList(
   jsonList: ExampleJson[],
 ): ExampleItem[] {
@@ -9,4 +12,14 @@ export function convertExampleJsonToList(
     circuit: '',
     link: '',
   }));
+}
+
+/** Builds the upstream main.js URL for a CHIRIMEN example id. */
+export function buildExampleMainJsUrl(exampleId: string): string {
+  return `${EXAMPLE_MAIN_JS_BASE_URL}/${exampleId}/main.js`;
+}
+
+/** Builds the on-device file name used when downloading an example (legacy panel: `main-<id>.js`). */
+export function buildExampleDownloadFileName(exampleId: string): string {
+  return `main-${exampleId}.js`;
 }

--- a/libs/example/src/lib/service/example-download.service.spec.ts
+++ b/libs/example/src/lib/service/example-download.service.spec.ts
@@ -1,0 +1,68 @@
+import { TestBed } from '@angular/core/testing';
+import { SerialFacadeService } from '@libs-web-serial';
+import { of, throwError } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ExampleDownloadService } from './example-download.service';
+
+describe('ExampleDownloadService', () => {
+  let service: ExampleDownloadService;
+  const exec$ = vi.fn();
+  const isConnected = vi.fn();
+
+  beforeEach(() => {
+    exec$.mockReset();
+    isConnected.mockReset();
+    isConnected.mockReturnValue(true);
+    exec$.mockReturnValue(of({ stdout: '', stderr: '', exitCode: 0 }));
+
+    TestBed.configureTestingModule({
+      providers: [
+        ExampleDownloadService,
+        {
+          provide: SerialFacadeService,
+          useValue: {
+            exec$,
+            isConnected,
+          },
+        },
+      ],
+    });
+    service = TestBed.inject(ExampleDownloadService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('throws when serial is disconnected', async () => {
+    isConnected.mockReturnValue(false);
+    await expect(service.downloadToShellCwd('hello-real-world')).rejects.toThrow(
+      'Serial port is not connected',
+    );
+    expect(exec$).not.toHaveBeenCalled();
+  });
+
+  it('runs wget to shell cwd with correct url and file name', async () => {
+    const fileName = await service.downloadToShellCwd('hello-real-world');
+
+    expect(fileName).toBe('main-hello-real-world.js');
+    expect(exec$).toHaveBeenCalledTimes(1);
+    const [cmd, options] = exec$.mock.calls[0];
+    expect(cmd).toContain('wget -O');
+    expect(cmd).toContain('main-hello-real-world.js');
+    expect(cmd).toContain(
+      'https://tutorial.chirimen.org/pizero/esm-examples/hello-real-world/main.js',
+    );
+    expect(options).toMatchObject({
+      prompt: 'pi@raspberrypi:',
+      timeout: 60_000,
+    });
+  });
+
+  it('propagates exec$ failures', async () => {
+    exec$.mockReturnValue(throwError(() => new Error('timeout')));
+    await expect(service.downloadToShellCwd('gpio-onchange')).rejects.toThrow(
+      'timeout',
+    );
+  });
+});

--- a/libs/example/src/lib/service/example-download.service.ts
+++ b/libs/example/src/lib/service/example-download.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, inject } from '@angular/core';
+import {
+  FileUtils,
+  PI_ZERO_PROMPT,
+  SERIAL_TIMEOUT,
+  SerialFacadeService,
+} from '@libs-web-serial';
+import { firstValueFrom } from 'rxjs';
+import {
+  buildExampleDownloadFileName,
+  buildExampleMainJsUrl,
+} from '../functions';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ExampleDownloadService {
+  private serial = inject(SerialFacadeService);
+
+  /**
+   * Downloads example main.js onto the device shell cwd via wget
+   * (same session as the interactive terminal).
+   *
+   * @returns Saved relative file name (e.g. `main-hello-real-world.js`)
+   */
+  async downloadToShellCwd(exampleId: string): Promise<string> {
+    if (!this.serial.isConnected()) {
+      throw new Error('Serial port is not connected');
+    }
+
+    const fileName = buildExampleDownloadFileName(exampleId);
+    const url = buildExampleMainJsUrl(exampleId);
+    const escapedFileName = FileUtils.escapePath(fileName);
+
+    await firstValueFrom(
+      this.serial.exec$(`wget -O ${escapedFileName} ${url}`, {
+        prompt: PI_ZERO_PROMPT,
+        timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
+      }),
+    );
+
+    return fileName;
+  }
+}

--- a/libs/example/src/lib/service/example.service.ts
+++ b/libs/example/src/lib/service/example.service.ts
@@ -12,20 +12,4 @@ export class ExampleService {
   getJsonArray(path: string): Observable<Array<ExampleJson>> {
     return this.http.get<Array<ExampleJson>>(path);
   }
-
-  downloadMainJs(exampleName: string): Observable<Blob> {
-    // memo
-    // eligrey / FileSaver.js を使うか後で判断
-    // https://github.com/eligrey/FileSaver.js
-    // https://zenn.dev/daiki_21/scraps/ff4ee44566b24a
-
-    return this.http.get(
-      'https://tutorial.chirimen.org/pizero/esm-examples/' +
-        exampleName +
-        'main.js',
-      {
-        responseType: 'blob',
-      },
-    );
-  }
 }

--- a/libs/example/src/lib/service/index.ts
+++ b/libs/example/src/lib/service/index.ts
@@ -1,2 +1,3 @@
 export * from './example.data.service';
+export * from './example-download.service';
 export * from './example.service';

--- a/libs/example/vitest.config.ts
+++ b/libs/example/vitest.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
       '@libs-dialogs': resolve(__dirname, '../dialogs/src/index.ts'),
       '@libs-shared': resolve(__dirname, '../shared/src/index.ts'),
       '@libs-editor': resolve(__dirname, '../editor/src/index.ts'),
+      '@libs-web-serial': resolve(__dirname, '../web-serial/src/index.ts'),
     },
   },
 });


### PR DESCRIPTION
## Summary

- Example の JS ダウンロードを、壊れていたブラウザ HTTP 取得からシリアル経由の `wget` に置き換えました
- 保存先は対話ターミナルと同一シェルのカレントディレクトリです（旧 chirimenPanel の `receiveMessage` 相当）
- URL を `.../esm-examples/<id>/main.js` に修正し、ファイル名は `main-<id>.js` としました

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #774

## What changed?

- `buildExampleMainJsUrl` / `buildExampleDownloadFileName` ヘルパーを追加
- `ExampleDownloadService` を新設し、`SerialFacadeService.exec$` で `wget -O` を実行
- `ExampleComponent` から `EditorService` 依存の固定パス保存を削除し、通知・二重クリック防止を追加
- 壊れていた `ExampleService.downloadMainJs`（URL 結合ミス）を削除

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details: `ExampleService.downloadMainJs` を削除。代わりに `ExampleDownloadService.downloadToShellCwd` を追加
- [ ] This change is backward compatible
- [x] This change introduces a breaking change
 - Migration notes: アプリ内利用のみ。外部パッケージ公開 API ではないため利用者側の追従は不要

## How to test

1. Pi Zero に Web Serial で接続する
2. ターミナルで任意のディレクトリに `cd` する（例: `cd ~/myApp`）
3. Example 画面を開き、任意の行の download アイコンをクリックする
4. 成功通知が出ること、およびターミナル cwd に `main-<id>.js` が作成されること（`ls` で確認）
5. 未接続時にクリックするとエラー通知になること
6. `pnpm nx test libs-example` / `pnpm nx lint libs-example` が通ること

## Environment (if relevant)

- Browser: Chromium 系（Web Serial 対応）
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)