### PR TITLE
feat(editor): load selected file from tree into editor

### DIFF
--- a/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.html
+++ b/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.html
@@ -9,6 +9,7 @@
       >
         <lib-file-tree-feature
           [currentPath]="shellStore.fileManagerCurrentPath()"
+          [selectedPath]="shellStore.selectedFilePath()"
           (currentPathChange)="onCurrentPathChange($event)"
           (fileSelected)="onFileSelected($event)"
         />
@@ -28,6 +29,7 @@
       >
         <lib-file-tree-feature
           [currentPath]="shellStore.fileManagerCurrentPath()"
+          [selectedPath]="shellStore.selectedFilePath()"
           (currentPathChange)="onCurrentPathChange($event)"
           (fileSelected)="onFileSelected($event)"
         />

--- a/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.spec.ts
+++ b/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.spec.ts
@@ -109,6 +109,28 @@ describe('LeftSidebarComponent', () => {
     expect(store.selectedFilePath()).toBeNull();
   });
 
+  it('passes selected file path to the file tree feature', () => {
+    const store = TestBed.inject(ConsoleShellStore);
+    store.setSelectedFilePath('./main.ts');
+    fixture.detectChanges();
+
+    const tree = fixture.debugElement.query(By.css('lib-file-tree-feature'));
+    expect(tree).not.toBeNull();
+    expect(tree.componentInstance.selectedPath()).toBe('./main.ts');
+  });
+
+  it('sets selected file path and navigates to editor on file select', () => {
+    const store = TestBed.inject(ConsoleShellStore);
+    const router = TestBed.inject(Router);
+
+    component.onFileSelected('./home/pi/app.js');
+
+    expect(store.selectedFilePath()).toBe('./home/pi/app.js');
+    expect(router.navigate).toHaveBeenCalledWith(['editor'], {
+      relativeTo: TestBed.inject(ActivatedRoute),
+    });
+  });
+
   it('should set tooltip on panel toggle based on open state', () => {
     const openButton = fixture.debugElement.query(
       By.css('button[aria-label="ファイツリー閉じる"]'),

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.html
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.html
@@ -1,9 +1,9 @@
 <div
-  class="editor-page flex h-full min-h-0 min-w-0 flex-col"
+  class="editor-page relative flex h-full min-h-0 min-w-0 flex-col"
 >
   <choh-editor-toolbar
     class="shrink-0"
-    [saveDisabled]="!isDirty() || isSaving()"
+    [saveDisabled]="!isDirty() || isSaving() || !currentFileName()"
     (saveRequested)="saveCurrentFile()"
   />
   <choh-file-name-display
@@ -11,11 +11,38 @@
     [fileName]="currentFileName()"
     [isDirty]="isDirty()"
   />
-  <choh-monaco-editor
-    class="min-h-0 min-w-0 flex-1"
-    [code]="code()"
-    (codeChange)="onCodeChange($event)"
-    (editorInitialized)="onEditorInitialized($event)"
-    (contentEdited)="onContentEdited()"
-  />
+
+  @if (loadError(); as error) {
+    <p
+      class="shrink-0 px-3 py-2 text-sm text-red-600"
+      role="alert"
+      aria-live="assertive"
+    >
+      Failed to load {{ error.path }}: {{ error.message }}
+    </p>
+  }
+
+  <div class="relative min-h-0 min-w-0 flex-1">
+    @if (isLoading()) {
+      <div
+        class="absolute inset-0 z-10 flex items-center justify-center bg-white/70"
+        role="status"
+        aria-live="polite"
+      >
+        <mat-progress-spinner
+          mode="indeterminate"
+          diameter="84"
+          aria-label="Loading file"
+        />
+      </div>
+    }
+
+    <choh-monaco-editor
+      class="flex h-full min-h-0 min-w-0"
+      [code]="code()"
+      (codeChange)="onCodeChange($event)"
+      (editorInitialized)="onEditorInitialized($event)"
+      (contentEdited)="onContentEdited()"
+    />
+  </div>
 </div>

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -1,4 +1,5 @@
 /// <reference types="vitest/globals" />
+import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ConsoleShellStore } from '@libs-shared';
 import { provideMonacoEditor } from 'ngx-monaco-editor-v2';
@@ -8,13 +9,14 @@ import { EditorPageComponent } from './editor-page.component';
 describe('EditorPageComponent', () => {
   let component: EditorPageComponent;
   let fixture: ComponentFixture<EditorPageComponent>;
+  const selectedFilePathSignal = signal<string | null>(null);
   const editorServiceMock = {
     loadTextFile: vi.fn().mockResolvedValue('loaded content'),
     saveTextFile: vi.fn().mockResolvedValue(undefined),
     initializeEditor: vi.fn(),
   };
   const shellStoreMock = {
-    selectedFilePath: vi.fn(() => null),
+    selectedFilePath: () => selectedFilePathSignal(),
   };
   const draftServiceMock = {
     read: vi.fn(() => null),
@@ -22,8 +24,19 @@ describe('EditorPageComponent', () => {
     clear: vi.fn(),
   };
 
+  async function loadPath(path: string, content = 'loaded content'): Promise<void> {
+    editorServiceMock.loadTextFile.mockResolvedValueOnce(content);
+    selectedFilePathSignal.set(path);
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
   beforeEach(async () => {
     vi.clearAllMocks();
+    selectedFilePathSignal.set(null);
+    draftServiceMock.read.mockReturnValue(null);
+    editorServiceMock.loadTextFile.mockResolvedValue('loaded content');
+
     await TestBed.configureTestingModule({
       imports: [EditorPageComponent],
       providers: [provideMonacoEditor({})],
@@ -43,14 +56,71 @@ describe('EditorPageComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should start with an empty editor when no file is selected', () => {
+    expect(component.code()).toBe('');
+    expect(component.currentFileName()).toBeNull();
+    expect(editorServiceMock.loadTextFile).not.toHaveBeenCalled();
+  });
+
+  it('should load the selected file into the editor', async () => {
+    await loadPath('/home/pi/main.js', 'console.log(1)');
+
+    expect(editorServiceMock.loadTextFile).toHaveBeenCalledWith(
+      '/home/pi/main.js',
+    );
+    expect(component.code()).toBe('console.log(1)');
+    expect(component.currentFileName()).toBe('main.js');
+    expect(component.isDirty()).toBe(false);
+    expect(component.loadError()).toBeNull();
+  });
+
+  it('should load an empty file without error', async () => {
+    await loadPath('/home/pi/empty.js', '');
+
+    expect(component.code()).toBe('');
+    expect(component.currentFileName()).toBe('empty.js');
+    expect(component.loadError()).toBeNull();
+  });
+
+  it('should show load error and keep previous content on failure', async () => {
+    await loadPath('/home/pi/ok.js', 'previous');
+    const previousCode = component.code();
+
+    editorServiceMock.loadTextFile.mockRejectedValueOnce(
+      new Error('Target file is not a text file'),
+    );
+    selectedFilePathSignal.set('/home/pi/binary.bin');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.code()).toBe(previousCode);
+    expect(component.currentFileName()).toBe('ok.js');
+    expect(component.loadError()).toEqual({
+      path: '/home/pi/binary.bin',
+      message: 'Target file is not a text file',
+    });
+  });
+
+  it('should skip reloading the same path while idle', async () => {
+    await loadPath('/home/pi/main.js', 'once');
+    editorServiceMock.loadTextFile.mockClear();
+
+    await (
+      component as unknown as { loadFile: (path: string) => Promise<void> }
+    ).loadFile('/home/pi/main.js');
+
+    expect(editorServiceMock.loadTextFile).not.toHaveBeenCalled();
+  });
+
   it('should save current file and clear dirty state', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
     component.isDirty.set(true);
     component.code.set('updated');
 
     await component.saveCurrentFile();
 
     expect(editorServiceMock.saveTextFile).toHaveBeenCalledWith(
-      '/home/pi/edited.js',
+      '/home/pi/main.js',
       'updated',
     );
     expect(component.isDirty()).toBe(false);
@@ -65,12 +135,13 @@ describe('EditorPageComponent', () => {
     expect(editorServiceMock.saveTextFile).not.toHaveBeenCalled();
   });
 
-  it('should store edits as a session draft', () => {
+  it('should store edits as a session draft', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
     component.onCodeChange('updated draft');
     component.onContentEdited();
 
     expect(draftServiceMock.save).toHaveBeenCalledWith(
-      '/home/pi/edited.js',
+      '/home/pi/main.js',
       'updated draft',
     );
   });

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.ts
@@ -6,6 +6,7 @@ import {
   OnInit,
   signal,
 } from '@angular/core';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { ConsoleShellStore } from '@libs-shared';
 import type { editor } from 'monaco-editor';
 import { EditorDraftService, EditorService } from '../../service';
@@ -13,22 +14,10 @@ import { EditorToolbarComponent } from '../editor-toolbar/editor-toolbar.compone
 import { FileNameDisplayComponent } from '../file-name-display/file-name-display.component';
 import { MonacoEditorComponent } from '../monaco-editor/monaco-editor.component';
 
-const DEFAULT_CODE = `
-    onload = async function () {
-      window.addEventListener("message", receiveMessage, false);
-      portWritelnWaitfor = window.opener.portWritelnWaitfor;
-      getOutputLines = function (inp) {
-        var ret = window.opener.getOutputLines(inp);
-        console.log(ret);
-        return ret;
-      };
-      cmdPrompt = window.opener.cmdPrompt;
-      mv = window.opener.mv;
-      cp = window.opener.cp;
-      showDir = window.opener.showDir;
-    };
-    const sleep = (msec) => new Promise((resolve) => setTimeout(resolve, msec));
-`;
+export interface EditorLoadError {
+  path: string;
+  message: string;
+}
 
 @Component({
   selector: 'choh-editor-page',
@@ -36,20 +25,23 @@ const DEFAULT_CODE = `
     MonacoEditorComponent,
     EditorToolbarComponent,
     FileNameDisplayComponent,
+    MatProgressSpinner,
   ],
   templateUrl: './editor-page.component.html',
 })
 export class EditorPageComponent implements OnInit {
-  code = signal(DEFAULT_CODE.trim());
+  code = signal('');
   isDirty = signal(false);
   isSaving = signal(false);
+  isLoading = signal(false);
+  loadError = signal<EditorLoadError | null>(null);
 
   private editorService = inject(EditorService);
   private draftService = inject(EditorDraftService);
   private shellStore = inject(ConsoleShellStore);
-  private readonly defaultFilePath = '/home/pi/edited.js';
-  private readonly activeFilePath = signal(this.defaultFilePath);
+  private readonly activeFilePath = signal<string | null>(null);
   private initialized = false;
+  private loadGeneration = 0;
 
   constructor() {
     effect(() => {
@@ -71,42 +63,69 @@ export class EditorPageComponent implements OnInit {
       return;
     }
 
-    await this.loadFile(
-      this.shellStore.selectedFilePath() ?? this.defaultFilePath,
-    );
+    const selectedPath = this.shellStore.selectedFilePath();
+    if (selectedPath) {
+      await this.loadFile(selectedPath);
+    }
     this.initialized = true;
   }
 
-  private currentFilePath(): string {
+  private currentFilePath(): string | null {
     return this.activeFilePath();
   }
 
-  currentFileName(): string {
-    return this.currentFilePath().split('/').pop() ?? this.currentFilePath();
+  currentFileName(): string | null {
+    const path = this.currentFilePath();
+    if (!path) {
+      return null;
+    }
+    return path.split('/').pop() ?? path;
   }
 
   private async loadFile(path: string): Promise<void> {
+    if (
+      path === this.activeFilePath() &&
+      !this.loadError() &&
+      !this.isLoading()
+    ) {
+      return;
+    }
+
+    const generation = ++this.loadGeneration;
+    this.isLoading.set(true);
+    this.loadError.set(null);
+
     try {
       const loaded = await this.editorService.loadTextFile(path);
+      if (generation !== this.loadGeneration) {
+        return;
+      }
       this.activeFilePath.set(path);
       this.code.set(loaded);
       this.isDirty.set(false);
-    } catch {
-      // ファイルが存在しない等の場合はデフォルトコードのまま
+    } catch (error: unknown) {
+      if (generation !== this.loadGeneration) {
+        return;
+      }
+      const message =
+        error instanceof Error ? error.message : 'Failed to load file';
+      this.loadError.set({ path, message });
+    } finally {
+      if (generation === this.loadGeneration) {
+        this.isLoading.set(false);
+      }
     }
   }
 
   async saveCurrentFile(): Promise<void> {
-    if (!this.isDirty() || this.isSaving()) {
+    const path = this.currentFilePath();
+    if (!path || !this.isDirty() || this.isSaving()) {
       return;
     }
 
     this.isSaving.set(true);
     try {
-      await this.editorService.saveTextFile(
-        this.currentFilePath(),
-        this.code(),
-      );
+      await this.editorService.saveTextFile(path, this.code());
       this.isDirty.set(false);
       this.draftService.clear();
     } finally {
@@ -120,14 +139,19 @@ export class EditorPageComponent implements OnInit {
 
   onCodeChange(code: string): void {
     this.code.set(code);
-    if (this.isDirty()) {
-      this.draftService.save(this.currentFilePath(), code);
+    const path = this.currentFilePath();
+    if (this.isDirty() && path) {
+      this.draftService.save(path, code);
     }
   }
 
   onContentEdited(): void {
+    const path = this.currentFilePath();
+    if (!path) {
+      return;
+    }
     this.isDirty.set(true);
-    this.draftService.save(this.currentFilePath(), this.code());
+    this.draftService.save(path, this.code());
   }
 
   @HostListener('window:keydown', ['$event'])

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.html
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.html
@@ -42,6 +42,7 @@
     >
       <lib-file-tree
         [nodes]="nodes"
+        [selectedPath]="selectedPath()"
         (directorySelected)="onDirectorySelected($event)"
         (fileSelected)="onFileSelected($event)"
         (nodeContextMenu)="onNodeContextMenu($event)"

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
@@ -42,6 +42,8 @@ export class FileTreeFeatureComponent {
 
   /** Bound from ConsoleShellStore via LeftSidebar (issue #727). */
   readonly currentPath = input<string>('.');
+  /** Currently open file path for tree highlight (issue #805). */
+  readonly selectedPath = input<string | null>(null);
   readonly currentPathChange = output<string>();
   readonly fileSelected = output<string>();
 

--- a/libs/file-manager/src/lib/component/file-tree/file-tree.component.html
+++ b/libs/file-manager/src/lib/component/file-tree/file-tree.component.html
@@ -8,6 +8,9 @@
           <button
             type="button"
             class="inline-flex w-full items-center gap-1 text-left px-2 py-1 rounded hover:bg-gray-100"
+            [class.bg-blue-50]="isSelected(node)"
+            [class.font-medium]="isSelected(node)"
+            [attr.aria-current]="isSelected(node) ? 'true' : null"
             (click)="onSelect(node)"
             (contextmenu)="onContextMenu($event, node)"
           >

--- a/libs/file-manager/src/lib/component/file-tree/file-tree.component.spec.ts
+++ b/libs/file-manager/src/lib/component/file-tree/file-tree.component.spec.ts
@@ -40,4 +40,17 @@ describe('FileTreeComponent', () => {
     expect(payload?.event.clientX).toBe(12);
     expect(event.defaultPrevented).toBe(true);
   });
+
+  it('highlights the selected file path', () => {
+    fixture.componentRef.setInput('selectedPath', './main.ts');
+    fixture.detectChanges();
+
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('button');
+    const fileButton = buttons[1];
+
+    expect(fileButton?.getAttribute('aria-current')).toBe('true');
+    expect(fileButton?.classList.contains('bg-blue-50')).toBe(true);
+    expect(buttons[0]?.getAttribute('aria-current')).toBeNull();
+  });
 });

--- a/libs/file-manager/src/lib/component/file-tree/file-tree.component.ts
+++ b/libs/file-manager/src/lib/component/file-tree/file-tree.component.ts
@@ -14,10 +14,16 @@ export interface FileTreeContextMenuEvent {
 })
 export class FileTreeComponent {
   readonly nodes = input<FileTreeNode[]>([]);
+  readonly selectedPath = input<string | null>(null);
 
   readonly directorySelected = output<FileTreeNode>();
   readonly fileSelected = output<FileTreeNode>();
   readonly nodeContextMenu = output<FileTreeContextMenuEvent>();
+
+  isSelected(node: FileTreeNode): boolean {
+    const selected = this.selectedPath();
+    return selected !== null && selected === node.path;
+  }
 
   onSelect(node: FileTreeNode): void {
     if (node.isDirectory) {


### PR DESCRIPTION
## Summary

- ファイルツリーで選択したファイルを Monaco Editor に読み込む流れを実用化し、ハードコードされていた `edited.js` フォールバックを削除しました
- 読込中のローディング表示と、失敗時のパス付きエラー表示を追加しました
- 選択中ファイルをツリー上で強調表示するよう配線しました

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #805
- Parent: #804

## What changed?

- `EditorPageComponent` で未選択時は空状態とし、`isLoading` / `loadError` を追加
- 同一パスの不要な再読込を避け、連続選択時は世代カウンタで古い結果を破棄
- 空ファイルは正常表示、バイナリ/読込失敗時は Editor 内容を置き換えずエラー表示
- `FileTree` / `FileTreeFeature` に `selectedPath` を追加し選択行をハイライト
- `LeftSidebar` から `ConsoleShellStore.selectedFilePath` をツリーへ渡すよう配線
- 上記の unit test を追加・更新

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. CHIRIMEN Lite に接続し、ファイルツリーに一覧が表示されることを確認する
2. `.js` などのテキストファイルを選択し、内容が Monaco Editor に表示されることを確認する
3. 空ファイルを選択してもエラーにならないことを確認する
4. ディレクトリを選択しても Editor 内容が不正に置き換わらないことを確認する
5. 読込中にローディングが表示されること、読込失敗時にパスとエラー概要が出ることを確認する
6. 選択中ファイルがツリー上で強調され、Editor 表示中のファイルと一致することを確認する
7. `pnpm nx test libs-editor` / `libs-file-manager` / `libs-console-shell` が通ることを確認する

## Environment (if relevant)

- Browser: Chrome (Web Serial)
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)