### PR TITLE
fix(web-serial): force colored bash ps1 after term export

### DIFF
--- a/libs/web-serial/README.md
+++ b/libs/web-serial/README.md
@@ -165,13 +165,13 @@ PiZeroSerialBootstrapService
 2. **ユーザー名送信後** — `Password:` プロンプト。
 3. **パスワード送信後** — Debian MOTD と `pi@raspberrypi:~$` 形式のシェルプロンプト。
 
-シェル到達後は **環境設定の初期化**（`PI_ZERO_ENVIRONMENT_STEPS`）を `exec$` で実行する。初期化には timezone に加えて language / locale / `TZ` などを含める。ターミナルへのライブ表示は **`terminalText$`**。プロンプト照合・ログイン判定は **`exec$` / `readUntilPrompt$` 経路**（内部で `receive$` チャンクをバッファ）により行う。
+シェル到達後は **環境設定の初期化**（`PI_ZERO_ENVIRONMENT_STEPS`）を `exec$` で実行する。初期化には `TERM=xterm-256color`、色付き `PS1`（Issue [#795](https://github.com/gurezo/chirimen-lite-console/issues/795)）、timezone、language / locale / `TZ` などを含める。ターミナルへのライブ表示は **`terminalText$`**。プロンプト照合・ログイン判定は **`exec$` / `readUntilPrompt$` 経路**（内部で `receive$` チャンクをバッファ）により行う。
 
 ## CHIRIMEN / Pi Zero 固有ロジックの集約（Issue [#594](https://github.com/gurezo/chirimen-lite-console/issues/594)）
 
 - Pi Zero 向けの **login / password / シェルプロンプト到達確認 / 環境初期化（timezone/language/locale/env）** は **`PiZeroSerialBootstrapService` に集約**する（[`pi-zero-serial-bootstrap.service.ts`](src/lib/pi-zero-serial-bootstrap.service.ts)）。
   - 接続単位の「一度だけ実行」などのオーケストレーションは `PiZeroSessionService`（[`pi-zero-session.service.ts`](src/lib/pi-zero-session.service.ts)）。
-  - 環境初期化ステップ（timezone/language/locale/env）／期待プロンプトの定数は [`pi-zero-bootstrap.config.ts`](src/lib/pi-zero-bootstrap.config.ts) に集約。
+  - 環境初期化ステップ（TERM / 色付き PS1 / timezone / language / locale / env）／期待プロンプトの定数は [`pi-zero-bootstrap.config.ts`](src/lib/constants/pi-zero-bootstrap.config.ts) に集約。
 - Pi Zero 固有のプロンプト判定（`pi@…` シェル / `login:` / `Password:` 等）は **`PiZeroPromptDetectorService`** に分離（[`pi-zero-prompt-detector.service.ts`](src/lib/pi-zero-prompt-detector.service.ts)）。
 - 汎用の `prompt` / `RegExp` 照合は **`matchesSerialPrompt`**（[`serial-prompt-match.ts`](src/lib/serial-command/serial-prompt-match.ts)）に集約し、**`SerialCommandPipelineService` が直接利用**する（Issue [#675](https://github.com/gurezo/chirimen-lite-console/issues/675) で `SerialPromptDetectorService` を廃止。単一コンシューマ・外部依存なしのため Injectable 境界を外した）。
 - 他サービス（`wifi`, `file-manager`, `remote`, `chirimen-setup`, `i2cdetect` など）は Pi Zero 固有ロジックを保持しない。期待プロンプト文字列としての `PI_ZERO_PROMPT` 利用は許容する。

--- a/libs/web-serial/src/lib/constants/pi-zero-bootstrap.config.ts
+++ b/libs/web-serial/src/lib/constants/pi-zero-bootstrap.config.ts
@@ -20,6 +20,13 @@ export const PI_ZERO_LC_ALL = 'C.UTF-8' as const;
 export const PI_ZERO_TZ_ENV = PI_ZERO_TIMEZONE;
 
 /**
+ * Debian/RPi 標準の色付き PS1。
+ * シリアルログイン時はシェル起動時点の TERM で色なし PS1 が確定するため、TERM 設定後に再適用する（#795）。
+ */
+export const PI_ZERO_COLORED_PS1 =
+  '\\[\\033[01;32m\\]\\u@\\h\\[\\033[00m\\]:\\[\\033[01;34m\\]\\w\\[\\033[00m\\]\\$ ';
+
+/**
  * 接続直後の環境初期化（timezone/language/locale/env 各ステップの説明とコマンド）。
  * timezone 設定では `sudo -n` を使い、対話的パスワード待ちを避ける。
  */
@@ -28,6 +35,11 @@ export const PI_ZERO_ENVIRONMENT_STEPS: readonly PiZeroEnvironmentStep[] = [
     statusMessage:
       '[コンソール] 端末種別 TERM=xterm-256color を設定しています...',
     command: 'export TERM=xterm-256color',
+  },
+  {
+    statusMessage:
+      '[コンソール] シェルプロンプトに色を設定しています...',
+    command: `PS1='${PI_ZERO_COLORED_PS1}'`,
   },
   {
     statusMessage:

--- a/libs/web-serial/src/lib/service/pi-zero-serial-bootstrap.service.spec.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-serial-bootstrap.service.spec.ts
@@ -44,7 +44,7 @@ describe('PiZeroSerialBootstrapService', () => {
     expect(send$).toHaveBeenCalledWith(`${PI_ZERO_LOGIN_USER}\r\n`);
     expect(send$).toHaveBeenCalledWith(`${PI_ZERO_LOGIN_PASSWORD}\r\n`);
     expect(logs.some((l) => l.includes('シェルプロンプトを待機中'))).toBe(true);
-    expect(exec).toHaveBeenCalledTimes(7); // environment setup steps
+    expect(exec).toHaveBeenCalledTimes(8); // environment setup steps
   });
 
   it('skips login send when shell already visible after flush', async () => {

--- a/libs/web-serial/src/lib/service/pi-zero-session.service.spec.ts
+++ b/libs/web-serial/src/lib/service/pi-zero-session.service.spec.ts
@@ -368,12 +368,14 @@ describe('PiZeroSessionService', () => {
       const service = createSession(serial, createShellReadinessMock());
       await firstValueFrom(service.setupEnvironment$());
 
-      expect(exec).toHaveBeenCalledTimes(7);
+      expect(exec).toHaveBeenCalledTimes(8);
       expect(exec.mock.calls[0]?.[0]).toBe('export TERM=xterm-256color');
-      expect(exec.mock.calls[1]?.[0]).toContain('export LANG=');
-      expect(exec.mock.calls[3]?.[0]).toContain('timedatectl set-timezone');
-      expect(exec.mock.calls[4]?.[0]).toBe('timedatectl status');
-      expect(exec.mock.calls[5]?.[0]).toContain('export TZ=');
+      expect(exec.mock.calls[1]?.[0]).toContain('PS1=');
+      expect(exec.mock.calls[1]?.[0]).toContain('\\033[01;32m');
+      expect(exec.mock.calls[2]?.[0]).toContain('export LANG=');
+      expect(exec.mock.calls[4]?.[0]).toContain('timedatectl set-timezone');
+      expect(exec.mock.calls[5]?.[0]).toBe('timedatectl status');
+      expect(exec.mock.calls[6]?.[0]).toContain('export TZ=');
     });
   });
 


### PR DESCRIPTION
## Summary

- シリアルログイン後に色なしのまま残る bash `PS1` を、`TERM=xterm-256color` 設定直後に Debian/RPi 標準の色付きプロンプトへ再設定する
- xterm テーマ適用後に `pi@raspberrypi:~$` が前景色（白っぽい）だけで描画されていた問題（#795）を解消する

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #795

## What changed?

- `PI_ZERO_ENVIRONMENT_STEPS` に色付き `PS1` 設定ステップを追加（`PI_ZERO_COLORED_PS1`）
- 環境初期化ステップ数・コマンド順序のテスト期待値を更新
- `libs/web-serial/README.md` に色付き PS1 を含む旨を追記

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx serve console` で localhost:4200 を開く
2. Pi Zero に接続し、環境初期化完了まで待つ
3. `pi@raspberrypi:~$` が緑（ユーザー@ホスト）+ 青（パス）で表示されること
4. 既存の `exec$` / プロンプト待機がタイムアウトしないこと
5. （自動）`pnpm nx test libs-web-serial -- pi-zero-session.service.spec.ts pi-zero-serial-bootstrap.service.spec.ts`

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)