### PR TITLE
feat(remote): add confirmed stop for selected forever process

### DIFF
--- a/libs/remote/src/lib/component/remote-page/remote-page.component.html
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.html
@@ -17,6 +17,12 @@
       (rowSelected)="onRowSelected($event)"
     />
 
+    @if (selected && !selected.running) {
+      <p class="text-sm text-gray-600" role="status">
+        選択中のプロセスは既に停止しています
+      </p>
+    }
+
     <mat-divider />
 
     <div class="flex flex-col gap-2">
@@ -55,7 +61,12 @@
       />
       <lib-remote-stop-button
         label="選択を停止"
-        [disabled]="actionInProgress() || !selected || !serialConnected()"
+        [disabled]="
+          actionInProgress() ||
+          !selected ||
+          !selected.running ||
+          !serialConnected()
+        "
         (stopClick)="stopSelected()"
       />
       <lib-remote-stop-button

--- a/libs/remote/src/lib/component/remote-page/remote-page.component.spec.ts
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.spec.ts
@@ -193,4 +193,85 @@ describe('RemotePageComponent', () => {
     next.detectChanges();
     expect(next.componentInstance.scriptPath).toBe('');
   });
+
+  it('stopSelected confirms then calls remoteStop.stopTarget', async () => {
+    component.selected = {
+      listIndex: 0,
+      uid: 'RelayServer',
+      command: 'node',
+      script: '/home/pi/RelayServer.js',
+      pid: '2222',
+      running: true,
+    };
+    const stop = TestBed.inject(RemoteStopService);
+    const dialog = TestBed.inject(DialogService);
+    await component.stopSelected();
+    expect(dialog.open).toHaveBeenCalled();
+    expect(stop.stopTarget).toHaveBeenCalledWith('RelayServer');
+  });
+
+  it('stopSelected skips stop when confirm is cancelled', async () => {
+    const dialog = TestBed.inject(DialogService) as unknown as {
+      open: ReturnType<typeof vi.fn>;
+    };
+    dialog.open.mockReturnValue({ closed: of(false) });
+    component.selected = {
+      listIndex: 0,
+      uid: 'RelayServer',
+      command: 'node',
+      script: '/home/pi/RelayServer.js',
+      running: true,
+    };
+    const stop = TestBed.inject(RemoteStopService);
+    await component.stopSelected();
+    expect(stop.stopTarget).not.toHaveBeenCalled();
+  });
+
+  it('stopSelected does nothing when nothing is selected', async () => {
+    component.selected = null;
+    const stop = TestBed.inject(RemoteStopService);
+    const dialog = TestBed.inject(DialogService);
+    await component.stopSelected();
+    expect(dialog.open).not.toHaveBeenCalled();
+    expect(stop.stopTarget).not.toHaveBeenCalled();
+  });
+
+  it('stopSelected does nothing when selected process is already stopped', async () => {
+    component.selected = {
+      listIndex: 0,
+      uid: 'RelayServer',
+      command: 'node',
+      script: '/home/pi/RelayServer.js',
+      running: false,
+    };
+    const stop = TestBed.inject(RemoteStopService);
+    const dialog = TestBed.inject(DialogService);
+    await component.stopSelected();
+    expect(dialog.open).not.toHaveBeenCalled();
+    expect(stop.stopTarget).not.toHaveBeenCalled();
+  });
+
+  it('stopSelected shows error notification when forever stop fails', async () => {
+    component.selected = {
+      listIndex: 0,
+      uid: 'RelayServer',
+      command: 'node',
+      script: '/home/pi/RelayServer.js',
+      running: true,
+    };
+    const stop = TestBed.inject(RemoteStopService) as unknown as {
+      stopTarget: ReturnType<typeof vi.fn>;
+    };
+    stop.stopTarget.mockRejectedValueOnce(
+      new Error('forever: stop failed: ENOENT'),
+    );
+    const notify = TestBed.inject(NotificationService) as unknown as {
+      error: ReturnType<typeof vi.fn>;
+    };
+    await component.stopSelected();
+    expect(notify.error).toHaveBeenCalledWith(
+      'Remote',
+      'forever: stop failed: ENOENT',
+    );
+  });
 });

--- a/libs/remote/src/lib/component/remote-page/remote-page.component.ts
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.ts
@@ -205,7 +205,7 @@ export class RemotePageComponent implements OnInit {
 
   async stopSelected(): Promise<void> {
     const target = this.selected;
-    if (!target || !(await this.ensureSerial())) {
+    if (!target || !target.running || !(await this.ensureSerial())) {
       return;
     }
     const confirmed = await this.confirmStopSelected(target);

--- a/libs/remote/src/lib/component/remote-page/remote-page.component.ts
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.ts
@@ -208,6 +208,10 @@ export class RemotePageComponent implements OnInit {
     if (!target || !(await this.ensureSerial())) {
       return;
     }
+    const confirmed = await this.confirmStopSelected(target);
+    if (!confirmed) {
+      return;
+    }
     this.actionInProgress.set(true);
     try {
       await this.remoteStop.stopTarget(target.uid);
@@ -220,6 +224,19 @@ export class RemotePageComponent implements OnInit {
     } finally {
       this.actionInProgress.set(false);
     }
+  }
+
+  private async confirmStopSelected(target: ForeverProcess): Promise<boolean> {
+    const pidLine = target.pid ? `\npid: ${target.pid}` : '';
+    const ref = this.dialogService.open(ConfirmDialogComponent, {
+      data: {
+        title: 'forever プロセスを停止',
+        message: `次の forever プロセスを停止します。よろしいですか？\n\nuid: ${target.uid}\nscript: ${target.script}${pidLine}`,
+        confirmLabel: '停止',
+        cancelLabel: 'キャンセル',
+      },
+    });
+    return !!(await firstValueFrom(ref.closed));
   }
 
   async confirmStopAll(): Promise<void> {


### PR DESCRIPTION
## Summary

- Forever 一覧で選択したプロセスの停止前に、uid / script / pid を示す確認ダイアログを表示する
- 既に停止済みのプロセスを選択した場合は「選択を停止」を無効化し、案内メッセージを表示する
- 選択停止フロー（確認・キャンセル・未選択・停止済み・失敗）のユニットテストを追加する

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #736

## What changed?

- `RemotePageComponent.stopSelected` に確認ダイアログを追加し、同意後のみ `forever stop` を実行する
- 選択プロセスが `running === false` のとき停止ボタンを無効化し、ステータス案内を表示する
- `remote-page.component.spec.ts` に選択停止まわりのテストを追加する

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. シリアル接続後、Remote（Forever 管理）ダイアログを開く
2. 「更新」でプロセス一覧を取得し、実行中の行を選択する
3. 「選択を停止」を押し、確認ダイアログの内容（uid / script / pid）を確認して停止できること
4. 確認をキャンセルすると停止されないこと
5. 未選択時および停止済みプロセス選択時は「選択を停止」が無効であること
6. `pnpm nx test libs-remote` が通ること

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)