### PR TITLE
feat(remote): harden forever stop-all with confirm impact and guards

### DIFF
--- a/libs/remote/src/lib/component/remote-page/remote-page.component.html
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.html
@@ -71,7 +71,9 @@
       />
       <lib-remote-stop-button
         label="すべて停止"
-        [disabled]="actionInProgress() || !serialConnected()"
+        [disabled]="
+          processes.length === 0 || actionInProgress() || !serialConnected()
+        "
         (stopClick)="confirmStopAll()"
       />
       <choh-button

--- a/libs/remote/src/lib/component/remote-page/remote-page.component.spec.ts
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.spec.ts
@@ -274,4 +274,158 @@ describe('RemotePageComponent', () => {
       'forever: stop failed: ENOENT',
     );
   });
+
+  it('confirmStopAll confirms then calls remoteStop.stopAll', async () => {
+    component.processes = [
+      {
+        listIndex: 0,
+        uid: 'RelayServer',
+        command: 'node',
+        script: '/home/pi/RelayServer.js',
+        running: true,
+      },
+    ];
+    const status = TestBed.inject(RemoteStatusService) as unknown as {
+      listPlain: ReturnType<typeof vi.fn>;
+    };
+    status.listPlain.mockResolvedValueOnce('No forever processes running');
+    const stop = TestBed.inject(RemoteStopService);
+    const dialog = TestBed.inject(DialogService);
+    await component.confirmStopAll();
+    expect(dialog.open).toHaveBeenCalled();
+    expect(stop.stopAll).toHaveBeenCalled();
+  });
+
+  it('confirmStopAll skips stop when confirm is cancelled', async () => {
+    const dialog = TestBed.inject(DialogService) as unknown as {
+      open: ReturnType<typeof vi.fn>;
+    };
+    dialog.open.mockReturnValue({ closed: of(false) });
+    component.processes = [
+      {
+        listIndex: 0,
+        uid: 'RelayServer',
+        command: 'node',
+        script: '/home/pi/RelayServer.js',
+        running: true,
+      },
+    ];
+    const stop = TestBed.inject(RemoteStopService);
+    await component.confirmStopAll();
+    expect(stop.stopAll).not.toHaveBeenCalled();
+  });
+
+  it('confirmStopAll does nothing when there are no processes', async () => {
+    component.processes = [];
+    const stop = TestBed.inject(RemoteStopService);
+    const dialog = TestBed.inject(DialogService);
+    await component.confirmStopAll();
+    expect(dialog.open).not.toHaveBeenCalled();
+    expect(stop.stopAll).not.toHaveBeenCalled();
+  });
+
+  it('confirmStopAll shows error notification when forever stopall fails', async () => {
+    component.processes = [
+      {
+        listIndex: 0,
+        uid: 'RelayServer',
+        command: 'node',
+        script: '/home/pi/RelayServer.js',
+        running: true,
+      },
+    ];
+    const stop = TestBed.inject(RemoteStopService) as unknown as {
+      stopAll: ReturnType<typeof vi.fn>;
+    };
+    stop.stopAll.mockRejectedValueOnce(
+      new Error('forever: stopall failed: EPERM'),
+    );
+    const notify = TestBed.inject(NotificationService) as unknown as {
+      error: ReturnType<typeof vi.fn>;
+    };
+    await component.confirmStopAll();
+    expect(notify.error).toHaveBeenCalledWith(
+      'Remote',
+      'forever: stopall failed: EPERM',
+    );
+  });
+
+  it('confirmStopAll reports remaining processes after stopall', async () => {
+    component.processes = [
+      {
+        listIndex: 0,
+        uid: 'RelayServer',
+        command: 'node',
+        script: '/home/pi/RelayServer.js',
+        running: true,
+      },
+    ];
+    const notify = TestBed.inject(NotificationService) as unknown as {
+      error: ReturnType<typeof vi.fn>;
+      success: ReturnType<typeof vi.fn>;
+    };
+    await component.confirmStopAll();
+    expect(notify.error).toHaveBeenCalledWith(
+      'Remote',
+      expect.stringContaining('残存: 1 件'),
+    );
+    expect(notify.success).not.toHaveBeenCalledWith(
+      'Remote',
+      'stopall を送信しました',
+    );
+  });
+
+  it('confirmStopAll shows success when no processes remain', async () => {
+    component.processes = [
+      {
+        listIndex: 0,
+        uid: 'RelayServer',
+        command: 'node',
+        script: '/home/pi/RelayServer.js',
+        running: true,
+      },
+    ];
+    const status = TestBed.inject(RemoteStatusService) as unknown as {
+      listPlain: ReturnType<typeof vi.fn>;
+    };
+    status.listPlain.mockResolvedValueOnce('No forever processes running');
+    const notify = TestBed.inject(NotificationService) as unknown as {
+      success: ReturnType<typeof vi.fn>;
+    };
+    await component.confirmStopAll();
+    expect(notify.success).toHaveBeenCalledWith(
+      'Remote',
+      'stopall を送信しました',
+    );
+  });
+
+  it('confirmStopAll confirm message lists impact and chirimen warning', async () => {
+    component.processes = [
+      {
+        listIndex: 0,
+        uid: 'RelayServer',
+        command: 'node',
+        script: '/home/pi/RelayServer.js',
+        running: true,
+      },
+    ];
+    const status = TestBed.inject(RemoteStatusService) as unknown as {
+      listPlain: ReturnType<typeof vi.fn>;
+    };
+    status.listPlain.mockResolvedValueOnce('No forever processes running');
+    const dialog = TestBed.inject(DialogService) as unknown as {
+      open: ReturnType<typeof vi.fn>;
+    };
+    await component.confirmStopAll();
+    const openArg = dialog.open.mock.calls[0]?.[1] as {
+      data: { message: string };
+    };
+    expect(openArg.data.message).toContain('対象: 1 件');
+    expect(openArg.data.message).toContain(
+      'uid: RelayServer / script: /home/pi/RelayServer.js',
+    );
+    expect(openArg.data.message).toContain(
+      'CHIRIMEN の動作に必要なプロセス',
+    );
+  });
 });

--- a/libs/remote/src/lib/component/remote-page/remote-page.component.ts
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.ts
@@ -243,9 +243,7 @@ export class RemotePageComponent implements OnInit {
     if (this.processes.length === 0 || !(await this.ensureSerial())) {
       return;
     }
-    const targets = this.processes
-      .map((p) => `- uid: ${p.uid} / script: ${p.script}`)
-      .join('\n');
+    const targets = this.formatProcessLines(this.processes);
     const ref = this.dialogService.open(ConfirmDialogComponent, {
       data: {
         title: 'すべての forever プロセスを停止',
@@ -268,14 +266,32 @@ export class RemotePageComponent implements OnInit {
     this.actionInProgress.set(true);
     try {
       await this.remoteStop.stopAll();
-      this.notify.success('Remote', 'stopall を送信しました');
       this.selected = null;
       await this.refreshList();
+      if (this.processes.length > 0) {
+        this.notify.error(
+          'Remote',
+          [
+            '一部または全部の停止に失敗しました。残存プロセスがあります。',
+            '',
+            `残存: ${this.processes.length} 件`,
+            this.formatProcessLines(this.processes),
+          ].join('\n'),
+        );
+      } else {
+        this.notify.success('Remote', 'stopall を送信しました');
+      }
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : 'stopall に失敗しました';
       this.notify.error('Remote', msg);
     } finally {
       this.actionInProgress.set(false);
     }
+  }
+
+  private formatProcessLines(processes: ForeverProcess[]): string {
+    return processes
+      .map((p) => `- uid: ${p.uid} / script: ${p.script}`)
+      .join('\n');
   }
 }

--- a/libs/remote/src/lib/component/remote-page/remote-page.component.ts
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.ts
@@ -243,10 +243,20 @@ export class RemotePageComponent implements OnInit {
     if (this.processes.length === 0 || !(await this.ensureSerial())) {
       return;
     }
+    const targets = this.processes
+      .map((p) => `- uid: ${p.uid} / script: ${p.script}`)
+      .join('\n');
     const ref = this.dialogService.open(ConfirmDialogComponent, {
       data: {
         title: 'すべての forever プロセスを停止',
-        message: 'forever stopall を実行します。よろしいですか？',
+        message: [
+          'Foreverで管理中のすべてのプロセスを停止します。この操作を続行しますか？',
+          '',
+          `対象: ${this.processes.length} 件`,
+          targets,
+          '',
+          '注意: CHIRIMEN の動作に必要なプロセス（例: RelayServer 等）も停止対象になります。',
+        ].join('\n'),
         confirmLabel: 'すべて停止',
         cancelLabel: 'キャンセル',
       },

--- a/libs/remote/src/lib/component/remote-page/remote-page.component.ts
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.ts
@@ -240,7 +240,7 @@ export class RemotePageComponent implements OnInit {
   }
 
   async confirmStopAll(): Promise<void> {
-    if (!(await this.ensureSerial())) {
+    if (this.processes.length === 0 || !(await this.ensureSerial())) {
       return;
     }
     const ref = this.dialogService.open(ConfirmDialogComponent, {


### PR DESCRIPTION
## Summary

- Forever「すべて停止」の確認ダイアログに影響範囲（uid/script）と CHIRIMEN 警告を表示する
- 対象プロセスが 0 件のときは「すべて停止」を無効化し、実行もしない
- `forever stopall` 後に残存プロセスがあれば対象付きでエラー通知する

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Closes #737

## What changed?

- Remote 画面の「すべて停止」を `processes.length === 0` のとき無効化
- 確認メッセージを Issue 例に合わせ、対象一覧と CHIRIMEN 警告を追加
- stopall 成功後に一覧を再取得し、残存があれば残 uid/script 付きでエラー表示
- `confirmStopAll` の確認・キャンセル・0件・失敗・残存・成功の vitest を追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. Remote 画面を開き、forever プロセス一覧を更新する
2. プロセス 0 件のとき「すべて停止」が無効であること
3. 1 件以上あるとき「すべて停止」で確認ダイアログに対象一覧と CHIRIMEN 警告が出ること
4. 同意後に `forever stopall` が走り、成功時は一覧が空になること
5. 残存がある場合は残存対象付きエラー通知になること
6. `pnpm nx test libs-remote` が通ること

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)