### PR TITLE
feat(wifi): add ok/ng labels to connectivity check dialog

### DIFF
--- a/libs/wifi/src/lib/component/index.ts
+++ b/libs/wifi/src/lib/component/index.ts
@@ -1,4 +1,5 @@
 export * from './wifi-connect-dialog/wifi-connect-dialog.component';
+export * from './wifi-connectivity-dialog/wifi-connectivity-dialog.component';
 export * from './wifi-form/wifi-form.component';
 export * from './wifi-info/wifi-info.component';
 export * from './wifi-list/wifi-list.component';

--- a/libs/wifi/src/lib/component/wifi-connectivity-dialog/wifi-connectivity-dialog.component.html
+++ b/libs/wifi/src/lib/component/wifi-connectivity-dialog/wifi-connectivity-dialog.component.html
@@ -1,0 +1,31 @@
+<div
+  class="flex min-w-[280px] max-w-full flex-col gap-4 rounded-lg bg-white p-5 text-gray-900 shadow-lg"
+>
+  <h2 class="m-0 text-lg font-medium">疎通確認（tutorial.chirimen.org）</h2>
+
+  <div>
+    @if (isOk) {
+      <span
+        class="rounded bg-green-100 px-1.5 py-0.5 text-sm font-medium text-green-800"
+        role="status"
+      >
+        OK
+      </span>
+    } @else {
+      <span
+        class="rounded bg-red-100 px-1.5 py-0.5 text-sm font-medium text-red-800"
+        role="status"
+      >
+        NG
+      </span>
+    }
+  </div>
+
+  <pre
+    class="m-0 max-h-64 overflow-auto whitespace-pre-wrap break-words rounded border border-gray-200 bg-gray-50 p-3 text-xs leading-relaxed text-gray-800"
+  >{{ detail }}</pre>
+
+  <div class="flex justify-end">
+    <button mat-stroked-button type="button" (click)="close()">閉じる</button>
+  </div>
+</div>

--- a/libs/wifi/src/lib/component/wifi-connectivity-dialog/wifi-connectivity-dialog.component.spec.ts
+++ b/libs/wifi/src/lib/component/wifi-connectivity-dialog/wifi-connectivity-dialog.component.spec.ts
@@ -1,0 +1,50 @@
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { WifiConnectivityDialogComponent } from './wifi-connectivity-dialog.component';
+
+describe('WifiConnectivityDialogComponent', () => {
+  let fixture: ComponentFixture<WifiConnectivityDialogComponent>;
+  const close = vi.fn();
+
+  async function setup(status: 'ok' | 'ng', detail: string): Promise<void> {
+    TestBed.resetTestingModule();
+    close.mockClear();
+    await TestBed.configureTestingModule({
+      imports: [WifiConnectivityDialogComponent],
+      providers: [
+        { provide: DialogRef, useValue: { close } },
+        {
+          provide: DIALOG_DATA,
+          useValue: { status, detail },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WifiConnectivityDialogComponent);
+    fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    await setup('ok', '200 OK');
+  });
+
+  it('shows OK badge when status is ok', () => {
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('OK');
+    expect(text).toContain('200 OK');
+    expect(text).toContain('疎通確認（tutorial.chirimen.org）');
+  });
+
+  it('shows NG badge when status is ng', async () => {
+    await setup('ng', 'unable to resolve host');
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('NG');
+    expect(text).toContain('unable to resolve host');
+  });
+
+  it('closes dialog when close is clicked', () => {
+    fixture.componentInstance.close();
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/libs/wifi/src/lib/component/wifi-connectivity-dialog/wifi-connectivity-dialog.component.ts
+++ b/libs/wifi/src/lib/component/wifi-connectivity-dialog/wifi-connectivity-dialog.component.ts
@@ -1,0 +1,22 @@
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { Component, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import type { WifiConnectivityDialogData } from '../../models';
+
+@Component({
+  selector: 'choh-wifi-connectivity-dialog',
+  imports: [MatButtonModule],
+  templateUrl: './wifi-connectivity-dialog.component.html',
+})
+export class WifiConnectivityDialogComponent {
+  private readonly dialogRef = inject(DialogRef<void>);
+  private readonly data = inject<WifiConnectivityDialogData>(DIALOG_DATA);
+
+  readonly status = this.data.status;
+  readonly detail = this.data.detail;
+  readonly isOk = this.status === 'ok';
+
+  close(): void {
+    this.dialogRef.close();
+  }
+}

--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.spec.ts
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../../service';
 import type { WiFiInfo } from '@libs-shared';
 import { SerialFacadeService } from '@libs-web-serial';
+import { WifiConnectivityDialogComponent } from '../wifi-connectivity-dialog/wifi-connectivity-dialog.component';
 import { WifiPageComponent } from './wifi-page.component';
 
 describe('WifiPageComponent', () => {
@@ -19,6 +20,7 @@ describe('WifiPageComponent', () => {
   let fixture: ComponentFixture<WifiPageComponent>;
 
   const scanNetworks = vi.fn();
+  const checkChirimenTutorialReachability = vi.fn();
   const restartWifiService = vi.fn().mockResolvedValue(undefined);
   const postConnectRebootRun = vi.fn().mockResolvedValue(undefined);
   const rebootFlowInProgress = signal(false);
@@ -37,6 +39,10 @@ describe('WifiPageComponent', () => {
       wifiInfos: [] as WiFiInfo[],
       rawData: [] as string[],
     });
+    checkChirimenTutorialReachability.mockClear();
+    checkChirimenTutorialReachability.mockResolvedValue(
+      'URL: https://tutorial.chirimen.org/ 200 OK',
+    );
     dialogClosed = of(undefined);
     restartWifiService.mockClear().mockResolvedValue(undefined);
     postConnectRebootRun.mockClear().mockResolvedValue(undefined);
@@ -73,9 +79,7 @@ describe('WifiPageComponent', () => {
               ipInfo: '',
               wlInfo: '',
             }),
-            checkChirimenTutorialReachability: vi
-              .fn()
-              .mockResolvedValue('OK'),
+            checkChirimenTutorialReachability,
           },
         },
         {
@@ -286,6 +290,44 @@ describe('WifiPageComponent', () => {
     scanNetworks.mockRejectedValueOnce(new Error('scan failed'));
     await component.runWifiScan();
     expect(component.scanError()).toBe('scan failed');
+  });
+
+  it('checkConnectivity opens dialog with ok status on success', async () => {
+    const dialog = TestBed.inject(Dialog);
+    const openSpy = vi.spyOn(dialog, 'open');
+
+    await component.checkConnectivity();
+
+    expect(openSpy).toHaveBeenCalledWith(
+      WifiConnectivityDialogComponent,
+      expect.objectContaining({
+        data: {
+          status: 'ok',
+          detail: 'URL: https://tutorial.chirimen.org/ 200 OK',
+        },
+      }),
+    );
+  });
+
+  it('checkConnectivity opens dialog with ng status on failure', async () => {
+    checkChirimenTutorialReachability.mockRejectedValueOnce(
+      new Error('Connectivity check failed'),
+    );
+    const dialog = TestBed.inject(Dialog);
+    const openSpy = vi.spyOn(dialog, 'open');
+
+    await component.checkConnectivity();
+
+    expect(openSpy).toHaveBeenCalledWith(
+      WifiConnectivityDialogComponent,
+      expect.objectContaining({
+        data: {
+          status: 'ng',
+          detail: 'Connectivity check failed',
+        },
+      }),
+    );
+    expect(notify.error).not.toHaveBeenCalled();
   });
 });
 

--- a/libs/wifi/src/lib/component/wifi-page/wifi-page.component.ts
+++ b/libs/wifi/src/lib/component/wifi-page/wifi-page.component.ts
@@ -12,14 +12,21 @@ import type { WiFiInfo } from '@libs-shared';
 import { ButtonComponent, NotificationService } from '@libs-shared';
 import { SerialFacadeService } from '@libs-web-serial';
 import { firstValueFrom } from 'rxjs';
-import { parseConnectedSsid } from '../../functions';
-import type { WifiConnectDialogData } from '../../models';
+import {
+  parseConnectedSsid,
+  parseConnectivityCheckResult,
+} from '../../functions';
+import type {
+  WifiConnectDialogData,
+  WifiConnectivityDialogData,
+} from '../../models';
 import {
   WifiPostConnectRebootFlowService,
   WifiRebootFlowService,
   WifiScanService,
 } from '../../service';
 import { WifiConnectDialogComponent } from '../wifi-connect-dialog/wifi-connect-dialog.component';
+import { WifiConnectivityDialogComponent } from '../wifi-connectivity-dialog/wifi-connectivity-dialog.component';
 import { WifiListComponent } from '../wifi-list/wifi-list.component';
 
 /**
@@ -236,20 +243,23 @@ export class WifiPageComponent implements OnInit {
     this.actionInProgress.set(true);
     try {
       const out = await this.wifiScan.checkChirimenTutorialReachability();
-      this.dialog.open(ConfirmDialogComponent, {
-        width: '480px',
-        data: {
-          title: '疎通確認（tutorial.chirimen.org）',
-          message: out.trim() || '完了（出力なし）',
-          confirmLabel: '閉じる',
-          hideCancel: true,
-        },
+      const detail = out.trim() || '完了（出力なし）';
+      this.openConnectivityDialog({
+        status: parseConnectivityCheckResult(out),
+        detail,
       });
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : '疎通確認に失敗しました';
-      this.notify.error('WiFi', msg);
+      this.openConnectivityDialog({ status: 'ng', detail: msg });
     } finally {
       this.actionInProgress.set(false);
     }
+  }
+
+  private openConnectivityDialog(data: WifiConnectivityDialogData): void {
+    this.dialog.open(WifiConnectivityDialogComponent, {
+      width: '480px',
+      data,
+    });
   }
 }

--- a/libs/wifi/src/lib/functions/connectivity-check.spec.ts
+++ b/libs/wifi/src/lib/functions/connectivity-check.spec.ts
@@ -1,0 +1,34 @@
+/// <reference types="vitest/globals" />
+import { parseConnectivityCheckResult } from './connectivity-check';
+
+describe('parseConnectivityCheckResult', () => {
+  it('returns ok when stdout contains 200 OK', () => {
+    const stdout = [
+      'wget --spider -nv https://tutorial.chirimen.org/',
+      '2024-07-23 14:18:21 URL: https://tutorial.chirimen.org/ 200 OK',
+      'pi@raspberrypi:~$',
+    ].join('\n');
+    expect(parseConnectivityCheckResult(stdout)).toBe('ok');
+  });
+
+  it('returns ok when stdout contains remote file exists', () => {
+    expect(
+      parseConnectivityCheckResult(
+        'https://tutorial.chirimen.org/:\nRemote file exists.',
+      ),
+    ).toBe('ok');
+  });
+
+  it('returns ng for failure-like wget output', () => {
+    expect(
+      parseConnectivityCheckResult(
+        'wget: unable to resolve host address ‘tutorial.chirimen.org’',
+      ),
+    ).toBe('ng');
+  });
+
+  it('returns ng for empty stdout', () => {
+    expect(parseConnectivityCheckResult('')).toBe('ng');
+    expect(parseConnectivityCheckResult('   ')).toBe('ng');
+  });
+});

--- a/libs/wifi/src/lib/functions/connectivity-check.ts
+++ b/libs/wifi/src/lib/functions/connectivity-check.ts
@@ -1,0 +1,15 @@
+export type ConnectivityCheckResult = 'ok' | 'ng';
+
+const OK_PATTERNS: RegExp[] = [/\b200\s+OK\b/i, /remote file exists/i];
+
+/**
+ * wget --spider の stdout から疎通結果を判定する。
+ */
+export function parseConnectivityCheckResult(
+  stdout: string,
+): ConnectivityCheckResult {
+  if (OK_PATTERNS.some((pattern) => pattern.test(stdout))) {
+    return 'ok';
+  }
+  return 'ng';
+}

--- a/libs/wifi/src/lib/functions/index.ts
+++ b/libs/wifi/src/lib/functions/index.ts
@@ -1,3 +1,4 @@
+export * from './connectivity-check';
 export * from './shell-quote';
 export * from './wifi-connect-error';
 export * from './wifi-parser';

--- a/libs/wifi/src/lib/models/index.ts
+++ b/libs/wifi/src/lib/models/index.ts
@@ -1,3 +1,4 @@
 export * from './wifi-connect-dialog.types';
+export * from './wifi-connectivity-dialog.types';
 export * from './wifi-form.types';
 export * from './wifi-status.types';

--- a/libs/wifi/src/lib/models/wifi-connectivity-dialog.types.ts
+++ b/libs/wifi/src/lib/models/wifi-connectivity-dialog.types.ts
@@ -1,0 +1,4 @@
+export interface WifiConnectivityDialogData {
+  status: 'ok' | 'ng';
+  detail: string;
+}


### PR DESCRIPTION
## Summary

- WiFi 疎通確認の結果を緑 OK / 赤 NG ラベルで一目で分かるようにした
- wget 出力のパースと専用結果ダイアログを追加した

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Closes #793

## What changed?

- `parseConnectivityCheckResult` で wget stdout から OK/NG を判定
- `WifiConnectivityDialogComponent` で緑 OK / 赤 NG バッジとログを表示
- `WifiPageComponent.checkConnectivity` を専用ダイアログに配線（失敗時もダイアログ表示）

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. アプリを起動し `/wifi` を開く
2. シリアル接続後に「疎通確認」を実行する
3. 成功時は緑の OK ラベルとログ、失敗時は赤の NG ラベルと詳細が表示されること

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)