### PR TITLE
feat(chirimen-setup): enable chirimen setup execution from ui

### DIFF
--- a/libs/chirimen-setup/src/lib/component/setup-page/setup-page.component.html
+++ b/libs/chirimen-setup/src/lib/component/setup-page/setup-page.component.html
@@ -5,6 +5,7 @@
     <h1 class="text-xl font-semibold text-gray-900">CHIRIMEN 初期セットアップ</h1>
     <p class="text-sm text-gray-600">
       Web Serial 経由で Raspberry Pi 上に Node.js と CHIRIMEN 依存を導入します。数十分かかる場合があります。
+      実行前に処理内容と影響を確認ダイアログで案内します。
     </p>
 
     <div class="flex flex-col gap-2 min-w-0">
@@ -50,17 +51,33 @@
       [indeterminate]="inProgress() && progressPercent() === 0"
     />
 
+    @if (stepItems().length > 0) {
+      <div class="flex flex-col gap-1 min-h-0">
+        <span class="text-sm font-medium text-gray-800">ステップ</span>
+        <lib-setup-step-list [steps]="stepItems()" />
+      </div>
+    }
+
     <mat-divider />
 
     <div class="flex flex-col gap-1 min-h-0 flex-1">
       <span class="text-sm font-medium text-gray-800">ログ</span>
       <textarea
         #logArea
-        class="border border-gray-300 rounded p-2 text-xs font-mono bg-gray-50 min-h-[180px] max-h-[40vh] overflow-auto resize-y w-full"
+        class="border border-gray-300 rounded p-2 text-xs font-mono bg-gray-50 min-h-[140px] max-h-[30vh] overflow-auto resize-y w-full"
         readonly
         [value]="logText()"
       ></textarea>
     </div>
+
+    @if (retryGuidance()) {
+      <div
+        class="border border-amber-300 bg-amber-50 text-amber-950 text-sm whitespace-pre-wrap rounded p-3"
+        role="alert"
+      >
+        {{ retryGuidance() }}
+      </div>
+    }
 
     <div class="flex flex-wrap gap-2 justify-end">
       <lib-setup-execute-button

--- a/libs/chirimen-setup/src/lib/component/setup-page/setup-page.component.spec.ts
+++ b/libs/chirimen-setup/src/lib/component/setup-page/setup-page.component.spec.ts
@@ -1,8 +1,12 @@
 /// <reference types="vitest/globals" />
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { computed } from '@angular/core';
+import { computed, signal } from '@angular/core';
 import { of } from 'rxjs';
-import { SetupCommandService } from '../../service';
+import {
+  SetupCommandService,
+  SetupPostSetupRebootFlowService,
+  SetupReadyCheckService,
+} from '../../service';
 import { ConfirmDialogComponent, DialogService } from '@libs-dialogs';
 import { NotificationService } from '@libs-shared';
 import { SerialFacadeService } from '@libs-web-serial';
@@ -12,9 +16,19 @@ describe('SetupPageComponent', () => {
   let component: SetupPageComponent;
   let fixture: ComponentFixture<SetupPageComponent>;
   let dialogOpen: ReturnType<typeof vi.fn>;
+  const rebootInProgress = signal(false);
+  let readyCheck: ReturnType<typeof vi.fn>;
+  let postSetupRebootRun: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     dialogOpen = vi.fn().mockReturnValue({ closed: of(true) });
+    readyCheck = vi.fn().mockResolvedValue({
+      ready: true,
+      nodeStdout: 'v20.18.1',
+      npmStdout: '10.8.2',
+    });
+    postSetupRebootRun = vi.fn().mockResolvedValue(undefined);
+    rebootInProgress.set(false);
 
     await TestBed.configureTestingModule({
       imports: [SetupPageComponent],
@@ -26,6 +40,17 @@ describe('SetupPageComponent', () => {
             buildStepList: vi.fn().mockReturnValue([
               { label: 'step1', phase: 'extra', status: 'pending' },
             ]),
+          },
+        },
+        {
+          provide: SetupReadyCheckService,
+          useValue: { check: readyCheck },
+        },
+        {
+          provide: SetupPostSetupRebootFlowService,
+          useValue: {
+            run: postSetupRebootRun,
+            inProgress: rebootInProgress.asReadonly(),
           },
         },
         {
@@ -42,6 +67,7 @@ describe('SetupPageComponent', () => {
             warning: vi.fn(),
             error: vi.fn(),
             success: vi.fn(),
+            info: vi.fn(),
           },
         },
       ],
@@ -68,6 +94,8 @@ describe('SetupPageComponent', () => {
       }),
     );
     expect(setup.run).toHaveBeenCalled();
+    expect(readyCheck).toHaveBeenCalled();
+    expect(postSetupRebootRun).toHaveBeenCalled();
   });
 
   it('runSetup does not run when confirm is cancelled', async () => {
@@ -75,6 +103,7 @@ describe('SetupPageComponent', () => {
     const setup = TestBed.inject(SetupCommandService);
     await component.runSetup();
     expect(setup.run).not.toHaveBeenCalled();
+    expect(postSetupRebootRun).not.toHaveBeenCalled();
   });
 
   it('shows retry guidance when setup fails', async () => {
@@ -111,5 +140,6 @@ describe('SetupPageComponent', () => {
     await component.runSetup();
     expect(component.retryGuidance()).toContain('Node.js バイナリを取得');
     expect(component.retryGuidance()).toContain('再試行手順');
+    expect(postSetupRebootRun).not.toHaveBeenCalled();
   });
 });

--- a/libs/chirimen-setup/src/lib/component/setup-page/setup-page.component.spec.ts
+++ b/libs/chirimen-setup/src/lib/component/setup-page/setup-page.component.spec.ts
@@ -1,30 +1,41 @@
 /// <reference types="vitest/globals" />
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { computed } from '@angular/core';
+import { of } from 'rxjs';
 import { SetupCommandService } from '../../service';
-import { DialogService } from '@libs-dialogs';
+import { ConfirmDialogComponent, DialogService } from '@libs-dialogs';
 import { NotificationService } from '@libs-shared';
 import { SerialFacadeService } from '@libs-web-serial';
-import { of } from 'rxjs';
 import { SetupPageComponent } from './setup-page.component';
 
 describe('SetupPageComponent', () => {
   let component: SetupPageComponent;
   let fixture: ComponentFixture<SetupPageComponent>;
+  let dialogOpen: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
+    dialogOpen = vi.fn().mockReturnValue({ closed: of(true) });
+
     await TestBed.configureTestingModule({
       imports: [SetupPageComponent],
       providers: [
         {
           provide: SetupCommandService,
-          useValue: { run: vi.fn().mockResolvedValue(undefined) },
+          useValue: {
+            run: vi.fn().mockResolvedValue(undefined),
+            buildStepList: vi.fn().mockReturnValue([
+              { label: 'step1', phase: 'extra', status: 'pending' },
+            ]),
+          },
         },
         {
           provide: SerialFacadeService,
           useValue: { isConnected: computed(() => true) },
         },
-        { provide: DialogService, useValue: { close: vi.fn() } },
+        {
+          provide: DialogService,
+          useValue: { close: vi.fn(), open: dialogOpen },
+        },
         {
           provide: NotificationService,
           useValue: {
@@ -45,9 +56,60 @@ describe('SetupPageComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('runSetup invokes SetupCommandService when connected', async () => {
+  it('runSetup shows confirm dialog then invokes SetupCommandService', async () => {
     const setup = TestBed.inject(SetupCommandService);
     await component.runSetup();
+    expect(dialogOpen).toHaveBeenCalledWith(
+      ConfirmDialogComponent,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          title: 'CHIRIMEN セットアップを実行',
+        }),
+      }),
+    );
     expect(setup.run).toHaveBeenCalled();
+  });
+
+  it('runSetup does not run when confirm is cancelled', async () => {
+    dialogOpen.mockReturnValueOnce({ closed: of(false) });
+    const setup = TestBed.inject(SetupCommandService);
+    await component.runSetup();
+    expect(setup.run).not.toHaveBeenCalled();
+  });
+
+  it('shows retry guidance when setup fails', async () => {
+    const setup = TestBed.inject(SetupCommandService) as {
+      run: ReturnType<typeof vi.fn>;
+    };
+    setup.run.mockImplementationOnce(
+      async (options: {
+        onProgress?: (p: {
+          stepIndex: number;
+          stepTotal: number;
+          phase: 'node';
+          label: string;
+          command: string;
+          stdout: string;
+          status: 'failed';
+          errorMessage?: string;
+        }) => void;
+      }) => {
+        options.onProgress?.({
+          stepIndex: 0,
+          stepTotal: 1,
+          phase: 'node',
+          label: 'Node.js バイナリを取得',
+          command: 'wget ...',
+          stdout: '',
+          status: 'failed',
+          errorMessage: 'timeout',
+        });
+        throw new Error('wget failed');
+      },
+    );
+
+    await component.runSetup();
+    expect(component.retryGuidance()).toContain('Node.js バイナリを取得');
+    expect(component.retryGuidance()).toContain('再試行手順');
   });
 });

--- a/libs/chirimen-setup/src/lib/component/setup-page/setup-page.component.ts
+++ b/libs/chirimen-setup/src/lib/component/setup-page/setup-page.component.ts
@@ -1,6 +1,7 @@
 import {
   Component,
   ElementRef,
+  computed,
   inject,
   signal,
   viewChild,
@@ -15,7 +16,11 @@ import {
   isValidNodeTarUrl,
   sanitizeProjectSubdir,
 } from '../../functions';
-import { SetupCommandService } from '../../service';
+import {
+  SetupCommandService,
+  SetupPostSetupRebootFlowService,
+  SetupReadyCheckService,
+} from '../../service';
 import type { SetupStepListItem, SetupStepProgress } from '../../models';
 import { SetupExecuteButtonComponent } from '../setup-execute-button/setup-execute-button.component';
 import { SetupProgressComponent } from '../setup-progress/setup-progress.component';
@@ -40,6 +45,8 @@ export class SetupPageComponent {
   private readonly notify = inject(NotificationService);
   private readonly serial = inject(SerialFacadeService);
   private readonly setup = inject(SetupCommandService);
+  private readonly readyCheck = inject(SetupReadyCheckService);
+  private readonly postSetupReboot = inject(SetupPostSetupRebootFlowService);
 
   private readonly logArea = viewChild<ElementRef<HTMLTextAreaElement>>('logArea');
 
@@ -47,12 +54,17 @@ export class SetupPageComponent {
   readonly useProjectSubdir = signal(true);
   readonly projectSubdir = signal(DEFAULT_PROJECT_SUBDIR);
 
-  readonly inProgress = signal(false);
+  readonly setupRunning = signal(false);
   readonly progressPercent = signal(0);
   readonly currentLabel = signal('');
   readonly logText = signal('');
   readonly stepItems = signal<SetupStepListItem[]>([]);
   readonly retryGuidance = signal('');
+
+  /** セットアップ実行中、または再起動案内フロー中 */
+  readonly inProgress = computed(
+    () => this.setupRunning() || this.postSetupReboot.inProgress(),
+  );
 
   closeModal(): void {
     this.dialogService.close();
@@ -159,7 +171,7 @@ export class SetupPageComponent {
     }
 
     const options = this.resolveOptions();
-    this.inProgress.set(true);
+    this.setupRunning.set(true);
     this.logText.set('');
     this.retryGuidance.set('');
     this.progressPercent.set(0);
@@ -182,7 +194,29 @@ export class SetupPageComponent {
           }
         },
       });
-      this.notify.success('Setup', 'セットアップが完了しました');
+
+      this.currentLabel.set('完了確認中…');
+      const ready = await this.readyCheck.check();
+      this.logText.update(
+        (t) =>
+          t +
+          `\n--- [verify] node/npm ---\nnode: ${ready.nodeStdout.trim()}\nnpm: ${ready.npmStdout.trim()}\nready: ${ready.ready}\n`,
+      );
+
+      if (ready.ready) {
+        this.notify.success(
+          'Setup',
+          'セットアップが完了しました。Terminal 等を利用できます',
+        );
+      } else {
+        this.notify.warning(
+          'Setup',
+          'コマンドは完了しましたが node/npm の確認に失敗しました。ログを確認してください',
+        );
+      }
+
+      // raspi-config 変更反映のため再起動を案内
+      await this.postSetupReboot.run();
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : 'セットアップに失敗しました';
       this.notify.error('Setup', msg);
@@ -200,7 +234,7 @@ export class SetupPageComponent {
         );
       }
     } finally {
-      this.inProgress.set(false);
+      this.setupRunning.set(false);
       this.currentLabel.set('');
     }
   }

--- a/libs/chirimen-setup/src/lib/component/setup-page/setup-page.component.ts
+++ b/libs/chirimen-setup/src/lib/component/setup-page/setup-page.component.ts
@@ -5,19 +5,22 @@ import {
   signal,
   viewChild,
 } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
 import {
   DEFAULT_NODE_TAR_URL,
   DEFAULT_PROJECT_SUBDIR,
 } from '../../constants';
 import {
+  buildSetupRetryMessage,
   isValidNodeTarUrl,
   sanitizeProjectSubdir,
 } from '../../functions';
 import { SetupCommandService } from '../../service';
-import type { SetupStepProgress } from '../../models';
+import type { SetupStepListItem, SetupStepProgress } from '../../models';
 import { SetupExecuteButtonComponent } from '../setup-execute-button/setup-execute-button.component';
 import { SetupProgressComponent } from '../setup-progress/setup-progress.component';
-import { DialogService } from '@libs-dialogs';
+import { SetupStepListComponent } from '../setup-step-list/setup-step-list.component';
+import { ConfirmDialogComponent, DialogService } from '@libs-dialogs';
 import { NotificationService } from '@libs-shared';
 import { SerialFacadeService } from '@libs-web-serial';
 import { MatDividerModule } from '@angular/material/divider';
@@ -28,6 +31,7 @@ import { MatDividerModule } from '@angular/material/divider';
     MatDividerModule,
     SetupProgressComponent,
     SetupExecuteButtonComponent,
+    SetupStepListComponent,
   ],
   templateUrl: './setup-page.component.html',
 })
@@ -47,6 +51,8 @@ export class SetupPageComponent {
   readonly progressPercent = signal(0);
   readonly currentLabel = signal('');
   readonly logText = signal('');
+  readonly stepItems = signal<SetupStepListItem[]>([]);
+  readonly retryGuidance = signal('');
 
   closeModal(): void {
     this.dialogService.close();
@@ -67,8 +73,21 @@ export class SetupPageComponent {
     this.useProjectSubdir.set(checked);
   }
 
+  private resolveOptions() {
+    return {
+      nodeTarUrl: this.nodeTarUrl().trim(),
+      projectSubdir: this.useProjectSubdir()
+        ? sanitizeProjectSubdir(this.projectSubdir())
+        : undefined,
+    };
+  }
+
   private appendLog(p: SetupStepProgress): void {
-    const block = `\n--- [${p.phase}] ${p.label} ---\n$ ${p.command}\n${p.stdout}\n`;
+    const errLine = p.stderr?.trim() ? `\n[stderr]\n${p.stderr}` : '';
+    const statusLine = p.errorMessage
+      ? `\n[status=${p.status}] ${p.errorMessage}`
+      : `\n[status=${p.status}]`;
+    const block = `\n--- [${p.phase}] ${p.label} ---${statusLine}\n$ ${p.command}\n${p.stdout}${errLine}\n`;
     this.logText.update((t) => t + block);
     queueMicrotask(() => {
       const el = this.logArea()?.nativeElement;
@@ -76,6 +95,48 @@ export class SetupPageComponent {
         el.scrollTop = el.scrollHeight;
       }
     });
+  }
+
+  private updateStepStatus(p: SetupStepProgress): void {
+    this.stepItems.update((items) => {
+      if (items.length === 0) {
+        return items;
+      }
+      const next = items.map((item) => ({ ...item }));
+      if (p.stepIndex >= 0 && p.stepIndex < next.length) {
+        next[p.stepIndex] = {
+          ...next[p.stepIndex],
+          status: p.status,
+        };
+      }
+      return next;
+    });
+  }
+
+  private async confirmRun(): Promise<boolean> {
+    const ref = this.dialogService.open(ConfirmDialogComponent, {
+      width: '480px',
+      data: {
+        title: 'CHIRIMEN セットアップを実行',
+        message: [
+          '次の処理を Web Serial 経由で実行します。',
+          '',
+          '・Node.js（linux-armv6l）の取得・展開と PATH 設定',
+          '・raspi-config によるカメラ関連設定の変更',
+          '・CHIRIMEN 用 package.json / RelayServer.js の取得と npm install',
+          '・forever の導入と既存プロセスの停止',
+          '',
+          '所要時間は数十分かかる場合があります。',
+          'インターネット接続と十分なディスク容量が必要です。',
+          'システム設定が変更され、再起動が必要になることがあります。',
+          '',
+          '実行しますか？',
+        ].join('\n'),
+        confirmLabel: '実行',
+        cancelLabel: 'キャンセル',
+      },
+    });
+    return (await firstValueFrom(ref.closed)) === true;
   }
 
   async runSetup(): Promise<void> {
@@ -93,28 +154,51 @@ export class SetupPageComponent {
       return;
     }
 
+    if (!(await this.confirmRun())) {
+      return;
+    }
+
+    const options = this.resolveOptions();
     this.inProgress.set(true);
     this.logText.set('');
+    this.retryGuidance.set('');
     this.progressPercent.set(0);
     this.currentLabel.set('開始…');
+    this.stepItems.set(this.setup.buildStepList(options));
+
+    let lastFailed: SetupStepProgress | undefined;
 
     try {
       await this.setup.run({
-        nodeTarUrl: url,
-        projectSubdir: this.useProjectSubdir()
-          ? sanitizeProjectSubdir(this.projectSubdir())
-          : undefined,
+        ...options,
         onProgress: (p: SetupStepProgress) => {
           const pct = Math.round(((p.stepIndex + 1) / p.stepTotal) * 100);
           this.progressPercent.set(Math.min(100, pct));
           this.currentLabel.set(p.label);
           this.appendLog(p);
+          this.updateStepStatus(p);
+          if (p.status === 'failed') {
+            lastFailed = p;
+          }
         },
       });
       this.notify.success('Setup', 'セットアップが完了しました');
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : 'セットアップに失敗しました';
       this.notify.error('Setup', msg);
+      if (lastFailed) {
+        this.retryGuidance.set(buildSetupRetryMessage(lastFailed));
+      } else {
+        this.retryGuidance.set(
+          [
+            `セットアップに失敗しました: ${msg}`,
+            '',
+            '再試行手順:',
+            '1. ログとシリアル接続を確認してください',
+            '2. 問題を解消したら、もう一度「セットアップ実行」を押してください',
+          ].join('\n'),
+        );
+      }
     } finally {
       this.inProgress.set(false);
       this.currentLabel.set('');

--- a/libs/chirimen-setup/src/lib/component/setup-step-list/setup-step-list.component.html
+++ b/libs/chirimen-setup/src/lib/component/setup-step-list/setup-step-list.component.html
@@ -1,5 +1,35 @@
-<ul>
-  @for (step of steps(); track step) {
-    <li>{{ step }}</li>
-  }
-</ul>
+@if (steps().length > 0) {
+  <ul class="text-sm space-y-1 max-h-[160px] overflow-auto border border-gray-200 rounded p-2 bg-gray-50">
+    @for (step of steps(); track $index) {
+      <li class="flex items-start gap-2 font-mono text-xs">
+        <span
+          class="shrink-0 w-16 text-right"
+          [class.text-gray-400]="step.status === 'pending'"
+          [class.text-blue-600]="step.status === 'running'"
+          [class.text-green-700]="step.status === 'ok'"
+          [class.text-red-700]="step.status === 'failed'"
+          [class.text-amber-700]="step.status === 'skipped'"
+        >
+          @switch (step.status) {
+            @case ('pending') {
+              待機
+            }
+            @case ('running') {
+              実行中
+            }
+            @case ('ok') {
+              成功
+            }
+            @case ('failed') {
+              失敗
+            }
+            @case ('skipped') {
+              スキップ
+            }
+          }
+        </span>
+        <span class="text-gray-800 break-words">{{ step.label }}</span>
+      </li>
+    }
+  </ul>
+}

--- a/libs/chirimen-setup/src/lib/component/setup-step-list/setup-step-list.component.ts
+++ b/libs/chirimen-setup/src/lib/component/setup-step-list/setup-step-list.component.ts
@@ -1,9 +1,10 @@
 import { Component, input } from '@angular/core';
+import type { SetupStepListItem } from '../../models';
 
 @Component({
   selector: 'lib-setup-step-list',
   templateUrl: './setup-step-list.component.html',
 })
 export class SetupStepListComponent {
-  readonly steps = input<string[]>([]);
+  readonly steps = input<SetupStepListItem[]>([]);
 }

--- a/libs/chirimen-setup/src/lib/constants/setup.constants.ts
+++ b/libs/chirimen-setup/src/lib/constants/setup.constants.ts
@@ -20,5 +20,6 @@ export const EXTRA_SETUP_STEPS: readonly ExtraSetupStep[] = [
   {
     label: 'タイムゾーンを Asia/Tokyo に設定',
     command: 'sudo timedatectl set-timezone Asia/Tokyo || true',
+    soft: true,
   },
 ];

--- a/libs/chirimen-setup/src/lib/functions/index.ts
+++ b/libs/chirimen-setup/src/lib/functions/index.ts
@@ -1,2 +1,3 @@
 export * from './node-install.steps';
+export * from './setup-retry-message';
 export * from './setup.util';

--- a/libs/chirimen-setup/src/lib/functions/node-install.steps.ts
+++ b/libs/chirimen-setup/src/lib/functions/node-install.steps.ts
@@ -14,9 +14,21 @@ export function buildNodeInstallStepList(
     : '';
 
   const steps: NodeInstallStep[] = [
-    { label: 'Node のバージョン確認', command: 'node -v || true' },
-    { label: 'npm のバージョン確認', command: 'npm -v || true' },
-    { label: 'forever の有無確認', command: 'which forever || true' },
+    {
+      label: 'Node のバージョン確認',
+      command: 'node -v || true',
+      soft: true,
+    },
+    {
+      label: 'npm のバージョン確認',
+      command: 'npm -v || true',
+      soft: true,
+    },
+    {
+      label: 'forever の有無確認',
+      command: 'which forever || true',
+      soft: true,
+    },
     {
       label: '作業ディレクトリ chirimenSetup を作成',
       command: 'mkdir -p chirimenSetup',

--- a/libs/chirimen-setup/src/lib/functions/setup-retry-message.spec.ts
+++ b/libs/chirimen-setup/src/lib/functions/setup-retry-message.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { buildSetupRetryMessage } from './setup-retry-message';
+import type { SetupStepProgress } from '../models';
+
+describe('buildSetupRetryMessage', () => {
+  it('includes failed step label and retry steps', () => {
+    const failed: SetupStepProgress = {
+      stepIndex: 2,
+      stepTotal: 10,
+      phase: 'node',
+      label: 'Node.js を展開',
+      command: 'sudo tar ...',
+      stdout: '',
+      status: 'failed',
+      errorMessage: 'timeout',
+    };
+    const msg = buildSetupRetryMessage(failed);
+    expect(msg).toContain('Node.js を展開');
+    expect(msg).toContain('3/10');
+    expect(msg).toContain('timeout');
+    expect(msg).toContain('再試行手順');
+  });
+});

--- a/libs/chirimen-setup/src/lib/functions/setup-retry-message.ts
+++ b/libs/chirimen-setup/src/lib/functions/setup-retry-message.ts
@@ -1,0 +1,22 @@
+import type { SetupStepProgress } from '../models';
+
+/**
+ * 途中失敗時に表示する再試行案内文を生成する。
+ */
+export function buildSetupRetryMessage(failed: SetupStepProgress): string {
+  const detail = failed.errorMessage?.trim()
+    ? `\n原因: ${failed.errorMessage.trim()}`
+    : '';
+  return [
+    `ステップ「${failed.label}」で失敗しました（${failed.stepIndex + 1}/${failed.stepTotal}）。`,
+    detail,
+    '',
+    '再試行手順:',
+    '1. ログとシリアル接続を確認してください',
+    '2. ネットワーク（wget）やディスク容量を確認してください',
+    '3. 問題を解消したら、もう一度「セットアップ実行」を押してください',
+    '4. 既に一部が完了している場合でも、同じ手順を再実行して構いません',
+  ]
+    .filter((line) => line !== undefined)
+    .join('\n');
+}

--- a/libs/chirimen-setup/src/lib/functions/setup.util.spec.ts
+++ b/libs/chirimen-setup/src/lib/functions/setup.util.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { DEFAULT_PROJECT_SUBDIR } from '../constants';
 import {
+  isSetupReady,
   isValidNodeTarUrl,
   sanitizeProjectSubdir,
 } from './setup.util';
@@ -30,5 +31,27 @@ describe('sanitizeProjectSubdir', () => {
 
   it('falls back to default when empty after sanitize', () => {
     expect(sanitizeProjectSubdir('@@@')).toBe(DEFAULT_PROJECT_SUBDIR);
+  });
+});
+
+describe('isSetupReady', () => {
+  it('returns true for valid node and npm versions', () => {
+    expect(isSetupReady('v20.18.1', '10.8.2')).toBe(true);
+  });
+
+  it('returns false when node is missing', () => {
+    expect(
+      isSetupReady('-bash: node: command not found', '10.8.2'),
+    ).toBe(false);
+  });
+
+  it('returns false when npm is missing', () => {
+    expect(isSetupReady('v20.18.1', '-bash: npm: command not found')).toBe(
+      false,
+    );
+  });
+
+  it('ignores leading blank lines', () => {
+    expect(isSetupReady('\n\nv22.0.0\n', '\n10.9.0\n')).toBe(true);
   });
 });

--- a/libs/chirimen-setup/src/lib/functions/setup.util.ts
+++ b/libs/chirimen-setup/src/lib/functions/setup.util.ts
@@ -21,7 +21,32 @@ export function sanitizeProjectSubdir(name: string): string {
   return s.length > 0 ? s : DEFAULT_PROJECT_SUBDIR;
 }
 
-export function isSetupReady(): boolean {
-  // TODO: セットアップ完了状態の確認ロジックを実装する。
-  return false;
+/**
+ * `node -v` / `npm -v` の標準出力からセットアップ完了を判定する。
+ */
+export function isSetupReady(stdoutNode: string, stdoutNpm: string): boolean {
+  const nodeLine = firstMeaningfulLine(stdoutNode);
+  const npmLine = firstMeaningfulLine(stdoutNpm);
+  if (!nodeLine || !npmLine) {
+    return false;
+  }
+  if (looksLikeBashMissing(nodeLine) || looksLikeBashMissing(npmLine)) {
+    return false;
+  }
+  const nodeOk = /^v?\d+\.\d+/.test(nodeLine);
+  const npmOk = /^\d+\.\d+/.test(npmLine);
+  return nodeOk && npmOk;
+}
+
+function firstMeaningfulLine(text: string): string {
+  return (
+    text
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .find((l) => l.length > 0) ?? ''
+  );
+}
+
+function looksLikeBashMissing(line: string): boolean {
+  return line.startsWith('-bash:') || line.includes('command not found');
 }

--- a/libs/chirimen-setup/src/lib/models/extra-setup.types.ts
+++ b/libs/chirimen-setup/src/lib/models/extra-setup.types.ts
@@ -1,4 +1,6 @@
 export interface ExtraSetupStep {
   label: string;
   command: string;
+  /** true のとき失敗してもセットアップを継続する */
+  soft?: boolean;
 }

--- a/libs/chirimen-setup/src/lib/models/node-install.types.ts
+++ b/libs/chirimen-setup/src/lib/models/node-install.types.ts
@@ -1,6 +1,8 @@
 export interface NodeInstallStep {
   label: string;
   command: string;
+  /** true のとき失敗してもセットアップを継続する（probe 等） */
+  soft?: boolean;
 }
 
 export interface NodeInstallOptions {

--- a/libs/chirimen-setup/src/lib/models/setup-progress.types.ts
+++ b/libs/chirimen-setup/src/lib/models/setup-progress.types.ts
@@ -3,6 +3,13 @@
  */
 export type SetupProgressPhase = 'extra' | 'node' | 'post';
 
+export type SetupStepStatus =
+  | 'pending'
+  | 'running'
+  | 'ok'
+  | 'failed'
+  | 'skipped';
+
 export interface SetupStepProgress {
   stepIndex: number;
   stepTotal: number;
@@ -10,4 +17,14 @@ export interface SetupStepProgress {
   label: string;
   command: string;
   stdout: string;
+  stderr?: string;
+  status: SetupStepStatus;
+  errorMessage?: string;
+}
+
+/** Setup 画面のステップ一覧表示用 */
+export interface SetupStepListItem {
+  label: string;
+  phase: SetupProgressPhase;
+  status: SetupStepStatus;
 }

--- a/libs/chirimen-setup/src/lib/service/extra-setup.service.ts
+++ b/libs/chirimen-setup/src/lib/service/extra-setup.service.ts
@@ -4,9 +4,20 @@ import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial';
 import { firstValueFrom } from 'rxjs';
 import { EXTRA_SETUP_STEPS } from '../constants';
 import type { ExtraSetupStep } from '../models';
+import type { SetupStepStatus } from '../models';
 
 export type { ExtraSetupStep } from '../models';
 export { EXTRA_SETUP_STEP_COUNT } from '../constants';
+
+export type ExtraSetupAfterStep = (
+  step: ExtraSetupStep,
+  result: {
+    stdout: string;
+    stderr?: string;
+    status: SetupStepStatus;
+    errorMessage?: string;
+  },
+) => void;
 
 @Injectable({ providedIn: 'root' })
 export class ExtraSetupService {
@@ -14,20 +25,31 @@ export class ExtraSetupService {
   private readonly prompt = PI_ZERO_PROMPT;
 
   /**
-   * @param onAfterStep 各コマンド完了時（失敗時も best-effort で通知）
+   * @param onAfterStep 各コマンド完了時（soft ステップは失敗しても継続）
    */
-  async apply(
-    onAfterStep?: (step: ExtraSetupStep, stdout: string) => void,
-  ): Promise<void> {
+  async apply(onAfterStep?: ExtraSetupAfterStep): Promise<void> {
     for (const step of EXTRA_SETUP_STEPS) {
       try {
-        const { stdout } = await firstValueFrom(this.serial.exec$(step.command, {
-          prompt: this.prompt,
-          timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
-        }));
-        onAfterStep?.(step, stdout);
-      } catch {
-        onAfterStep?.(step, '');
+        const { stdout, stderr } = await firstValueFrom(
+          this.serial.exec$(step.command, {
+            prompt: this.prompt,
+            timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
+          }),
+        );
+        onAfterStep?.(step, { stdout, stderr, status: 'ok' });
+      } catch (e: unknown) {
+        const errorMessage =
+          e instanceof Error ? e.message : 'コマンドの実行に失敗しました';
+        onAfterStep?.(step, {
+          stdout: '',
+          status: step.soft ? 'skipped' : 'failed',
+          errorMessage,
+        });
+        if (!step.soft) {
+          throw e instanceof Error
+            ? e
+            : new Error(errorMessage);
+        }
       }
     }
   }

--- a/libs/chirimen-setup/src/lib/service/index.ts
+++ b/libs/chirimen-setup/src/lib/service/index.ts
@@ -1,3 +1,6 @@
 export * from './extra-setup.service';
 export * from './node-install.service';
 export * from './setup-command.service';
+export * from './setup-ready-check.service';
+export * from './setup-reboot-flow.service';
+export * from './setup-post-setup-reboot-flow.service';

--- a/libs/chirimen-setup/src/lib/service/node-install.service.ts
+++ b/libs/chirimen-setup/src/lib/service/node-install.service.ts
@@ -4,9 +4,20 @@ import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial';
 import { firstValueFrom } from 'rxjs';
 import { buildNodeInstallStepList } from '../functions';
 import type { NodeInstallOptions, NodeInstallStep } from '../models';
+import type { SetupStepStatus } from '../models';
 
 export type { NodeInstallOptions, NodeInstallStep } from '../models';
 export { buildNodeInstallStepList } from '../functions';
+
+export type NodeInstallAfterStep = (
+  step: NodeInstallStep,
+  result: {
+    stdout: string;
+    stderr?: string;
+    status: SetupStepStatus;
+    errorMessage?: string;
+  },
+) => void;
 
 @Injectable({ providedIn: 'root' })
 export class NodeInstallService {
@@ -19,18 +30,36 @@ export class NodeInstallService {
 
   /**
    * Node.js をインストールして、chirimen 用の依存まで導入します。
+   * soft でないステップの失敗時は fail-fast します。
    */
   async install(
     options: NodeInstallOptions,
-    onAfterStep?: (step: NodeInstallStep, stdout: string) => void,
+    onAfterStep?: NodeInstallAfterStep,
   ): Promise<void> {
     const steps = this.buildInstallSteps(options);
     for (const step of steps) {
-      const { stdout } = await firstValueFrom(this.serial.exec$(step.command, {
-        prompt: this.prompt,
-        timeout: SERIAL_TIMEOUT.NODE_INSTALL,
-      }));
-      onAfterStep?.(step, stdout);
+      try {
+        const { stdout, stderr } = await firstValueFrom(
+          this.serial.exec$(step.command, {
+            prompt: this.prompt,
+            timeout: SERIAL_TIMEOUT.NODE_INSTALL,
+          }),
+        );
+        onAfterStep?.(step, { stdout, stderr, status: 'ok' });
+      } catch (e: unknown) {
+        const errorMessage =
+          e instanceof Error ? e.message : 'コマンドの実行に失敗しました';
+        onAfterStep?.(step, {
+          stdout: '',
+          status: step.soft ? 'skipped' : 'failed',
+          errorMessage,
+        });
+        if (!step.soft) {
+          throw e instanceof Error
+            ? e
+            : new Error(errorMessage);
+        }
+      }
     }
   }
 }

--- a/libs/chirimen-setup/src/lib/service/setup-command.service.ts
+++ b/libs/chirimen-setup/src/lib/service/setup-command.service.ts
@@ -3,12 +3,14 @@ import { SerialFacadeService } from '@libs-web-serial';
 import { PI_ZERO_PROMPT, SERIAL_TIMEOUT } from '@libs-web-serial';
 import { firstValueFrom } from 'rxjs';
 import { EXTRA_SETUP_STEPS } from '../constants';
-import {
-  ExtraSetupService,
-  type ExtraSetupStep,
-} from './extra-setup.service';
-import { NodeInstallService, type NodeInstallStep } from './node-install.service';
-import type { SetupStepProgress } from '../models';
+import { ExtraSetupService } from './extra-setup.service';
+import { NodeInstallService } from './node-install.service';
+import type {
+  SetupProgressPhase,
+  SetupStepListItem,
+  SetupStepProgress,
+  SetupStepStatus,
+} from '../models';
 
 export interface SetupCommandOptions {
   /**
@@ -25,6 +27,12 @@ export interface SetupRunOptions extends SetupCommandOptions {
   onProgress?: (progress: SetupStepProgress) => void;
 }
 
+const POST_STEP = {
+  label: 'forever プロセスを停止（整地）',
+  command: 'forever stopall',
+  soft: true,
+} as const;
+
 @Injectable({ providedIn: 'root' })
 export class SetupCommandService {
   private serial = inject(SerialFacadeService);
@@ -34,17 +42,36 @@ export class SetupCommandService {
   private readonly prompt = PI_ZERO_PROMPT;
 
   /**
+   * 実行予定のステップ一覧（UI の初期表示用）
+   */
+  buildStepList(options: SetupCommandOptions): SetupStepListItem[] {
+    const nodeSteps = this.nodeInstall.buildInstallSteps(options);
+    return [
+      ...EXTRA_SETUP_STEPS.map((s) => ({
+        label: s.label,
+        phase: 'extra' as const,
+        status: 'pending' as const,
+      })),
+      ...nodeSteps.map((s) => ({
+        label: s.label,
+        phase: 'node' as const,
+        status: 'pending' as const,
+      })),
+      {
+        label: POST_STEP.label,
+        phase: 'post' as const,
+        status: 'pending' as const,
+      },
+    ];
+  }
+
+  /**
    * CHIRIMEN 初期セットアップを実行します。
    *
    * issue #412 のコマンド分類に沿って「TZ/デバイス設定 + Node/依存導入」を実行します。
    */
   async run(options: SetupRunOptions): Promise<void> {
     const { onProgress, ...cmdOptions } = options;
-
-    const postStep = {
-      label: 'forever プロセスを停止（整地）',
-      command: 'forever stopall',
-    } as const;
 
     const extraSteps = EXTRA_SETUP_STEPS;
     const nodeSteps = this.nodeInstall.buildInstallSteps(cmdOptions);
@@ -53,10 +80,13 @@ export class SetupCommandService {
     let stepIndex = 0;
 
     const emit = (
-      phase: SetupStepProgress['phase'],
+      phase: SetupProgressPhase,
       label: string,
       command: string,
       stdout: string,
+      status: SetupStepStatus,
+      stderr?: string,
+      errorMessage?: string,
     ) => {
       onProgress?.({
         stepIndex,
@@ -65,26 +95,57 @@ export class SetupCommandService {
         label,
         command,
         stdout,
+        stderr,
+        status,
+        errorMessage,
       });
       stepIndex += 1;
     };
 
-    await this.extraSetup.apply((step: ExtraSetupStep, stdout: string) => {
-      emit('extra', step.label, step.command, stdout);
+    await this.extraSetup.apply((step, result) => {
+      emit(
+        'extra',
+        step.label,
+        step.command,
+        result.stdout,
+        result.status,
+        result.stderr,
+        result.errorMessage,
+      );
     });
 
-    await this.nodeInstall.install(cmdOptions, (step: NodeInstallStep, stdout) => {
-      emit('node', step.label, step.command, stdout);
+    await this.nodeInstall.install(cmdOptions, (step, result) => {
+      emit(
+        'node',
+        step.label,
+        step.command,
+        result.stdout,
+        result.status,
+        result.stderr,
+        result.errorMessage,
+      );
     });
 
     try {
-      const { stdout } = await firstValueFrom(this.serial.exec$(postStep.command, {
-        prompt: this.prompt,
-        timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
-      }));
-      emit('post', postStep.label, postStep.command, stdout);
-    } catch {
-      emit('post', postStep.label, postStep.command, '');
+      const { stdout, stderr } = await firstValueFrom(
+        this.serial.exec$(POST_STEP.command, {
+          prompt: this.prompt,
+          timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
+        }),
+      );
+      emit('post', POST_STEP.label, POST_STEP.command, stdout, 'ok', stderr);
+    } catch (e: unknown) {
+      const errorMessage =
+        e instanceof Error ? e.message : 'forever stopall に失敗しました';
+      emit(
+        'post',
+        POST_STEP.label,
+        POST_STEP.command,
+        '',
+        'skipped',
+        undefined,
+        errorMessage,
+      );
     }
   }
 }

--- a/libs/chirimen-setup/src/lib/service/setup-post-setup-reboot-flow.service.ts
+++ b/libs/chirimen-setup/src/lib/service/setup-post-setup-reboot-flow.service.ts
@@ -1,0 +1,155 @@
+import { Injectable, inject, signal } from '@angular/core';
+import { ConfirmDialogComponent, DialogService } from '@libs-dialogs';
+import { NotificationService } from '@libs-shared';
+import {
+  SerialExpectedDisconnectService,
+  SerialFacadeService,
+} from '@libs-web-serial';
+import { firstValueFrom } from 'rxjs';
+import { SetupRebootFlowService } from './setup-reboot-flow.service';
+
+const RECONNECT_POLL_MS = 500;
+/** 再接続待ちの上限（ブラウザ操作が必要なため長め）。 */
+const RECONNECT_WAIT_MS = 10 * 60 * 1000;
+
+/**
+ * セットアップ成功後の確認付き再起動〜再接続案内フロー（#734）。
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class SetupPostSetupRebootFlowService {
+  private readonly dialogService = inject(DialogService);
+  private readonly notify = inject(NotificationService);
+  private readonly serial = inject(SerialFacadeService);
+  private readonly setupReboot = inject(SetupRebootFlowService);
+  private readonly expectedDisconnect = inject(
+    SerialExpectedDisconnectService,
+  );
+
+  private readonly inProgressSignal = signal(false);
+  readonly inProgress = this.inProgressSignal.asReadonly();
+
+  /**
+   * 再起動確認 → コマンド送信 → 切断クリーンアップ → 再接続案内。
+   * 二重実行時は何もしない。ユーザーがキャンセルした場合も正常終了。
+   */
+  async run(): Promise<void> {
+    if (this.inProgressSignal()) {
+      return;
+    }
+
+    this.inProgressSignal.set(true);
+    try {
+      const confirmed = await this.confirmReboot();
+      if (!confirmed) {
+        this.notify.info(
+          'Setup',
+          '再起動をスキップしました。カメラ設定などを反映する場合は後から再起動してください',
+        );
+        return;
+      }
+
+      this.expectedDisconnect.beginExpectedDisconnect('reboot');
+      this.expectedDisconnect.beginRebootPending();
+      try {
+        const result = await this.setupReboot.rebootDevice();
+        if (result === 'failed') {
+          this.expectedDisconnect.clearExpectedDisconnect();
+          this.notify.error(
+            'Setup',
+            '再起動コマンドの実行に失敗しました。シリアル接続を確認してください',
+          );
+          return;
+        }
+
+        await this.cleanupSerialAfterReboot();
+        this.notify.info('Setup', '再起動を送信しました');
+      } finally {
+        this.expectedDisconnect.clearRebootPending();
+      }
+
+      await this.showInfoDialog(
+        'デバイス再起動中',
+        'Raspberry Pi が再起動しています。電源ランプなどが安定するまでしばらくお待ちください。',
+      );
+
+      await this.showInfoDialog(
+        'Web Serial の再接続',
+        '再起動が完了したら、ツールバーの Connect からシリアルポートを選び直してください。ブラウザの権限制約により、再接続にはユーザー操作が必要です。再接続後はオートログインが実行されます。その後 Terminal や他機能を利用できます。',
+      );
+
+      const reconnected = await this.waitForReconnect();
+      this.expectedDisconnect.clearExpectedDisconnect();
+
+      if (!reconnected) {
+        this.notify.warning(
+          'Setup',
+          '再接続が確認できませんでした。Connect 後に Terminal 等を利用してください',
+        );
+        return;
+      }
+
+      this.notify.success('Setup', '再接続を確認しました');
+    } finally {
+      this.inProgressSignal.set(false);
+    }
+  }
+
+  private async confirmReboot(): Promise<boolean> {
+    const ref = this.dialogService.open(ConfirmDialogComponent, {
+      width: '480px',
+      data: {
+        title: 'デバイスを再起動',
+        message:
+          'raspi-config の変更などを反映するためデバイスの再起動を推奨します。シリアル接続が切れます。Editor の未保存内容は同一タブの下書きとして保持されます（タブを閉じると消える場合があります）。再起動しますか？',
+        confirmLabel: '再起動',
+        cancelLabel: '後で',
+      },
+    });
+    const confirmed = await firstValueFrom(ref.closed);
+    return confirmed === true;
+  }
+
+  private async showInfoDialog(title: string, message: string): Promise<void> {
+    const ref = this.dialogService.open(ConfirmDialogComponent, {
+      width: '480px',
+      data: {
+        title,
+        message,
+        confirmLabel: '次へ',
+        hideCancel: true,
+      },
+    });
+    await firstValueFrom(ref.closed);
+  }
+
+  private async cleanupSerialAfterReboot(): Promise<void> {
+    try {
+      await firstValueFrom(this.serial.disconnect$());
+    } catch {
+      // 既に切断済みでもセッション掃除を試みるだけなので無視
+    }
+  }
+
+  private async waitForReconnect(): Promise<boolean> {
+    if (this.serial.isConnected()) {
+      return true;
+    }
+
+    const deadline = Date.now() + RECONNECT_WAIT_MS;
+    while (Date.now() < deadline) {
+      await delay(RECONNECT_POLL_MS);
+      if (this.serial.isConnected()) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/libs/chirimen-setup/src/lib/service/setup-ready-check.service.ts
+++ b/libs/chirimen-setup/src/lib/service/setup-ready-check.service.ts
@@ -1,0 +1,71 @@
+import { Injectable, inject } from '@angular/core';
+import {
+  PI_ZERO_PROMPT,
+  SERIAL_TIMEOUT,
+  SerialFacadeService,
+} from '@libs-web-serial';
+import { firstValueFrom } from 'rxjs';
+import { isSetupReady } from '../functions';
+
+export interface SetupReadyCheckResult {
+  ready: boolean;
+  nodeStdout: string;
+  npmStdout: string;
+}
+
+/**
+ * セットアップ完了後に node / npm が使えるかを検証する。
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class SetupReadyCheckService {
+  private readonly serial = inject(SerialFacadeService);
+
+  async check(): Promise<SetupReadyCheckResult> {
+    // 新規シェルでも PATH が効くようプロファイルを読む
+    try {
+      await firstValueFrom(
+        this.serial.exec$('. ~/.profile', {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
+        }),
+      );
+    } catch {
+      // profile 読込失敗でもバージョン確認は試す
+    }
+
+    let nodeStdout = '';
+    let npmStdout = '';
+
+    try {
+      const node = await firstValueFrom(
+        this.serial.exec$('node -v', {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
+        }),
+      );
+      nodeStdout = node.stdout;
+    } catch (e: unknown) {
+      nodeStdout = e instanceof Error ? e.message : '';
+    }
+
+    try {
+      const npm = await firstValueFrom(
+        this.serial.exec$('npm -v', {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.FILE_TRANSFER,
+        }),
+      );
+      npmStdout = npm.stdout;
+    } catch (e: unknown) {
+      npmStdout = e instanceof Error ? e.message : '';
+    }
+
+    return {
+      ready: isSetupReady(nodeStdout, npmStdout),
+      nodeStdout,
+      npmStdout,
+    };
+  }
+}

--- a/libs/chirimen-setup/src/lib/service/setup-reboot-flow.service.ts
+++ b/libs/chirimen-setup/src/lib/service/setup-reboot-flow.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, inject } from '@angular/core';
+import {
+  PI_ZERO_PROMPT,
+  SERIAL_TIMEOUT,
+  SerialFacadeService,
+} from '@libs-web-serial';
+import { firstValueFrom } from 'rxjs';
+
+/** デバイス再起動コマンドの結果 */
+export type SetupRebootDeviceResult = 'ok' | 'failed';
+
+/**
+ * Setup 完了後のデバイス再起動コマンド送信。
+ * wifi へ依存せず web-serial のみを利用する。
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class SetupRebootFlowService {
+  private readonly serial = inject(SerialFacadeService);
+
+  /**
+   * デバイスを再起動する。
+   * 再起動でシリアルが切れるとタイムアウトや切断エラーになり得る。
+   * 切断されていれば成功、接続が残っていればコマンド失敗とみなす。
+   */
+  async rebootDevice(): Promise<SetupRebootDeviceResult> {
+    try {
+      await firstValueFrom(
+        this.serial.exec$('sudo reboot', {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.REBOOT,
+        }),
+      );
+    } catch {
+      // 再起動でシリアルが切れるとタイムアウトや切断エラーになり得る
+    }
+
+    if (!this.serial.isConnected()) {
+      return 'ok';
+    }
+    return 'failed';
+  }
+}


### PR DESCRIPTION
## Summary

- Setup 画面から CHIRIMEN 環境セットアップを UI 完結で実行できるようにしました（実行前確認・ステップ成否・ログ・失敗時再試行案内）
- 完了後に node/npm の利用可否を検証し、raspi-config 反映のための再起動確認・再接続案内を追加しました
- 既存のセットアップコマンド列（#412）は維持し、soft ステップ以外は fail-fast で失敗を可視化します

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #734

## What changed?

- `SetupStepProgress` に `status` / `stderr` / `errorMessage` を追加し、各ステップの成否を通知
- `ExtraSetupService` / `NodeInstallService` / `SetupCommandService` で soft 以外を fail-fast、進捗を UI に反映
- Setup ページに実行前 Confirm、ステップ一覧、失敗時再試行案内を接続
- `isSetupReady` と完了後検証、再起動〜再接続案内フロー（`SetupPostSetupRebootFlowService`）を追加

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details: `@libs-chirimen-setup` から ready check / reboot flow サービスを export。`SetupStepProgress` に必須の `status` を追加（破壊的だが lib 内部利用が主）
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. シリアル接続後、ツールバーから Setup を開く
2. 「セットアップ実行」で確認ダイアログの内容を確認し、実行する
3. ステップ一覧・進捗バー・ログに stdout/stderr と成否が表示されることを確認する
4. 途中失敗時（例: ネットワーク切断）に再試行案内が表示されることを確認する
5. 成功時に node/npm 検証ログが出た後、再起動確認ダイアログが表示されることを確認する（「後で」でスキップ可）
6. 再起動後、Connect で再接続し Terminal が利用できることを確認する

```bash
pnpm nx test libs-chirimen-setup
pnpm nx lint libs-chirimen-setup
```

## Environment (if relevant)

- Browser: Chrome（Web Serial 対応）
- OS: macOS / Windows / Linux
- Node version: （ローカル開発環境）
- pnpm version: （ローカル開発環境）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)