### PR TITLE
feat(remote): start selected forever app from remote panel

### DIFF
--- a/libs/remote/src/lib/component/remote-page/remote-page.component.html
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.html
@@ -27,7 +27,7 @@
         type="text"
         [(ngModel)]="scriptPath"
         placeholder="/home/pi/RelayServer.js"
-        [disabled]="actionInProgress()"
+        [disabled]="actionInProgress() || !serialConnected()"
       />
     </div>
 
@@ -35,24 +35,24 @@
 
     <div class="flex flex-wrap gap-2 justify-between w-full">
       <lib-remote-run-button
-        [disabled]="actionInProgress() || !scriptPath.trim()"
+        [disabled]="actionInProgress() || !scriptPath.trim() || !serialConnected()"
         (runClick)="startScript()"
       />
       <lib-remote-stop-button
         label="選択を停止"
-        [disabled]="actionInProgress() || !selected"
+        [disabled]="actionInProgress() || !selected || !serialConnected()"
         (stopClick)="stopSelected()"
       />
       <lib-remote-stop-button
         label="すべて停止"
-        [disabled]="actionInProgress()"
+        [disabled]="actionInProgress() || !serialConnected()"
         (stopClick)="confirmStopAll()"
       />
       <choh-button
         [label]="listInProgress() ? '更新中…' : '更新'"
         type="button"
         (clickEvent)="refreshList()"
-        [disabled]="listInProgress() || actionInProgress()"
+        [disabled]="listInProgress() || actionInProgress() || !serialConnected()"
       />
       <choh-button label="閉じる" type="button" (clickEvent)="closeModal()" />
     </div>

--- a/libs/remote/src/lib/component/remote-page/remote-page.component.html
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.html
@@ -21,14 +21,29 @@
 
     <div class="flex flex-col gap-2">
       <label class="text-sm font-medium" for="remote-script-path">起動するスクリプトパス（リモート）</label>
-      <input
-        id="remote-script-path"
-        class="border border-gray-300 rounded px-2 py-1.5 w-full text-sm font-mono"
-        type="text"
-        [(ngModel)]="scriptPath"
-        placeholder="/home/pi/RelayServer.js"
-        [disabled]="actionInProgress() || !serialConnected()"
-      />
+      <div class="flex flex-col sm:flex-row gap-2 items-stretch sm:items-center">
+        <input
+          id="remote-script-path"
+          class="border border-gray-300 rounded px-2 py-1.5 w-full text-sm font-mono"
+          type="text"
+          [(ngModel)]="scriptPath"
+          placeholder="/home/pi/RelayServer.js"
+          [disabled]="actionInProgress() || !serialConnected()"
+        />
+        <choh-button
+          label="選択中のファイルを使う"
+          type="button"
+          [disabled]="
+            !selectedJsPath() || actionInProgress() || !serialConnected()
+          "
+          (clickEvent)="useSelectedFile()"
+        />
+      </div>
+      @if (selectedJsPath(); as jsPath) {
+        <p class="text-xs text-gray-500 font-mono truncate" [title]="jsPath">
+          File Manager 選択中: {{ jsPath }}
+        </p>
+      }
     </div>
 
     <mat-divider />

--- a/libs/remote/src/lib/component/remote-page/remote-page.component.spec.ts
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.spec.ts
@@ -6,7 +6,7 @@ import { DialogService } from '@libs-dialogs';
 import { RemoteRunService } from '../../service';
 import { RemoteStatusService } from '../../service';
 import { RemoteStopService } from '../../service';
-import { NotificationService } from '@libs-shared';
+import { ConsoleShellStore, NotificationService } from '@libs-shared';
 import { SerialFacadeService } from '@libs-web-serial';
 import { RemotePageComponent } from './remote-page.component';
 
@@ -17,9 +17,11 @@ describe('RemotePageComponent', () => {
   let component: RemotePageComponent;
   let fixture: ComponentFixture<RemotePageComponent>;
   let serialConnected: ReturnType<typeof signal<boolean>>;
+  let selectedFilePath: ReturnType<typeof signal<string | null>>;
 
   beforeEach(async () => {
     serialConnected = signal(true);
+    selectedFilePath = signal<string | null>(null);
     const dialogRef = { closed: of(true) };
     await TestBed.configureTestingModule({
       imports: [RemotePageComponent],
@@ -44,6 +46,12 @@ describe('RemotePageComponent', () => {
           provide: SerialFacadeService,
           useValue: {
             isConnected: computed(() => serialConnected()),
+          },
+        },
+        {
+          provide: ConsoleShellStore,
+          useValue: {
+            selectedFilePath: computed(() => selectedFilePath()),
           },
         },
         {
@@ -124,5 +132,24 @@ describe('RemotePageComponent', () => {
     await component.startScript();
     expect(stop.stopTarget).toHaveBeenCalledWith('RelayServer');
     expect(run.start).toHaveBeenCalledWith('/home/pi/RelayServer.js');
+  });
+
+  it('prefills scriptPath from File Manager .js selection on init', async () => {
+    selectedFilePath.set('/home/pi/myApp/main.js');
+    const next = TestBed.createComponent(RemotePageComponent);
+    next.detectChanges();
+    expect(next.componentInstance.scriptPath).toBe('/home/pi/myApp/main.js');
+  });
+
+  it('useSelectedFile copies selectedJsPath into scriptPath', () => {
+    selectedFilePath.set('/home/pi/app.js');
+    component.scriptPath = '/other.js';
+    component.useSelectedFile();
+    expect(component.scriptPath).toBe('/home/pi/app.js');
+  });
+
+  it('selectedJsPath is null for non-js selection', () => {
+    selectedFilePath.set('/home/pi/readme.md');
+    expect(component.selectedJsPath()).toBeNull();
   });
 });

--- a/libs/remote/src/lib/component/remote-page/remote-page.component.spec.ts
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.spec.ts
@@ -152,4 +152,45 @@ describe('RemotePageComponent', () => {
     selectedFilePath.set('/home/pi/readme.md');
     expect(component.selectedJsPath()).toBeNull();
   });
+
+  it('serialConnected reflects SerialFacadeService isConnected', () => {
+    expect(component.serialConnected()).toBe(true);
+    serialConnected.set(false);
+    expect(component.serialConnected()).toBe(false);
+  });
+
+  it('startScript warns and does not start when serial disconnected', async () => {
+    serialConnected.set(false);
+    component.scriptPath = '/app.js';
+    const run = TestBed.inject(RemoteRunService);
+    const notify = TestBed.inject(NotificationService) as unknown as {
+      warning: ReturnType<typeof vi.fn>;
+    };
+    await component.startScript();
+    expect(notify.warning).toHaveBeenCalled();
+    expect(run.start).not.toHaveBeenCalled();
+  });
+
+  it('startScript shows error notification when forever start fails', async () => {
+    component.scriptPath = '/app.js';
+    const run = TestBed.inject(RemoteRunService) as unknown as {
+      start: ReturnType<typeof vi.fn>;
+    };
+    run.start.mockRejectedValueOnce(new Error('forever: start failed: EACCES'));
+    const notify = TestBed.inject(NotificationService) as unknown as {
+      error: ReturnType<typeof vi.fn>;
+    };
+    await component.startScript();
+    expect(notify.error).toHaveBeenCalledWith(
+      'Remote',
+      'forever: start failed: EACCES',
+    );
+  });
+
+  it('does not prefill scriptPath when selected file is not .js', () => {
+    selectedFilePath.set('/home/pi/readme.md');
+    const next = TestBed.createComponent(RemotePageComponent);
+    next.detectChanges();
+    expect(next.componentInstance.scriptPath).toBe('');
+  });
 });

--- a/libs/remote/src/lib/component/remote-page/remote-page.component.spec.ts
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.spec.ts
@@ -88,10 +88,41 @@ describe('RemotePageComponent', () => {
     expect(notify.warning).toHaveBeenCalled();
   });
 
-  it('startScript calls remoteRun.start', async () => {
+  it('startScript confirms then calls remoteRun.start', async () => {
+    component.scriptPath = '/app.js';
+    const run = TestBed.inject(RemoteRunService);
+    const dialog = TestBed.inject(DialogService);
+    await component.startScript();
+    expect(dialog.open).toHaveBeenCalled();
+    expect(run.start).toHaveBeenCalledWith('/app.js');
+  });
+
+  it('startScript skips start when confirm is cancelled', async () => {
+    const dialog = TestBed.inject(DialogService) as unknown as {
+      open: ReturnType<typeof vi.fn>;
+    };
+    dialog.open.mockReturnValue({ closed: of(false) });
     component.scriptPath = '/app.js';
     const run = TestBed.inject(RemoteRunService);
     await component.startScript();
-    expect(run.start).toHaveBeenCalledWith('/app.js');
+    expect(run.start).not.toHaveBeenCalled();
+  });
+
+  it('startScript restarts when the same script is already running', async () => {
+    component.scriptPath = '/home/pi/RelayServer.js';
+    component.processes = [
+      {
+        listIndex: 0,
+        uid: 'RelayServer',
+        command: 'node',
+        script: '/home/pi/RelayServer.js',
+        running: true,
+      },
+    ];
+    const run = TestBed.inject(RemoteRunService);
+    const stop = TestBed.inject(RemoteStopService);
+    await component.startScript();
+    expect(stop.stopTarget).toHaveBeenCalledWith('RelayServer');
+    expect(run.start).toHaveBeenCalledWith('/home/pi/RelayServer.js');
   });
 });

--- a/libs/remote/src/lib/component/remote-page/remote-page.component.ts
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.ts
@@ -1,9 +1,19 @@
-import { Component, computed, inject, signal } from '@angular/core';
+import {
+  Component,
+  computed,
+  inject,
+  OnInit,
+  signal,
+} from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatDividerModule } from '@angular/material/divider';
 import { ConfirmDialogComponent, DialogService } from '@libs-dialogs';
 import type { ForeverProcess } from '@libs-shared';
-import { ButtonComponent, NotificationService } from '@libs-shared';
+import {
+  ButtonComponent,
+  ConsoleShellStore,
+  NotificationService,
+} from '@libs-shared';
 import {
   PI_ZERO_PROMPT,
   sanitizeSerialStdout,
@@ -25,6 +35,10 @@ import { RemoteStopButtonComponent } from '../remote-stop-button/remote-stop-but
 
 const FOREVER_LIST_CMD = 'forever list --plain';
 
+function isJsScriptPath(path: string | null | undefined): path is string {
+  return !!path && /\.js$/i.test(path.trim());
+}
+
 @Component({
   selector: 'lib-remote-page',
   imports: [
@@ -37,7 +51,7 @@ const FOREVER_LIST_CMD = 'forever list --plain';
   ],
   templateUrl: './remote-page.component.html',
 })
-export class RemotePageComponent {
+export class RemotePageComponent implements OnInit {
   processes: ForeverProcess[] = [];
   selected: ForeverProcess | null = null;
   scriptPath = '';
@@ -48,11 +62,32 @@ export class RemotePageComponent {
   private readonly dialogService = inject(DialogService);
   private readonly notify = inject(NotificationService);
   private readonly serial = inject(SerialFacadeService);
+  private readonly shellStore = inject(ConsoleShellStore);
   private readonly remoteStatus = inject(RemoteStatusService);
   private readonly remoteRun = inject(RemoteRunService);
   private readonly remoteStop = inject(RemoteStopService);
 
   readonly serialConnected = computed(() => this.serial.isConnected());
+
+  /** File Manager で選択中の .js パス（なければ null）。 */
+  readonly selectedJsPath = computed(() => {
+    const path = this.shellStore.selectedFilePath();
+    return isJsScriptPath(path) ? path.trim() : null;
+  });
+
+  ngOnInit(): void {
+    const path = this.selectedJsPath();
+    if (path) {
+      this.scriptPath = path;
+    }
+  }
+
+  useSelectedFile(): void {
+    const path = this.selectedJsPath();
+    if (path) {
+      this.scriptPath = path;
+    }
+  }
 
   closeModal(): void {
     this.dialogService.close();

--- a/libs/remote/src/lib/component/remote-page/remote-page.component.ts
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, computed, inject, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatDividerModule } from '@angular/material/divider';
 import { ConfirmDialogComponent, DialogService } from '@libs-dialogs';
@@ -10,7 +10,10 @@ import {
   SerialFacadeService,
 } from '@libs-web-serial';
 import { firstValueFrom } from 'rxjs';
-import { parseForeverListPlain } from '../../functions';
+import {
+  findRunningProcessByScript,
+  parseForeverListPlain,
+} from '../../functions';
 import {
   RemoteRunService,
   RemoteStatusService,
@@ -48,6 +51,8 @@ export class RemotePageComponent {
   private readonly remoteStatus = inject(RemoteStatusService);
   private readonly remoteRun = inject(RemoteRunService);
   private readonly remoteStop = inject(RemoteStopService);
+
+  readonly serialConnected = computed(() => this.serial.isConnected());
 
   closeModal(): void {
     this.dialogService.close();
@@ -103,17 +108,64 @@ export class RemotePageComponent {
     if (!path || !(await this.ensureSerial())) {
       return;
     }
+
+    const running = findRunningProcessByScript(this.processes, path);
+    const confirmed = running
+      ? await this.confirmRestart(path, running)
+      : await this.confirmStart(path);
+    if (!confirmed) {
+      return;
+    }
+
     this.actionInProgress.set(true);
     try {
+      if (running) {
+        await this.remoteStop.stopTarget(running.uid);
+      }
       await this.remoteRun.start(path);
-      this.notify.success('Remote', '起動コマンドを送信しました');
+      this.notify.success(
+        'Remote',
+        running ? '再起動コマンドを送信しました' : '起動コマンドを送信しました',
+      );
       await this.refreshList();
     } catch (e: unknown) {
-      const msg = e instanceof Error ? e.message : '起動に失敗しました';
+      const msg =
+        e instanceof Error
+          ? e.message
+          : running
+            ? '再起動に失敗しました'
+            : '起動に失敗しました';
       this.notify.error('Remote', msg);
     } finally {
       this.actionInProgress.set(false);
     }
+  }
+
+  private async confirmStart(path: string): Promise<boolean> {
+    const ref = this.dialogService.open(ConfirmDialogComponent, {
+      data: {
+        title: 'forever で起動',
+        message: `次のスクリプトを forever start します。よろしいですか？\n\n${path}`,
+        confirmLabel: '起動',
+        cancelLabel: 'キャンセル',
+      },
+    });
+    return !!(await firstValueFrom(ref.closed));
+  }
+
+  private async confirmRestart(
+    path: string,
+    running: ForeverProcess,
+  ): Promise<boolean> {
+    const ref = this.dialogService.open(ConfirmDialogComponent, {
+      data: {
+        title: '既に起動中のアプリを再起動',
+        message: `「${running.uid}」(${running.script}) は既に実行中です。停止してから次のスクリプトを再起動しますか？\n\n${path}`,
+        confirmLabel: '再起動',
+        cancelLabel: 'キャンセル',
+      },
+    });
+    return !!(await firstValueFrom(ref.closed));
   }
 
   async stopSelected(): Promise<void> {

--- a/libs/remote/src/lib/functions/remote.util.spec.ts
+++ b/libs/remote/src/lib/functions/remote.util.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { formatRemoteStatus, parseForeverListPlain } from './remote.util';
+import {
+  findRunningProcessByScript,
+  formatRemoteStatus,
+  normalizeScriptPath,
+  parseForeverListPlain,
+  scriptsMatch,
+} from './remote.util';
 
 describe('formatRemoteStatus', () => {
   it('trims and drops blank lines', () => {
@@ -71,5 +77,43 @@ not a row
 
   it('ignores rows with too few columns after split', () => {
     expect(parseForeverListPlain('[0]  onlyone')).toEqual([]);
+  });
+});
+
+describe('normalizeScriptPath / scriptsMatch', () => {
+  it('normalizes slashes and trailing slash', () => {
+    expect(normalizeScriptPath('  /home/pi/app.js/  ')).toBe('/home/pi/app.js');
+    expect(normalizeScriptPath('C:\\x\\y.js')).toBe('C:/x/y.js');
+  });
+
+  it('matches exact and path-suffix forms', () => {
+    expect(scriptsMatch('/home/pi/app.js', '/home/pi/app.js')).toBe(true);
+    expect(scriptsMatch('/home/pi/app.js', 'app.js')).toBe(true);
+    expect(scriptsMatch('app.js', '/home/pi/app.js')).toBe(true);
+    expect(scriptsMatch('/home/pi/a.js', '/home/pi/b.js')).toBe(false);
+  });
+
+  it('uses first token when forever script column includes args', () => {
+    expect(scriptsMatch('/home/pi/app.js --flag', '/home/pi/app.js')).toBe(
+      true,
+    );
+  });
+});
+
+describe('findRunningProcessByScript', () => {
+  it('returns running process matching script path', () => {
+    const processes = parseForeverListPlain(
+      '[0]  RelayServer  node  /home/pi/RelayServer.js  1111  2222  /tmp/a.log  0:0:0:1',
+    );
+    expect(
+      findRunningProcessByScript(processes, 'RelayServer.js')?.uid,
+    ).toBe('RelayServer');
+  });
+
+  it('ignores stopped processes', () => {
+    const processes = parseForeverListPlain(
+      '[0]  app  node  /x.js  1  2  /l.log  STOPPED',
+    );
+    expect(findRunningProcessByScript(processes, '/x.js')).toBeUndefined();
   });
 });

--- a/libs/remote/src/lib/functions/remote.util.ts
+++ b/libs/remote/src/lib/functions/remote.util.ts
@@ -78,3 +78,38 @@ export function parseForeverListPlain(stdout: string): ForeverProcess[] {
 
   return out;
 }
+
+/** Normalize a remote script path for comparison (trim, unify slashes, drop trailing /). */
+export function normalizeScriptPath(path: string): string {
+  return String(path)
+    .trim()
+    .replace(/\\/g, '/')
+    .replace(/\/+$/, '');
+}
+
+/**
+ * Whether two script path strings refer to the same forever target.
+ * Matches exact paths, or when one path ends with the other as a path suffix.
+ * The forever script column may include args — only the first token is used.
+ */
+export function scriptsMatch(a: string, b: string): boolean {
+  const na = normalizeScriptPath(a.split(/\s+/)[0] ?? '');
+  const nb = normalizeScriptPath(b.split(/\s+/)[0] ?? '');
+  if (!na || !nb) {
+    return false;
+  }
+  if (na === nb) {
+    return true;
+  }
+  return na.endsWith(`/${nb}`) || nb.endsWith(`/${na}`);
+}
+
+/** Find a running forever process whose script matches the given path. */
+export function findRunningProcessByScript(
+  processes: ForeverProcess[],
+  scriptPath: string,
+): ForeverProcess | undefined {
+  return processes.find(
+    (p) => p.running && scriptsMatch(p.script, scriptPath),
+  );
+}

--- a/libs/remote/src/lib/service/remote-run.service.spec.ts
+++ b/libs/remote/src/lib/service/remote-run.service.spec.ts
@@ -1,0 +1,50 @@
+import '@angular/compiler';
+import { Injector } from '@angular/core';
+import { from } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SerialFacadeService } from '@libs-web-serial';
+import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial';
+import { RemoteRunService } from './remote-run.service';
+
+describe('RemoteRunService', () => {
+  let exec: ReturnType<typeof vi.fn>;
+  let svc: RemoteRunService;
+
+  beforeEach(() => {
+    exec = vi.fn().mockResolvedValue({ stdout: '' });
+    const injector = Injector.create({
+      providers: [
+        RemoteRunService,
+        {
+          provide: SerialFacadeService,
+          useValue: {
+            exec$: (...args: unknown[]) => from(exec(...args)),
+          },
+        },
+      ],
+    });
+    svc = injector.get(RemoteRunService);
+  });
+
+  it('start calls forever start -w with JSON-quoted script path', async () => {
+    await svc.start(`/home/pi/my app'x.js`);
+    expect(exec).toHaveBeenCalledWith(
+      `forever start -w ${JSON.stringify(`/home/pi/my app'x.js`)}`,
+      {
+        prompt: PI_ZERO_PROMPT,
+        timeout: SERIAL_TIMEOUT.PROCESS_CONTROL,
+      },
+    );
+  });
+
+  it('start appends JSON-quoted args after the script path', async () => {
+    await svc.start('/home/pi/app.js', ['--foo', `bar'baz`]);
+    expect(exec).toHaveBeenCalledWith(
+      `forever start -w ${JSON.stringify('/home/pi/app.js')} ${JSON.stringify('--foo')} ${JSON.stringify(`bar'baz`)}`,
+      {
+        prompt: PI_ZERO_PROMPT,
+        timeout: SERIAL_TIMEOUT.PROCESS_CONTROL,
+      },
+    );
+  });
+});

--- a/libs/remote/src/lib/service/remote-run.service.ts
+++ b/libs/remote/src/lib/service/remote-run.service.ts
@@ -14,11 +14,16 @@ export class RemoteRunService {
    * @param scriptPath Remote 上の JS ファイルパス（例: RelayServer.js）
    */
   async start(scriptPath: string, args: string[] = []): Promise<void> {
-    const argsPart = args.length ? ` ${args.map((a) => JSON.stringify(a)).join(' ')}` : '';
+    const quotedPath = JSON.stringify(scriptPath);
+    const argsPart = args.length
+      ? ` ${args.map((a) => JSON.stringify(a)).join(' ')}`
+      : '';
     // -w は start の待ち合わせ（環境依存のため長めの timeout）
-    await firstValueFrom(this.serial.exec$(`forever start -w ${scriptPath}${argsPart}`, {
-      prompt: this.prompt,
-      timeout: SERIAL_TIMEOUT.PROCESS_CONTROL,
-    }));
+    await firstValueFrom(
+      this.serial.exec$(`forever start -w ${quotedPath}${argsPart}`, {
+        prompt: this.prompt,
+        timeout: SERIAL_TIMEOUT.PROCESS_CONTROL,
+      }),
+    );
   }
 }


### PR DESCRIPTION
## Summary

- Forever 管理画面からスクリプトを確認付きで起動できるようにし、同一 script が実行中なら停止して再起動する
- File Manager で選択中の `.js` を起動パスにプリフィル／反映できるようにする
- `forever start` のスクリプトパスを JSON クォートし、未接続時は操作を無効化する

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #735

## What changed?

- `RemoteRunService.start` で script path を `JSON.stringify` して安全に渡すようにした
- 起動前に ConfirmDialog を表示し、既に同一 script が running の場合は stop → start の再起動フローにした
- `ConsoleShellStore.selectedFilePath` から `.js` を起動パスへプリフィルし、「選択中のファイルを使う」ボタンを追加した
- シリアル未接続時は入力・起動／停止／更新ボタンを disable にした
- util（`scriptsMatch` 等）と remote-page / remote-run のテストを追加した

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. シリアル接続後、ツールバーの Remote を開き、スクリプトパスを入力して「起動」→ 確認ダイアログ後に `forever start -w` が走ることを確認する
2. 同じ script を再度起動し、再起動確認 → 停止後に起動されることを確認する
3. File Manager で `.js` を選択した状態で Remote を開き、パスがプリフィルされること／「選択中のファイルを使う」で反映されることを確認する
4. 未接続時に起動・更新・停止が無効化されることを確認する
5. `pnpm nx test libs-remote` が通ることを確認する

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)