### PR TITLE
feat(remote): refresh forever process list with loading and retry

### DIFF
--- a/libs/remote/src/lib/component/remote-page/remote-page.component.html
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.html
@@ -14,7 +14,11 @@
     <lib-remote-status-list
       [processes]="processes"
       [selected]="selected"
+      [loading]="listInProgress()"
+      [error]="listError()"
+      [fetched]="listFetched()"
       (rowSelected)="onRowSelected($event)"
+      (retry)="refreshList()"
     />
 
     @if (selected && !selected.running) {

--- a/libs/remote/src/lib/component/remote-page/remote-page.component.spec.ts
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.spec.ts
@@ -85,6 +85,8 @@ describe('RemotePageComponent', () => {
     await component.refreshList();
     expect(component.processes.length).toBe(1);
     expect(component.processes[0]?.uid).toBe('RelayServer');
+    expect(component.listFetched()).toBe(true);
+    expect(component.listError()).toBeNull();
   });
 
   it('refreshList warns when serial disconnected', async () => {
@@ -96,6 +98,58 @@ describe('RemotePageComponent', () => {
     expect(notify.warning).toHaveBeenCalled();
   });
 
+  it('refreshList sets listError when forever list fails', async () => {
+    const status = TestBed.inject(RemoteStatusService) as unknown as {
+      listPlain: ReturnType<typeof vi.fn>;
+    };
+    status.listPlain.mockRejectedValueOnce(new Error('list failed'));
+    const notify = TestBed.inject(NotificationService) as unknown as {
+      error: ReturnType<typeof vi.fn>;
+    };
+    await component.refreshList();
+    expect(component.listError()).toBe('list failed');
+    expect(component.listFetched()).toBe(false);
+    expect(component.listInProgress()).toBe(false);
+    expect(notify.error).toHaveBeenCalledWith('Remote', 'list failed');
+  });
+
+  it('refreshList ignores concurrent calls while in progress', async () => {
+    const status = TestBed.inject(RemoteStatusService) as unknown as {
+      listPlain: ReturnType<typeof vi.fn>;
+    };
+    let resolveList!: (value: string) => void;
+    status.listPlain.mockReturnValueOnce(
+      new Promise<string>((resolve) => {
+        resolveList = resolve;
+      }),
+    );
+
+    const first = component.refreshList();
+    await Promise.resolve();
+    expect(status.listPlain).toHaveBeenCalledTimes(1);
+
+    const second = component.refreshList();
+    expect(status.listPlain).toHaveBeenCalledTimes(1);
+
+    resolveList(PLAIN_ROW);
+    await Promise.all([first, second]);
+    expect(status.listPlain).toHaveBeenCalledTimes(1);
+    expect(component.processes.length).toBe(1);
+  });
+
+  it('refreshList clears listError on success after a previous failure', async () => {
+    const status = TestBed.inject(RemoteStatusService) as unknown as {
+      listPlain: ReturnType<typeof vi.fn>;
+    };
+    status.listPlain.mockRejectedValueOnce(new Error('list failed'));
+    await component.refreshList();
+    expect(component.listError()).toBe('list failed');
+
+    status.listPlain.mockResolvedValueOnce(PLAIN_ROW);
+    await component.refreshList();
+    expect(component.listError()).toBeNull();
+    expect(component.listFetched()).toBe(true);
+  });
   it('startScript confirms then calls remoteRun.start', async () => {
     component.scriptPath = '/app.js';
     const run = TestBed.inject(RemoteRunService);

--- a/libs/remote/src/lib/component/remote-page/remote-page.component.ts
+++ b/libs/remote/src/lib/component/remote-page/remote-page.component.ts
@@ -57,6 +57,8 @@ export class RemotePageComponent implements OnInit {
   scriptPath = '';
 
   readonly listInProgress = signal(false);
+  readonly listError = signal<string | null>(null);
+  readonly listFetched = signal(false);
   readonly actionInProgress = signal(false);
 
   private readonly dialogService = inject(DialogService);
@@ -107,10 +109,14 @@ export class RemotePageComponent implements OnInit {
   }
 
   async refreshList(): Promise<void> {
+    if (this.listInProgress()) {
+      return;
+    }
     if (!(await this.ensureSerial())) {
       return;
     }
     this.listInProgress.set(true);
+    this.listError.set(null);
     try {
       const stdout = await this.remoteStatus.listPlain();
       const cleaned = sanitizeSerialStdout(
@@ -119,6 +125,7 @@ export class RemotePageComponent implements OnInit {
         PI_ZERO_PROMPT,
       );
       this.processes = parseForeverListPlain(cleaned);
+      this.listFetched.set(true);
       const prev = this.selected;
       if (prev) {
         const still = this.processes.find(
@@ -132,6 +139,7 @@ export class RemotePageComponent implements OnInit {
       );
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : '一覧の取得に失敗しました';
+      this.listError.set(msg);
       this.notify.error('Remote', msg);
     } finally {
       this.listInProgress.set(false);

--- a/libs/remote/src/lib/component/remote-status-list/remote-status-list.component.html
+++ b/libs/remote/src/lib/component/remote-status-list/remote-status-list.component.html
@@ -5,26 +5,47 @@
   class="max-h-[min(360px,40vh)] overflow-y-auto w-full border border-gray-200 rounded"
   role="list"
 >
-  @for (p of processes(); track trackKey(p)) {
-    <button
-      type="button"
-      role="listitem"
-      class="w-full text-left px-3 py-2 border-b border-gray-100 hover:bg-gray-50"
-      [class.bg-blue-50]="isSelected(p)"
-      (click)="rowSelected.emit(p)"
-    >
-      <div class="font-mono text-sm">{{ p.uid }}</div>
-      <div class="text-xs text-gray-600 break-all">{{ p.script }}</div>
-      <div class="text-xs mt-0.5" [class.text-green-700]="p.running" [class.text-gray-500]="!p.running">
-        {{ p.running ? '実行中' : '停止' }}
-        @if (p.uptime) {
-          <span class="text-gray-400"> · {{ p.uptime }}</span>
+  @if (loading()) {
+    <p class="p-3 text-sm text-gray-600" role="status">取得中…</p>
+  } @else if (error(); as err) {
+    <div class="p-3 flex flex-col gap-2" role="alert">
+      <p class="text-sm text-red-700">{{ err }}</p>
+      <choh-button
+        label="再試行"
+        type="button"
+        (clickEvent)="retry.emit()"
+      />
+    </div>
+  } @else {
+    @for (p of processes(); track trackKey(p)) {
+      <button
+        type="button"
+        role="listitem"
+        class="w-full text-left px-3 py-2 border-b border-gray-100 hover:bg-gray-50"
+        [class.bg-blue-50]="isSelected(p)"
+        (click)="rowSelected.emit(p)"
+      >
+        <div class="font-mono text-sm">{{ p.uid }}</div>
+        <div class="text-xs text-gray-600 break-all">{{ p.script }}</div>
+        <div
+          class="text-xs mt-0.5"
+          [class.text-green-700]="p.running"
+          [class.text-gray-500]="!p.running"
+        >
+          {{ p.running ? '実行中' : '停止' }}
+          @if (p.uptime) {
+            <span class="text-gray-400"> · {{ p.uptime }}</span>
+          }
+        </div>
+      </button>
+    } @empty {
+      <p class="p-3 text-sm text-gray-600">
+        @if (fetched()) {
+          プロセスがありません。
+        } @else {
+          「更新」で一覧を取得してください。
         }
-      </div>
-    </button>
-  } @empty {
-    <p class="p-3 text-sm text-gray-600">
-      プロセスがありません。「更新」で一覧を取得してください。
-    </p>
+      </p>
+    }
   }
 </div>

--- a/libs/remote/src/lib/component/remote-status-list/remote-status-list.component.spec.ts
+++ b/libs/remote/src/lib/component/remote-status-list/remote-status-list.component.spec.ts
@@ -43,4 +43,49 @@ describe('RemoteStatusListComponent', () => {
 
     expect(spy).toHaveBeenCalledWith(proc);
   });
+
+  it('shows loading status while fetching', () => {
+    fixture.componentRef.setInput('loading', true);
+    fixture.detectChanges();
+    const status = fixture.nativeElement.querySelector(
+      '[role="status"]',
+    ) as HTMLElement;
+    expect(status.textContent).toContain('取得中');
+  });
+
+  it('shows error and emits retry', () => {
+    fixture.componentRef.setInput('error', 'list failed');
+    fixture.detectChanges();
+
+    const alert = fixture.nativeElement.querySelector(
+      '[role="alert"]',
+    ) as HTMLElement;
+    expect(alert.textContent).toContain('list failed');
+
+    const spy = vi.fn();
+    component.retry.subscribe(spy);
+    const retryBtn = fixture.nativeElement.querySelector(
+      'choh-button button',
+    ) as HTMLButtonElement;
+    retryBtn.click();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('shows unfetched empty message before first successful fetch', () => {
+    fixture.componentRef.setInput('fetched', false);
+    fixture.componentRef.setInput('processes', []);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain(
+      '「更新」で一覧を取得してください。',
+    );
+  });
+
+  it('shows empty message after successful fetch with no processes', () => {
+    fixture.componentRef.setInput('fetched', true);
+    fixture.componentRef.setInput('processes', []);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain(
+      'プロセスがありません。',
+    );
+  });
 });

--- a/libs/remote/src/lib/component/remote-status-list/remote-status-list.component.ts
+++ b/libs/remote/src/lib/component/remote-status-list/remote-status-list.component.ts
@@ -1,15 +1,21 @@
 import { Component, input, output } from '@angular/core';
 import type { ForeverProcess } from '@libs-shared';
+import { ButtonComponent } from '@libs-shared';
 
 @Component({
   selector: 'lib-remote-status-list',
+  imports: [ButtonComponent],
   templateUrl: './remote-status-list.component.html',
 })
 export class RemoteStatusListComponent {
   readonly processes = input<ForeverProcess[]>([]);
   readonly selected = input<ForeverProcess | null>(null);
+  readonly loading = input(false);
+  readonly error = input<string | null>(null);
+  readonly fetched = input(false);
 
   readonly rowSelected = output<ForeverProcess>();
+  readonly retry = output<void>();
 
   trackKey(p: ForeverProcess): string {
     return `${p.listIndex}\0${p.uid}`;


### PR DESCRIPTION
## Summary

- Forever 管理画面の一覧更新に二重取得防止と一覧内ローディングを追加する
- 取得失敗時にエラー表示と再試行操作を追加する
- 未取得 / 0 件の空状態を区別し、起動・停止後の既存自動更新は維持する

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #738

## What changed?

- `refreshList()` に `listInProgress` 中の早期 return、`listError` / `listFetched` 状態を追加
- `RemoteStatusListComponent` に loading / error / retry / 空状態区別の UI を追加
- 失敗・再試行・二重呼び出し防止のユニットテストを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. シリアル接続後、Remote ダイアログを開き「更新」で一覧を取得できること
2. 取得中に「取得中…」が表示され、更新ボタンが無効化されること
3. 一覧取得失敗時にエラーと「再試行」が表示され、再試行で再取得できること
4. プロセス 0 件時は「プロセスがありません。」、未取得時は「更新で一覧を取得してください」と表示されること
5. 起動・停止後に一覧が自動更新されること
6. `pnpm nx test libs-remote` が通ること

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)