### PR TITLE
fix(wifi): restore wifi setup script write for #779

### DIFF
--- a/libs/web-serial/src/lib/functions/file.utils.spec.ts
+++ b/libs/web-serial/src/lib/functions/file.utils.spec.ts
@@ -1,0 +1,58 @@
+import { FileUtils } from './file.utils';
+
+describe('FileUtils heredoc helpers', () => {
+  describe('chooseHeredocDelimiter', () => {
+    it('uses CHIRIMEN_EOF when content has no collision', () => {
+      expect(FileUtils.chooseHeredocDelimiter('hello\nEOL\nworld')).toBe(
+        'CHIRIMEN_EOF',
+      );
+    });
+
+    it('increments suffix when CHIRIMEN_EOF appears as a line', () => {
+      expect(
+        FileUtils.chooseHeredocDelimiter('before\nCHIRIMEN_EOF\nafter'),
+      ).toBe('CHIRIMEN_EOF_0');
+    });
+
+    it('skips occupied numbered suffixes', () => {
+      const content = ['CHIRIMEN_EOF', 'CHIRIMEN_EOF_0', 'body'].join('\n');
+      expect(FileUtils.chooseHeredocDelimiter(content)).toBe('CHIRIMEN_EOF_1');
+    });
+  });
+
+  describe('generateHeredocCommand', () => {
+    it('keeps full content when body contains an EOL line', () => {
+      const content = [
+        '#!/bin/sh',
+        'sudo sh -c "cat > /tmp/x" <<EOL',
+        'ssid=test',
+        'EOL',
+        'echo done',
+      ].join('\n');
+
+      const command = FileUtils.generateHeredocCommand('/tmp/wifi_setup.sh', content);
+
+      expect(command).toContain(`<< 'CHIRIMEN_EOF'`);
+      expect(command.endsWith('\nCHIRIMEN_EOF')).toBe(true);
+      expect(command).toContain(content);
+      // outer delimiter must not be the colliding EOL used inside the script
+      expect(command).not.toMatch(/<< 'EOL'/);
+    });
+
+    it('escapes the target path', () => {
+      const command = FileUtils.generateHeredocCommand('/tmp/a b.sh', 'x');
+      expect(command.startsWith(`cat > ${FileUtils.escapePath('/tmp/a b.sh')}`)).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('generateAppendCommand', () => {
+    it('uses a collision-safe delimiter', () => {
+      const content = 'line\nCHIRIMEN_EOF\nmore';
+      const command = FileUtils.generateAppendCommand('notes.txt', content);
+      expect(command).toContain(`<< 'CHIRIMEN_EOF_0'`);
+      expect(command).toContain(content);
+    });
+  });
+});

--- a/libs/web-serial/src/lib/functions/file.utils.ts
+++ b/libs/web-serial/src/lib/functions/file.utils.ts
@@ -95,12 +95,38 @@ export class FileUtils {
     return bytes.buffer;
   }
 
+  /**
+   * 本文に現れない heredoc 終端を選ぶ（固定 `EOL` は内容中の `EOL` 行と衝突する）。
+   */
+  static chooseHeredocDelimiter(content: string): string {
+    const base = 'CHIRIMEN_EOF';
+    if (!FileUtils.contentHasDelimiterLine(content, base)) {
+      return base;
+    }
+    let n = 0;
+    while (FileUtils.contentHasDelimiterLine(content, `${base}_${n}`)) {
+      n += 1;
+    }
+    return `${base}_${n}`;
+  }
+
+  private static contentHasDelimiterLine(
+    content: string,
+    delimiter: string,
+  ): boolean {
+    return content.split(/\r?\n/).some((line) => line === delimiter);
+  }
+
   static generateHeredocCommand(fileName: string, content: string): string {
-    return `cat > ${fileName} << 'EOL'\n${content}\nEOL`;
+    const delimiter = FileUtils.chooseHeredocDelimiter(content);
+    const path = FileUtils.escapePath(fileName);
+    return `cat > ${path} << '${delimiter}'\n${content}\n${delimiter}`;
   }
 
   static generateAppendCommand(fileName: string, content: string): string {
-    return `cat >> ${fileName} << 'EOL'\n${content}\nEOL`;
+    const delimiter = FileUtils.chooseHeredocDelimiter(content);
+    const path = FileUtils.escapePath(fileName);
+    return `cat >> ${path} << '${delimiter}'\n${content}\n${delimiter}`;
   }
 
   static generateBase64SaveCommand(fileName: string): string {

--- a/libs/web-serial/src/lib/service/file-content.service.ts
+++ b/libs/web-serial/src/lib/service/file-content.service.ts
@@ -61,7 +61,7 @@ export class FileContentService {
     try {
       const command = FileUtils.generateHeredocCommand(path, content);
       await firstValueFrom(this.serial.exec$(command, {
-        prompt: 'EOL',
+        prompt: PI_ZERO_PROMPT,
         timeout: SERIAL_TIMEOUT.DEFAULT,
       }));
     } catch (error: unknown) {
@@ -106,7 +106,7 @@ export class FileContentService {
     try {
       const command = FileUtils.generateAppendCommand(path, content);
       await firstValueFrom(this.serial.exec$(command, {
-        prompt: 'EOL',
+        prompt: PI_ZERO_PROMPT,
         timeout: SERIAL_TIMEOUT.DEFAULT,
       }));
     } catch (error: unknown) {

--- a/libs/wifi/src/lib/service/wifi-config.service.spec.ts
+++ b/libs/wifi/src/lib/service/wifi-config.service.spec.ts
@@ -1,0 +1,59 @@
+import { TestBed } from '@angular/core/testing';
+import { FileContentService, SerialFacadeService } from '@libs-web-serial';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WifiConfigService } from './wifi-config.service';
+import { WifiRebootFlowService } from './wifi-reboot-flow.service';
+
+describe('WifiConfigService', () => {
+  let service: WifiConfigService;
+  let exec$: ReturnType<typeof vi.fn>;
+  let writeTextFile: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    exec$ = vi.fn().mockReturnValue(of({ stdout: '', stderr: '', exitCode: 0 }));
+    writeTextFile = vi.fn().mockResolvedValue(undefined);
+
+    TestBed.configureTestingModule({
+      providers: [
+        WifiConfigService,
+        {
+          provide: SerialFacadeService,
+          useValue: { exec$ },
+        },
+        {
+          provide: FileContentService,
+          useValue: { writeTextFile },
+        },
+        {
+          provide: WifiRebootFlowService,
+          useValue: { restartWifiService: vi.fn() },
+        },
+      ],
+    });
+
+    service = TestBed.inject(WifiConfigService);
+  });
+
+  it('writes wifi_setup.sh under /tmp and runs it from that path', async () => {
+    await service.setWiFi('MyNet', 'secret');
+
+    expect(writeTextFile).toHaveBeenCalledTimes(1);
+    const [path, script] = writeTextFile.mock.calls[0] as [string, string];
+    expect(path).toBe('/tmp/wifi_setup.sh');
+
+    expect(script).toContain('<<WPA_CONF_EOF');
+    expect(script).toContain('\nWPA_CONF_EOF\n');
+    expect(script).toContain('wpa_cli -i wlan0 reconfigure');
+    expect(script).toContain('nmcli dev wifi connect');
+    // bare EOL delimiter must not appear as a whole line (heredoc clash)
+    expect(script.split(/\r?\n/).some((line) => line === 'EOL')).toBe(false);
+
+    const runCmd = exec$.mock.calls
+      .map((args: unknown[]) => args[0] as string)
+      .find((cmd) => cmd.includes('/tmp/wifi_setup.sh'));
+    expect(runCmd).toBe(
+      `chmod +x /tmp/wifi_setup.sh && /tmp/wifi_setup.sh 'MyNet' 'secret'`,
+    );
+  });
+});

--- a/libs/wifi/src/lib/service/wifi-config.service.ts
+++ b/libs/wifi/src/lib/service/wifi-config.service.ts
@@ -32,23 +32,20 @@ export class WifiConfigService {
    */
   async setWiFi(ssid: string, password: string): Promise<void> {
     try {
-      await firstValueFrom(this.serial.exec$('cd', {
-        prompt: PI_ZERO_PROMPT,
-        timeout: SERIAL_TIMEOUT.DEFAULT,
-      }));
       await firstValueFrom(this.serial.exec$('sudo touch /boot/ssh', {
         prompt: PI_ZERO_PROMPT,
         timeout: SERIAL_TIMEOUT.DEFAULT,
       }));
 
       const wifiSetupScript = this.generateWifiSetupScript();
+      const scriptPath = '/tmp/wifi_setup.sh';
 
-      await this.fileContent.writeTextFile('wifi_setup.sh', wifiSetupScript);
+      await this.fileContent.writeTextFile(scriptPath, wifiSetupScript);
 
       const qSsid = shellSingleQuote(ssid);
       const qPass = shellSingleQuote(password);
       const result = await firstValueFrom(this.serial.exec$(
-        `chmod +x wifi_setup.sh && ./wifi_setup.sh ${qSsid} ${qPass}`,
+        `chmod +x ${scriptPath} && ${scriptPath} ${qSsid} ${qPass}`,
         {
           prompt: PI_ZERO_PROMPT,
           timeout: SERIAL_TIMEOUT.LONG,
@@ -102,7 +99,7 @@ DEBIAN_VERSION=$(cut -d . -f 1 /etc/debian_version)
 
 if [ "$DEBIAN_VERSION" -le 11 ]; then
   WPA_CONF_PATH=/etc/wpa_supplicant/wpa_supplicant.conf
-  sudo sh -c "cat > $WPA_CONF_PATH" <<EOL
+  sudo sh -c "cat > $WPA_CONF_PATH" <<WPA_CONF_EOF
 ctrl_interface=DIR=/var/run/wpa_supplicant GROUP=netdev
 update_config=1
 country=JP
@@ -110,7 +107,7 @@ network={
   ssid="$SSID"
   psk="$PASSWORD"
 }
-EOL
+WPA_CONF_EOF
   if ! sudo wpa_cli -i wlan0 reconfigure; then
     echo "WIFI_CONNECT_FAILED"
     exit 1


### PR DESCRIPTION
## Summary

WiFi 設定スクリプト書き込み時に heredoc 終端 `EOL` が衝突し、`wifi_setup.sh` が途中で切れて設定が永続化されない問題を修正しました。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #779

## What changed?

- `FileUtils.generateHeredocCommand` / `generateAppendCommand` で本文と衝突しない区切りを自動選択し、`writeTextFile` / `appendToFile` の完了待ちを `PI_ZERO_PROMPT` に変更
- `WifiConfigService.setWiFi` を参照実装どおり `/tmp/wifi_setup.sh` へ書き込み、スクリプト内 heredoc を `WPA_CONF_EOF` に変更
- 上記の回帰テストを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx test libs-web-serial -- file.utils.spec`
2. `pnpm nx test libs-wifi -- wifi-config.service.spec`
3. 実機: localhost:4200 でログイン → WiFi 画面で SSID/Password 設定 → 再起動 → 再接続後に WiFi Info で接続を確認

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)