### PR TITLE
fix(wifi): align wifi scan columns with shared subgrid

### DIFF
--- a/libs/wifi/src/lib/component/wifi-info/wifi-info.component.spec.ts
+++ b/libs/wifi/src/lib/component/wifi-info/wifi-info.component.spec.ts
@@ -31,6 +31,14 @@ describe('WifiInfoComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('uses subgrid host classes without own column template', () => {
+    const host = fixture.nativeElement as HTMLElement;
+    expect(host.className).toContain('grid-cols-subgrid');
+    expect(host.className).toContain('col-span-4');
+    expect(host.className).toContain('sm:col-span-5');
+    expect(host.className).not.toContain('grid-cols-[minmax');
+  });
+
   it('shows hidden label for empty ssid', () => {
     fixture.componentRef.setInput('wifiInfo', { ...sample, ssid: '' });
     fixture.detectChanges();

--- a/libs/wifi/src/lib/component/wifi-info/wifi-info.component.ts
+++ b/libs/wifi/src/lib/component/wifi-info/wifi-info.component.ts
@@ -18,7 +18,7 @@ import {
     role: 'listitem',
     tabindex: '0',
     class:
-      'grid w-full grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto_auto] items-center gap-2 border-b border-gray-100 px-3 py-2 text-left hover:bg-gray-50 focus-visible:ring-2 focus-visible:outline-none sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_auto_auto]',
+      'col-span-4 grid w-full grid-cols-subgrid items-center gap-2 border-b border-gray-100 px-3 py-2 text-left hover:bg-gray-50 focus-visible:ring-2 focus-visible:outline-none sm:col-span-5',
     '[class.bg-blue-50]': 'selected()',
     '[attr.aria-selected]': 'selected()',
     '(click)': 'onHostClick($event)',

--- a/libs/wifi/src/lib/component/wifi-list/wifi-list.component.html
+++ b/libs/wifi/src/lib/component/wifi-list/wifi-list.component.html
@@ -4,13 +4,13 @@
   </div>
 
   <div
-    class="min-h-0 flex-1 overflow-y-auto rounded border border-gray-200"
+    class="grid min-h-0 flex-1 grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto_auto] overflow-y-auto rounded border border-gray-200 sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_auto_auto]"
     role="list"
     [attr.aria-busy]="scanInProgress()"
     [attr.aria-label]="'WiFi アクセスポイント一覧'"
   >
     <div
-      class="sticky top-0 z-10 grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto_auto] gap-2 border-b border-gray-200 bg-gray-50 px-3 py-2 text-xs font-semibold text-gray-600 sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_auto_auto]"
+      class="sticky top-0 z-10 col-span-4 grid grid-cols-subgrid gap-2 border-b border-gray-200 bg-gray-50 px-3 py-2 text-xs font-semibold text-gray-600 sm:col-span-5"
       role="presentation"
     >
       <div>SSID</div>
@@ -21,9 +21,13 @@
     </div>
 
     @if (scanInProgress()) {
-      <p class="p-3 text-sm text-gray-600" role="status">スキャン中…</p>
+      <p class="col-span-full p-3 text-sm text-gray-600" role="status">
+        スキャン中…
+      </p>
     } @else if (scanError()) {
-      <p class="p-3 text-sm text-red-700" role="alert">{{ scanError() }}</p>
+      <p class="col-span-full p-3 text-sm text-red-700" role="alert">
+        {{ scanError() }}
+      </p>
     } @else {
       @for (
         wifiInfo of wifiInfoList();
@@ -38,7 +42,7 @@
           (connectNetwork)="networkConnect.emit($event)"
         />
       } @empty {
-        <p class="p-3 text-sm text-gray-600">
+        <p class="col-span-full p-3 text-sm text-gray-600">
           スキャン結果がありません。「再スキャン」で取得してください。
         </p>
       }

--- a/libs/wifi/src/lib/component/wifi-list/wifi-list.component.spec.ts
+++ b/libs/wifi/src/lib/component/wifi-list/wifi-list.component.spec.ts
@@ -79,6 +79,33 @@ describe('WifiListComponent', () => {
     expect(text).toContain('WPA2');
   });
 
+  it('shares column tracks via subgrid between header and rows', () => {
+    fixture.componentRef.setInput('wifiInfoList', [sampleNetwork]);
+    fixture.detectChanges();
+
+    const list = fixture.nativeElement.querySelector(
+      '[role="list"]',
+    ) as HTMLElement;
+    expect(list.className).toContain(
+      'grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto_auto]',
+    );
+    expect(list.className).toContain(
+      'sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)_auto_auto]',
+    );
+
+    const header = list.querySelector(
+      '[role="presentation"]',
+    ) as HTMLElement;
+    expect(header.className).toContain('grid-cols-subgrid');
+    expect(header.className).toContain('col-span-4');
+    expect(header.className).toContain('sm:col-span-5');
+
+    const row = list.querySelector('choh-wifi-info') as HTMLElement;
+    expect(row.className).toContain('grid-cols-subgrid');
+    expect(row.className).toContain('col-span-4');
+    expect(row.className).toContain('sm:col-span-5');
+  });
+
   it('marks selected and connected rows', () => {
     fixture.componentRef.setInput('wifiInfoList', [sampleNetwork]);
     fixture.componentRef.setInput('selectedAddress', sampleNetwork.address);


### PR DESCRIPTION
## Summary

WiFi スキャン結果のヘッダと各行で列トラックを共有し、列ズレを解消する。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #797

## What changed?

- 親リスト（`role="list"`）を共有 CSS Grid 化し、列テンプレートを親で一度だけ定義するように変更
- ヘッダ行と `choh-wifi-info` を `grid-cols-subgrid` で継承し、末尾の `auto` 列幅が揃うように修正
- スキャン中 / エラー / 空状態メッセージに `col-span-full` を付与
- 共有 subgrid レイアウトの回帰テストを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx test libs-wifi` / `pnpm nx lint libs-wifi` が成功すること
2. `http://localhost:4200/wifi` を開き、SSID / Signal / Security / 接続状態 / 接続操作の列境界がヘッダと全行で揃うこと
3. 「接続中」バッジがある行と「—」の行でも列がズレないこと
4. 「再スキャン」「接続」ボタンの動作が従来どおりであること

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)