### PR TITLE
feat(editor): manage unsaved state and local drafts

### DIFF
--- a/docs/serial-architecture.md
+++ b/docs/serial-architecture.md
@@ -204,7 +204,7 @@ Web Serial の物理接続と Linux シェルのログイン状態は別であ�
 - **接続直後の `login:` では発火しない**。一度シェル到達（`ready === true`）したあとに限りログアウト完了とみなす。
 - **`logout` 失敗でシェルが残る場合はリセットしない**（末尾がシェルプロンプトのままなら `logoutCompletedEpoch` は増えない）。
 - **再接続時**は新しい connection epoch と `resetSession()` によりオートログイン（`runAfterConnect$`）を再実行できる。
-- **Editor 未保存内容**はデバイスへ書き戻せず失われるため、`EditorDraftService` が同じタブの `sessionStorage` にドラフトを保持し、再接続後に Editor を開いた際に自動復元する。
+- **Editor 未保存内容**はデバイスへ書き戻せず失われるため、`EditorDraftService` が同じタブの `sessionStorage` に **ファイルパス単位**でドラフトを保持する。Editor 再表示時は自動復元せず、Restore / Discard / Reload from device を選択できる。保存状態は `Saved to device` / `Unsaved changes` / `Draft saved locally` / `Saving` / `Save failed` を区別し、Draft 保存だけではデバイス保存済みとはみなさない。未保存のまま別ファイル選択・別ページ遷移・ブラウザ終了する場合は確認する（Draft 自体は同一タブの sessionStorage に残る）。
 - **ユーザー通知**: ログアウト検出時に `SerialNotificationService.notifyLogoutDetected()` でトーストを表示する（接続成功／失敗トーストと同系統）。
 - **入力ブロック（ログアウト）**: Terminal で `logout` / `exit` を送ると `logoutPending` が立ち、Console 全体にローダーオーバーレイを表示して操作をブロックする。失敗してシェルへ戻った場合、または 30 秒タイムアウト時はローダーを解除する。
 - **入力ブロック（接続中）**: `isConnecting`、または接続済みかつシェル未準備（`isLoggedIn === false` かつ `setupStatus !== 'failed'`）の間、ログアウトと同様のローダーオーバーレイで UI / ターミナル入力をブロックする（issue #755）。初期化失敗時はオーバーレイを解除し再操作を許可する。

--- a/libs/console-shell/src/lib/lib.route.ts
+++ b/libs/console-shell/src/lib/lib.route.ts
@@ -1,5 +1,13 @@
-import { Routes } from '@angular/router';
+import { CanDeactivateFn, Routes } from '@angular/router';
 import { browserCheckGuard } from '@libs-shared';
+
+type CanComponentDeactivate = {
+  canDeactivate?: () => boolean | Promise<boolean>;
+};
+
+const canDeactivateGuard: CanDeactivateFn<CanComponentDeactivate> = (
+  component,
+) => component.canDeactivate?.() ?? true;
 
 export const consoleShellRoutes: Routes = [
   {
@@ -20,6 +28,7 @@ export const consoleShellRoutes: Routes = [
         path: 'editor',
         loadComponent: () =>
           import('@libs-editor').then((m) => m.EditorPageComponent),
+        canDeactivate: [canDeactivateGuard],
       },
       {
         path: 'example',

--- a/libs/editor/project.json
+++ b/libs/editor/project.json
@@ -10,7 +10,8 @@
   ],
   "implicitDependencies": [
     "libs-shared",
-    "libs-web-serial"
+    "libs-web-serial",
+    "libs-dialogs"
   ],
   "targets": {
     "build": {

--- a/libs/editor/src/index.ts
+++ b/libs/editor/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/service';
 export * from './lib/functions';
 export * from './lib/component';
+export * from './lib/guards';

--- a/libs/editor/src/lib/component/editor-draft-resolve-dialog/editor-draft-resolve-dialog.component.html
+++ b/libs/editor/src/lib/component/editor-draft-resolve-dialog/editor-draft-resolve-dialog.component.html
@@ -1,0 +1,12 @@
+<div class="dialog-content">
+  <h2>Local draft found</h2>
+  <p>
+    A local draft exists for {{ path }}. Restore the draft, discard it, or reload the
+    file from the device?
+  </p>
+  <div class="dialog-actions">
+    <button type="button" (click)="discard()">Discard draft</button>
+    <button type="button" (click)="reload()">Reload from device</button>
+    <button type="button" (click)="restore()">Restore draft</button>
+  </div>
+</div>

--- a/libs/editor/src/lib/component/editor-draft-resolve-dialog/editor-draft-resolve-dialog.component.ts
+++ b/libs/editor/src/lib/component/editor-draft-resolve-dialog/editor-draft-resolve-dialog.component.ts
@@ -1,0 +1,83 @@
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { Component, inject, OnInit } from '@angular/core';
+
+export type EditorDraftResolveChoice = 'restore' | 'discard' | 'reload';
+
+export interface EditorDraftResolveDialogData {
+  path: string;
+}
+
+@Component({
+  selector: 'choh-editor-draft-resolve-dialog',
+  templateUrl: './editor-draft-resolve-dialog.component.html',
+  styles: [
+    `
+      .dialog-content {
+        min-width: 280px;
+        max-width: 100%;
+        padding: 1.25rem 1.5rem;
+        background: #fff;
+        color: rgba(0, 0, 0, 0.87);
+        border-radius: 8px;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+      }
+      .dialog-content h2 {
+        margin: 0 0 0.75rem;
+        font-size: 1.125rem;
+        font-weight: 500;
+        line-height: 1.4;
+      }
+      .dialog-content p {
+        margin: 0;
+        white-space: pre-wrap;
+        word-break: break-word;
+        line-height: 1.5;
+      }
+      .dialog-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-top: 1.25rem;
+        justify-content: flex-end;
+      }
+      .dialog-actions button {
+        padding: 0.4rem 0.85rem;
+        border: 1px solid rgba(0, 0, 0, 0.24);
+        border-radius: 4px;
+        background: #fff;
+        color: inherit;
+        cursor: pointer;
+        font: inherit;
+      }
+      .dialog-actions button:hover {
+        background: rgba(0, 0, 0, 0.04);
+      }
+    `,
+  ],
+})
+export class EditorDraftResolveDialogComponent implements OnInit {
+  private readonly dialogRef = inject(DialogRef<EditorDraftResolveChoice | null>, {
+    optional: true,
+  });
+  private readonly data = inject<EditorDraftResolveDialogData | null>(DIALOG_DATA, {
+    optional: true,
+  });
+
+  path = '';
+
+  ngOnInit(): void {
+    this.path = this.data?.path ?? '';
+  }
+
+  restore(): void {
+    this.dialogRef?.close('restore');
+  }
+
+  discard(): void {
+    this.dialogRef?.close('discard');
+  }
+
+  reload(): void {
+    this.dialogRef?.close('reload');
+  }
+}

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.html
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.html
@@ -9,7 +9,7 @@
   <choh-file-name-display
     class="shrink-0"
     [fileName]="currentFileName()"
-    [isDirty]="isDirty()"
+    [saveStatus]="saveStatus()"
   />
 
   @if (loadError(); as error) {
@@ -19,6 +19,16 @@
       aria-live="assertive"
     >
       Failed to load {{ error.path }}: {{ error.message }}
+    </p>
+  }
+
+  @if (saveError(); as error) {
+    <p
+      class="shrink-0 px-3 py-2 text-sm text-red-600"
+      role="alert"
+      aria-live="assertive"
+    >
+      Failed to save: {{ error }}
     </p>
   }
 

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.html
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.html
@@ -4,7 +4,9 @@
   <choh-editor-toolbar
     class="shrink-0"
     [saveDisabled]="!isDirty() || isSaving() || !currentFileName()"
+    [discardDisabled]="!isDirty() || isSaving() || !currentFileName()"
     (saveRequested)="saveCurrentFile()"
+    (discardRequested)="discardChanges()"
   />
   <choh-file-name-display
     class="shrink-0"

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -212,6 +212,28 @@ describe('EditorPageComponent', () => {
     expect(component.saveStatus()).toBe('draftSavedLocally');
   });
 
+  it('should reload from device when draft resolve chooses reload', async () => {
+    const closed = mockDialogResult('reload');
+    draftServiceMock.list.mockReturnValueOnce([
+      {
+        path: '/home/pi/draft.js',
+        content: 'restored draft',
+        updatedAt: Date.now(),
+      },
+    ]);
+    editorServiceMock.loadTextFile.mockResolvedValue('device content');
+
+    const initPromise = component.ngOnInit();
+    closed.next('reload');
+    closed.complete();
+    await initPromise;
+
+    expect(draftServiceMock.clear).toHaveBeenCalledWith('/home/pi/draft.js');
+    expect(component.code()).toBe('device content');
+    expect(component.saveStatus()).toBe('savedToDevice');
+    expect(component.isDirty()).toBe(false);
+  });
+
   it('should confirm before switching files while dirty', async () => {
     await loadPath('/home/pi/main.js', 'loaded content');
     component.onCodeChange('dirty');

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -20,8 +20,11 @@ describe('EditorPageComponent', () => {
   };
   const draftServiceMock = {
     read: vi.fn(() => null),
+    list: vi.fn(() => []),
+    has: vi.fn(() => false),
     save: vi.fn(),
     clear: vi.fn(),
+    clearAll: vi.fn(),
   };
 
   async function loadPath(path: string, content = 'loaded content'): Promise<void> {
@@ -35,6 +38,7 @@ describe('EditorPageComponent', () => {
     vi.clearAllMocks();
     selectedFilePathSignal.set(null);
     draftServiceMock.read.mockReturnValue(null);
+    draftServiceMock.list.mockReturnValue([]);
     editorServiceMock.loadTextFile.mockResolvedValue('loaded content');
 
     await TestBed.configureTestingModule({
@@ -124,7 +128,7 @@ describe('EditorPageComponent', () => {
       'updated',
     );
     expect(component.isDirty()).toBe(false);
-    expect(draftServiceMock.clear).toHaveBeenCalled();
+    expect(draftServiceMock.clear).toHaveBeenCalledWith('/home/pi/main.js');
   });
 
   it('should skip save when dirty state is false', async () => {
@@ -147,11 +151,13 @@ describe('EditorPageComponent', () => {
   });
 
   it('should restore a session draft before loading the remote file', async () => {
-    draftServiceMock.read.mockReturnValueOnce({
-      path: '/home/pi/draft.js',
-      content: 'restored draft',
-      dirty: true,
-    });
+    draftServiceMock.list.mockReturnValueOnce([
+      {
+        path: '/home/pi/draft.js',
+        content: 'restored draft',
+        updatedAt: Date.now(),
+      },
+    ]);
     editorServiceMock.loadTextFile.mockClear();
 
     await component.ngOnInit();

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -1,8 +1,10 @@
 /// <reference types="vitest/globals" />
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DialogService } from '@libs-dialogs';
 import { ConsoleShellStore } from '@libs-shared';
 import { provideMonacoEditor } from 'ngx-monaco-editor-v2';
+import { Subject } from 'rxjs';
 import { EditorDraftService, EditorService } from '../../service';
 import { EditorPageComponent } from './editor-page.component';
 
@@ -17,6 +19,9 @@ describe('EditorPageComponent', () => {
   };
   const shellStoreMock = {
     selectedFilePath: () => selectedFilePathSignal(),
+    setSelectedFilePath: vi.fn((path: string | null) => {
+      selectedFilePathSignal.set(path);
+    }),
   };
   const draftServiceMock = {
     read: vi.fn(() => null),
@@ -26,12 +31,23 @@ describe('EditorPageComponent', () => {
     clear: vi.fn(),
     clearAll: vi.fn(),
   };
+  const dialogServiceMock = {
+    open: vi.fn(),
+  };
 
   async function loadPath(path: string, content = 'loaded content'): Promise<void> {
     editorServiceMock.loadTextFile.mockResolvedValue(content);
     selectedFilePathSignal.set(path);
     fixture.detectChanges();
     await fixture.whenStable();
+  }
+
+  function mockDialogResult(result: unknown): Subject<unknown> {
+    const closed = new Subject<unknown>();
+    dialogServiceMock.open.mockReturnValueOnce({
+      closed: closed.asObservable(),
+    });
+    return closed;
   }
 
   beforeEach(async () => {
@@ -48,6 +64,7 @@ describe('EditorPageComponent', () => {
       .overrideProvider(EditorService, { useValue: editorServiceMock })
       .overrideProvider(EditorDraftService, { useValue: draftServiceMock })
       .overrideProvider(ConsoleShellStore, { useValue: shellStoreMock })
+      .overrideProvider(DialogService, { useValue: dialogServiceMock })
       .compileComponents();
 
     fixture = TestBed.createComponent(EditorPageComponent);
@@ -172,7 +189,8 @@ describe('EditorPageComponent', () => {
     expect(component.isDirty()).toBe(true);
   });
 
-  it('should restore a session draft before loading the remote file', async () => {
+  it('should prompt to restore a draft instead of auto-loading remote content', async () => {
+    const closed = mockDialogResult('restore');
     draftServiceMock.list.mockReturnValueOnce([
       {
         path: '/home/pi/draft.js',
@@ -180,14 +198,57 @@ describe('EditorPageComponent', () => {
         updatedAt: Date.now(),
       },
     ]);
-    editorServiceMock.loadTextFile.mockClear();
+    editorServiceMock.loadTextFile.mockResolvedValue('device content');
 
-    await component.ngOnInit();
+    const initPromise = component.ngOnInit();
+    closed.next('restore');
+    closed.complete();
+    await initPromise;
 
+    expect(dialogServiceMock.open).toHaveBeenCalled();
     expect(component.code()).toBe('restored draft');
     expect(component.currentFileName()).toBe('draft.js');
     expect(component.isDirty()).toBe(true);
     expect(component.saveStatus()).toBe('draftSavedLocally');
+  });
+
+  it('should confirm before switching files while dirty', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
+    component.onCodeChange('dirty');
+    component.onContentEdited();
+
+    const closed = mockDialogResult(false);
+    editorServiceMock.loadTextFile.mockClear();
+
+    const switchPromise = (
+      component as unknown as { loadFile: (path: string) => Promise<void> }
+    ).loadFile('/home/pi/other.js');
+    closed.next(false);
+    closed.complete();
+    await switchPromise;
+
+    expect(component.currentFileName()).toBe('main.js');
+    expect(component.code()).toBe('dirty');
+    expect(shellStoreMock.setSelectedFilePath).toHaveBeenCalledWith(
+      '/home/pi/main.js',
+    );
     expect(editorServiceMock.loadTextFile).not.toHaveBeenCalled();
+  });
+
+  it('should discard dirty changes back to baseline', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
+    component.onCodeChange('dirty');
+    component.onContentEdited();
+
+    const closed = mockDialogResult(true);
+
+    const discardPromise = component.discardChanges();
+    closed.next(true);
+    closed.complete();
+    await discardPromise;
+
+    expect(component.code()).toBe('loaded content');
+    expect(component.saveStatus()).toBe('savedToDevice');
+    expect(draftServiceMock.clear).toHaveBeenCalledWith('/home/pi/main.js');
   });
 });

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -251,4 +251,24 @@ describe('EditorPageComponent', () => {
     expect(component.saveStatus()).toBe('savedToDevice');
     expect(draftServiceMock.clear).toHaveBeenCalledWith('/home/pi/main.js');
   });
+
+  it('should allow deactivation when clean', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
+
+    await expect(component.canDeactivate()).resolves.toBe(true);
+    expect(dialogServiceMock.open).not.toHaveBeenCalled();
+  });
+
+  it('should confirm before deactivating while dirty', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
+    component.onCodeChange('dirty');
+    component.onContentEdited();
+
+    const closed = mockDialogResult(false);
+    const deactivatePromise = component.canDeactivate();
+    closed.next(false);
+    closed.complete();
+
+    await expect(deactivatePromise).resolves.toBe(false);
+  });
 });

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -28,7 +28,7 @@ describe('EditorPageComponent', () => {
   };
 
   async function loadPath(path: string, content = 'loaded content'): Promise<void> {
-    editorServiceMock.loadTextFile.mockResolvedValueOnce(content);
+    editorServiceMock.loadTextFile.mockResolvedValue(content);
     selectedFilePathSignal.set(path);
     fixture.detectChanges();
     await fixture.whenStable();
@@ -75,6 +75,7 @@ describe('EditorPageComponent', () => {
     expect(component.code()).toBe('console.log(1)');
     expect(component.currentFileName()).toBe('main.js');
     expect(component.isDirty()).toBe(false);
+    expect(component.saveStatus()).toBe('savedToDevice');
     expect(component.loadError()).toBeNull();
   });
 
@@ -90,7 +91,7 @@ describe('EditorPageComponent', () => {
     await loadPath('/home/pi/ok.js', 'previous');
     const previousCode = component.code();
 
-    editorServiceMock.loadTextFile.mockRejectedValueOnce(
+    editorServiceMock.loadTextFile.mockRejectedValue(
       new Error('Target file is not a text file'),
     );
     selectedFilePathSignal.set('/home/pi/binary.bin');
@@ -118,8 +119,8 @@ describe('EditorPageComponent', () => {
 
   it('should save current file and clear dirty state', async () => {
     await loadPath('/home/pi/main.js', 'loaded content');
-    component.isDirty.set(true);
-    component.code.set('updated');
+    component.onCodeChange('updated');
+    component.onContentEdited();
 
     await component.saveCurrentFile();
 
@@ -128,18 +129,36 @@ describe('EditorPageComponent', () => {
       'updated',
     );
     expect(component.isDirty()).toBe(false);
+    expect(component.saveStatus()).toBe('savedToDevice');
     expect(draftServiceMock.clear).toHaveBeenCalledWith('/home/pi/main.js');
   });
 
+  it('should keep edits and draft when save fails', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
+    component.onCodeChange('updated');
+    component.onContentEdited();
+    editorServiceMock.saveTextFile.mockRejectedValueOnce(
+      new Error('device busy'),
+    );
+
+    await component.saveCurrentFile();
+
+    expect(component.code()).toBe('updated');
+    expect(component.isDirty()).toBe(true);
+    expect(component.saveStatus()).toBe('saveFailed');
+    expect(component.saveError()).toBe('device busy');
+    expect(draftServiceMock.clear).not.toHaveBeenCalled();
+  });
+
   it('should skip save when dirty state is false', async () => {
-    component.isDirty.set(false);
+    await loadPath('/home/pi/main.js', 'loaded content');
 
     await component.saveCurrentFile();
 
     expect(editorServiceMock.saveTextFile).not.toHaveBeenCalled();
   });
 
-  it('should store edits as a session draft', async () => {
+  it('should mark unsaved then draft-saved without claiming device save', async () => {
     await loadPath('/home/pi/main.js', 'loaded content');
     component.onCodeChange('updated draft');
     component.onContentEdited();
@@ -148,6 +167,9 @@ describe('EditorPageComponent', () => {
       '/home/pi/main.js',
       'updated draft',
     );
+    expect(component.saveStatus()).toBe('draftSavedLocally');
+    expect(component.saveStatus()).not.toBe('savedToDevice');
+    expect(component.isDirty()).toBe(true);
   });
 
   it('should restore a session draft before loading the remote file', async () => {
@@ -165,6 +187,7 @@ describe('EditorPageComponent', () => {
     expect(component.code()).toBe('restored draft');
     expect(component.currentFileName()).toBe('draft.js');
     expect(component.isDirty()).toBe(true);
+    expect(component.saveStatus()).toBe('draftSavedLocally');
     expect(editorServiceMock.loadTextFile).not.toHaveBeenCalled();
   });
 });

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  computed,
   effect,
   HostListener,
   inject,
@@ -13,6 +14,10 @@ import { EditorDraftService, EditorService } from '../../service';
 import { EditorToolbarComponent } from '../editor-toolbar/editor-toolbar.component';
 import { FileNameDisplayComponent } from '../file-name-display/file-name-display.component';
 import { MonacoEditorComponent } from '../monaco-editor/monaco-editor.component';
+import {
+  EditorSaveStatus,
+  isEditorDirtyStatus,
+} from './editor-save-status';
 
 export interface EditorLoadError {
   path: string;
@@ -31,15 +36,19 @@ export interface EditorLoadError {
 })
 export class EditorPageComponent implements OnInit {
   code = signal('');
-  isDirty = signal(false);
-  isSaving = signal(false);
-  isLoading = signal(false);
+  saveStatus = signal<EditorSaveStatus | null>(null);
   loadError = signal<EditorLoadError | null>(null);
+  saveError = signal<string | null>(null);
+
+  readonly isDirty = computed(() => isEditorDirtyStatus(this.saveStatus()));
+  readonly isSaving = computed(() => this.saveStatus() === 'saving');
+  readonly isLoading = computed(() => this.saveStatus() === 'loading');
 
   private editorService = inject(EditorService);
   private draftService = inject(EditorDraftService);
   private shellStore = inject(ConsoleShellStore);
   private readonly activeFilePath = signal<string | null>(null);
+  private baselineContent = '';
   private initialized = false;
   private loadGeneration = 0;
 
@@ -62,7 +71,8 @@ export class EditorPageComponent implements OnInit {
     if (draft) {
       this.activeFilePath.set(draft.path);
       this.code.set(draft.content);
-      this.isDirty.set(true);
+      this.baselineContent = '';
+      this.saveStatus.set('draftSavedLocally');
       this.initialized = true;
       return;
     }
@@ -89,23 +99,23 @@ export class EditorPageComponent implements OnInit {
     if (
       path === this.activeFilePath() &&
       !this.loadError() &&
-      !this.isLoading()
+      this.saveStatus() !== 'loading'
     ) {
       return;
     }
 
     const generation = ++this.loadGeneration;
-    this.isLoading.set(true);
+    const previousStatus = this.saveStatus();
+    this.saveStatus.set('loading');
     this.loadError.set(null);
+    this.saveError.set(null);
 
     try {
       const loaded = await this.editorService.loadTextFile(path);
       if (generation !== this.loadGeneration) {
         return;
       }
-      this.activeFilePath.set(path);
-      this.code.set(loaded);
-      this.isDirty.set(false);
+      this.applyDeviceContent(path, loaded);
     } catch (error: unknown) {
       if (generation !== this.loadGeneration) {
         return;
@@ -113,11 +123,20 @@ export class EditorPageComponent implements OnInit {
       const message =
         error instanceof Error ? error.message : 'Failed to load file';
       this.loadError.set({ path, message });
-    } finally {
-      if (generation === this.loadGeneration) {
-        this.isLoading.set(false);
+      if (this.activeFilePath()) {
+        this.saveStatus.set(previousStatus ?? 'savedToDevice');
+      } else {
+        this.saveStatus.set(null);
       }
     }
+  }
+
+  private applyDeviceContent(path: string, content: string): void {
+    this.activeFilePath.set(path);
+    this.code.set(content);
+    this.baselineContent = content;
+    this.saveStatus.set('savedToDevice');
+    this.saveError.set(null);
   }
 
   async saveCurrentFile(): Promise<void> {
@@ -126,13 +145,18 @@ export class EditorPageComponent implements OnInit {
       return;
     }
 
-    this.isSaving.set(true);
+    this.saveStatus.set('saving');
+    this.saveError.set(null);
     try {
       await this.editorService.saveTextFile(path, this.code());
-      this.isDirty.set(false);
+      this.baselineContent = this.code();
+      this.saveStatus.set('savedToDevice');
       this.draftService.clear(path);
-    } finally {
-      this.isSaving.set(false);
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to save file';
+      this.saveError.set(message);
+      this.saveStatus.set('saveFailed');
     }
   }
 
@@ -142,19 +166,29 @@ export class EditorPageComponent implements OnInit {
 
   onCodeChange(code: string): void {
     this.code.set(code);
-    const path = this.currentFilePath();
-    if (this.isDirty() && path) {
-      this.draftService.save(path, code);
-    }
+    this.syncDirtyStateFromCode(code);
   }
 
   onContentEdited(): void {
+    this.syncDirtyStateFromCode(this.code());
+  }
+
+  private syncDirtyStateFromCode(code: string): void {
     const path = this.currentFilePath();
-    if (!path) {
+    if (!path || this.saveStatus() === 'loading' || this.saveStatus() === 'saving') {
       return;
     }
-    this.isDirty.set(true);
-    this.draftService.save(path, this.code());
+
+    if (code === this.baselineContent) {
+      this.saveStatus.set('savedToDevice');
+      this.saveError.set(null);
+      this.draftService.clear(path);
+      return;
+    }
+
+    this.saveStatus.set('unsavedChanges');
+    this.draftService.save(path, code);
+    this.saveStatus.set('draftSavedLocally');
   }
 
   @HostListener('window:keydown', ['$event'])

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.ts
@@ -54,7 +54,11 @@ export class EditorPageComponent implements OnInit {
   }
 
   async ngOnInit(): Promise<void> {
-    const draft = this.draftService.read();
+    const selectedPath = this.shellStore.selectedFilePath();
+    const draft =
+      (selectedPath ? this.draftService.read(selectedPath) : null) ??
+      this.draftService.list()[0] ??
+      null;
     if (draft) {
       this.activeFilePath.set(draft.path);
       this.code.set(draft.content);
@@ -63,7 +67,6 @@ export class EditorPageComponent implements OnInit {
       return;
     }
 
-    const selectedPath = this.shellStore.selectedFilePath();
     if (selectedPath) {
       await this.loadFile(selectedPath);
     }
@@ -127,7 +130,7 @@ export class EditorPageComponent implements OnInit {
     try {
       await this.editorService.saveTextFile(path, this.code());
       this.isDirty.set(false);
-      this.draftService.clear();
+      this.draftService.clear(path);
     } finally {
       this.isSaving.set(false);
     }

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.ts
@@ -242,7 +242,10 @@ export class EditorPageComponent implements OnInit {
       : null;
   }
 
-  private async confirmLeaveUnsaved(message: string): Promise<boolean> {
+  private async confirmLeaveUnsaved(
+    message: string,
+    confirmLabel = 'Discard',
+  ): Promise<boolean> {
     if (this.promptInFlight) {
       return this.promptInFlight;
     }
@@ -252,7 +255,7 @@ export class EditorPageComponent implements OnInit {
         data: {
           title: 'Unsaved changes',
           message,
-          confirmLabel: 'Discard',
+          confirmLabel,
           cancelLabel: 'Cancel',
         },
       });
@@ -316,6 +319,16 @@ export class EditorPageComponent implements OnInit {
     await this.fetchDeviceFile(path);
   }
 
+  async canDeactivate(): Promise<boolean> {
+    if (!this.isDirty()) {
+      return true;
+    }
+    return this.confirmLeaveUnsaved(
+      'You have unsaved changes. Leave the editor? Your local draft will be kept in this browser tab.',
+      'Leave',
+    );
+  }
+
   onEditorInitialized(editorInstance: editor.IStandaloneCodeEditor): void {
     this.editorService.initializeEditor(editorInstance);
   }
@@ -349,6 +362,15 @@ export class EditorPageComponent implements OnInit {
     this.saveStatus.set('unsavedChanges');
     this.draftService.save(path, code);
     this.saveStatus.set('draftSavedLocally');
+  }
+
+  @HostListener('window:beforeunload', ['$event'])
+  onBeforeUnload(event: BeforeUnloadEvent): void {
+    if (!this.isDirty()) {
+      return;
+    }
+    event.preventDefault();
+    event.returnValue = true;
   }
 
   @HostListener('window:keydown', ['$event'])

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.ts
@@ -8,16 +8,19 @@ import {
   signal,
 } from '@angular/core';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { ConfirmDialogComponent, DialogService } from '@libs-dialogs';
 import { ConsoleShellStore } from '@libs-shared';
 import type { editor } from 'monaco-editor';
-import { EditorDraftService, EditorService } from '../../service';
+import { firstValueFrom } from 'rxjs';
+import { EditorDraft, EditorDraftService, EditorService } from '../../service';
+import {
+  EditorDraftResolveChoice,
+  EditorDraftResolveDialogComponent,
+} from '../editor-draft-resolve-dialog/editor-draft-resolve-dialog.component';
 import { EditorToolbarComponent } from '../editor-toolbar/editor-toolbar.component';
 import { FileNameDisplayComponent } from '../file-name-display/file-name-display.component';
 import { MonacoEditorComponent } from '../monaco-editor/monaco-editor.component';
-import {
-  EditorSaveStatus,
-  isEditorDirtyStatus,
-} from './editor-save-status';
+import { EditorSaveStatus, isEditorDirtyStatus } from './editor-save-status';
 
 export interface EditorLoadError {
   path: string;
@@ -47,15 +50,23 @@ export class EditorPageComponent implements OnInit {
   private editorService = inject(EditorService);
   private draftService = inject(EditorDraftService);
   private shellStore = inject(ConsoleShellStore);
+  private dialog = inject(DialogService);
   private readonly activeFilePath = signal<string | null>(null);
   private baselineContent = '';
+  private baselineReady = false;
   private initialized = false;
   private loadGeneration = 0;
+  private ignoreNextSelection = false;
+  private promptInFlight: Promise<boolean> | null = null;
 
   constructor() {
     effect(() => {
       const selectedPath = this.shellStore.selectedFilePath();
       if (!this.initialized || !selectedPath) {
+        return;
+      }
+      if (this.ignoreNextSelection) {
+        this.ignoreNextSelection = false;
         return;
       }
       void this.loadFile(selectedPath);
@@ -66,21 +77,30 @@ export class EditorPageComponent implements OnInit {
     const selectedPath = this.shellStore.selectedFilePath();
     const draft =
       (selectedPath ? this.draftService.read(selectedPath) : null) ??
-      this.draftService.list()[0] ??
+      this.latestDraft() ??
       null;
+
     if (draft) {
-      this.activeFilePath.set(draft.path);
-      this.code.set(draft.content);
-      this.baselineContent = '';
-      this.saveStatus.set('draftSavedLocally');
+      this.shellStore.setSelectedFilePath(draft.path);
+      await this.resolveDraft(draft);
       this.initialized = true;
       return;
     }
 
     if (selectedPath) {
-      await this.loadFile(selectedPath);
+      await this.loadFile(selectedPath, { skipDirtyCheck: true });
     }
     this.initialized = true;
+  }
+
+  private latestDraft(): EditorDraft | null {
+    const drafts = this.draftService.list();
+    if (drafts.length === 0) {
+      return null;
+    }
+    return drafts.reduce((latest, draft) =>
+      draft.updatedAt > latest.updatedAt ? draft : latest,
+    );
   }
 
   private currentFilePath(): string | null {
@@ -95,15 +115,49 @@ export class EditorPageComponent implements OnInit {
     return path.split('/').pop() ?? path;
   }
 
-  private async loadFile(path: string): Promise<void> {
+  private async loadFile(
+    path: string,
+    options?: { skipDirtyCheck?: boolean; forceDevice?: boolean },
+  ): Promise<void> {
     if (
       path === this.activeFilePath() &&
       !this.loadError() &&
-      this.saveStatus() !== 'loading'
+      this.saveStatus() !== 'loading' &&
+      !options?.forceDevice
     ) {
       return;
     }
 
+    if (
+      !options?.skipDirtyCheck &&
+      this.isDirty() &&
+      path !== this.activeFilePath()
+    ) {
+      const confirmed = await this.confirmLeaveUnsaved(
+        'You have unsaved changes. Discard them and open the other file?',
+      );
+      if (!confirmed) {
+        this.revertSelection();
+        return;
+      }
+      const currentPath = this.activeFilePath();
+      if (currentPath) {
+        this.draftService.clear(currentPath);
+      }
+    }
+
+    if (!options?.forceDevice) {
+      const draft = this.draftService.read(path);
+      if (draft && path !== this.activeFilePath()) {
+        await this.resolveDraft(draft);
+        return;
+      }
+    }
+
+    await this.fetchDeviceFile(path);
+  }
+
+  private async fetchDeviceFile(path: string): Promise<void> {
     const generation = ++this.loadGeneration;
     const previousStatus = this.saveStatus();
     this.saveStatus.set('loading');
@@ -135,8 +189,85 @@ export class EditorPageComponent implements OnInit {
     this.activeFilePath.set(path);
     this.code.set(content);
     this.baselineContent = content;
+    this.baselineReady = true;
     this.saveStatus.set('savedToDevice');
     this.saveError.set(null);
+  }
+
+  private async resolveDraft(draft: EditorDraft): Promise<void> {
+    const choice = await this.openDraftResolveDialog(draft.path);
+    switch (choice) {
+      case 'restore':
+        await this.restoreDraft(draft);
+        break;
+      case 'discard':
+      case 'reload':
+        this.draftService.clear(draft.path);
+        await this.fetchDeviceFile(draft.path);
+        break;
+      default:
+        this.draftService.clear(draft.path);
+        await this.fetchDeviceFile(draft.path);
+        break;
+    }
+  }
+
+  private async restoreDraft(draft: EditorDraft): Promise<void> {
+    this.activeFilePath.set(draft.path);
+    this.code.set(draft.content);
+    this.saveStatus.set('draftSavedLocally');
+    this.saveError.set(null);
+    this.loadError.set(null);
+
+    try {
+      this.baselineContent = await this.editorService.loadTextFile(draft.path);
+      this.baselineReady = true;
+    } catch {
+      this.baselineContent = '';
+      this.baselineReady = false;
+    }
+  }
+
+  private async openDraftResolveDialog(
+    path: string,
+  ): Promise<EditorDraftResolveChoice | null> {
+    const ref = this.dialog.open(EditorDraftResolveDialogComponent, {
+      width: '420px',
+      data: { path },
+      disableClose: true,
+    });
+    const result = await firstValueFrom(ref.closed);
+    return result === 'restore' || result === 'discard' || result === 'reload'
+      ? result
+      : null;
+  }
+
+  private async confirmLeaveUnsaved(message: string): Promise<boolean> {
+    if (this.promptInFlight) {
+      return this.promptInFlight;
+    }
+    this.promptInFlight = (async () => {
+      const ref = this.dialog.open(ConfirmDialogComponent, {
+        width: '400px',
+        data: {
+          title: 'Unsaved changes',
+          message,
+          confirmLabel: 'Discard',
+          cancelLabel: 'Cancel',
+        },
+      });
+      return (await firstValueFrom(ref.closed)) === true;
+    })();
+    try {
+      return await this.promptInFlight;
+    } finally {
+      this.promptInFlight = null;
+    }
+  }
+
+  private revertSelection(): void {
+    this.ignoreNextSelection = true;
+    this.shellStore.setSelectedFilePath(this.activeFilePath());
   }
 
   async saveCurrentFile(): Promise<void> {
@@ -150,6 +281,7 @@ export class EditorPageComponent implements OnInit {
     try {
       await this.editorService.saveTextFile(path, this.code());
       this.baselineContent = this.code();
+      this.baselineReady = true;
       this.saveStatus.set('savedToDevice');
       this.draftService.clear(path);
     } catch (error: unknown) {
@@ -158,6 +290,30 @@ export class EditorPageComponent implements OnInit {
       this.saveError.set(message);
       this.saveStatus.set('saveFailed');
     }
+  }
+
+  async discardChanges(): Promise<void> {
+    const path = this.currentFilePath();
+    if (!path || !this.isDirty()) {
+      return;
+    }
+
+    const confirmed = await this.confirmLeaveUnsaved(
+      'Discard local changes and restore the last loaded device content?',
+    );
+    if (!confirmed) {
+      return;
+    }
+
+    this.draftService.clear(path);
+    if (this.baselineReady) {
+      this.code.set(this.baselineContent);
+      this.saveStatus.set('savedToDevice');
+      this.saveError.set(null);
+      return;
+    }
+
+    await this.fetchDeviceFile(path);
   }
 
   onEditorInitialized(editorInstance: editor.IStandaloneCodeEditor): void {
@@ -175,11 +331,15 @@ export class EditorPageComponent implements OnInit {
 
   private syncDirtyStateFromCode(code: string): void {
     const path = this.currentFilePath();
-    if (!path || this.saveStatus() === 'loading' || this.saveStatus() === 'saving') {
+    if (
+      !path ||
+      this.saveStatus() === 'loading' ||
+      this.saveStatus() === 'saving'
+    ) {
       return;
     }
 
-    if (code === this.baselineContent) {
+    if (this.baselineReady && code === this.baselineContent) {
       this.saveStatus.set('savedToDevice');
       this.saveError.set(null);
       this.draftService.clear(path);

--- a/libs/editor/src/lib/component/editor-page/editor-save-status.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-save-status.ts
@@ -1,0 +1,26 @@
+export type EditorSaveStatus =
+  | 'loading'
+  | 'savedToDevice'
+  | 'unsavedChanges'
+  | 'draftSavedLocally'
+  | 'saving'
+  | 'saveFailed';
+
+export const EDITOR_SAVE_STATUS_LABEL: Record<EditorSaveStatus, string> = {
+  loading: 'Loading',
+  savedToDevice: 'Saved to device',
+  unsavedChanges: 'Unsaved changes',
+  draftSavedLocally: 'Draft saved locally',
+  saving: 'Saving',
+  saveFailed: 'Save failed',
+};
+
+export function isEditorDirtyStatus(
+  status: EditorSaveStatus | null | undefined,
+): boolean {
+  return (
+    status === 'unsavedChanges' ||
+    status === 'draftSavedLocally' ||
+    status === 'saveFailed'
+  );
+}

--- a/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.html
+++ b/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.html
@@ -1,5 +1,12 @@
-<div class="editor-toolbar">
+<div class="editor-toolbar flex gap-2 px-3 py-2">
   <button type="button" [disabled]="saveDisabled()" (click)="saveRequested.emit()">
     Save
+  </button>
+  <button
+    type="button"
+    [disabled]="discardDisabled()"
+    (click)="discardRequested.emit()"
+  >
+    Discard
   </button>
 </div>

--- a/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.spec.ts
@@ -22,9 +22,26 @@ describe('EditorToolbarComponent', () => {
 
   it('should emit saveRequested when save button is clicked', () => {
     const emitSpy = vi.spyOn(component.saveRequested, 'emit');
-    const button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+    const buttons = fixture.nativeElement.querySelectorAll(
+      'button',
+    ) as NodeListOf<HTMLButtonElement>;
 
-    button.click();
+    buttons[0].click();
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should emit discardRequested when discard button is clicked', async () => {
+    fixture.componentRef.setInput('discardDisabled', false);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const emitSpy = vi.spyOn(component.discardRequested, 'emit');
+    const buttons = fixture.nativeElement.querySelectorAll(
+      'button',
+    ) as NodeListOf<HTMLButtonElement>;
+
+    buttons[1].click();
 
     expect(emitSpy).toHaveBeenCalledTimes(1);
   });
@@ -34,8 +51,10 @@ describe('EditorToolbarComponent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    const button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+    const buttons = fixture.nativeElement.querySelectorAll(
+      'button',
+    ) as NodeListOf<HTMLButtonElement>;
 
-    expect(button.disabled).toBe(true);
+    expect(buttons[0].disabled).toBe(true);
   });
 });

--- a/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.ts
+++ b/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.ts
@@ -6,5 +6,7 @@ import { Component, input, output } from '@angular/core';
 })
 export class EditorToolbarComponent {
   saveDisabled = input(false);
+  discardDisabled = input(true);
   saveRequested = output<void>();
+  discardRequested = output<void>();
 }

--- a/libs/editor/src/lib/component/file-name-display/file-name-display.component.html
+++ b/libs/editor/src/lib/component/file-name-display/file-name-display.component.html
@@ -1,10 +1,23 @@
-<div class="file-name-display">
+<div class="file-name-display flex flex-wrap items-center gap-x-2 gap-y-1 px-3 py-1 text-sm">
   @if (fileName()) {
-    <span>{{ fileName() }}</span>
-    @if (isDirty()) {
-      <span> *</span>
-    }
+    <span>
+      {{ fileName() }}
+      @if (isDirty()) {
+        <span aria-hidden="true"> *</span>
+      }
+    </span>
   } @else {
     <span>—</span>
+  }
+
+  @if (statusLabel(); as label) {
+    <span
+      class="text-xs text-neutral-600"
+      role="status"
+      aria-live="polite"
+      data-testid="editor-save-status"
+    >
+      {{ label }}
+    </span>
   }
 </div>

--- a/libs/editor/src/lib/component/file-name-display/file-name-display.component.spec.ts
+++ b/libs/editor/src/lib/component/file-name-display/file-name-display.component.spec.ts
@@ -20,13 +20,24 @@ describe('FileNameDisplayComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render file name with dirty marker', async () => {
+  it('should render file name with dirty marker and status label', async () => {
     fixture.componentRef.setInput('fileName', 'main.js');
-    fixture.componentRef.setInput('isDirty', true);
+    fixture.componentRef.setInput('saveStatus', 'unsavedChanges');
     fixture.detectChanges();
     await fixture.whenStable();
 
     expect(fixture.nativeElement.textContent).toContain('main.js');
     expect(fixture.nativeElement.textContent).toContain('*');
+    expect(fixture.nativeElement.textContent).toContain('Unsaved changes');
+  });
+
+  it('should show saved to device without dirty marker', async () => {
+    fixture.componentRef.setInput('fileName', 'main.js');
+    fixture.componentRef.setInput('saveStatus', 'savedToDevice');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.textContent).toContain('Saved to device');
+    expect(fixture.nativeElement.textContent).not.toContain('*');
   });
 });

--- a/libs/editor/src/lib/component/file-name-display/file-name-display.component.ts
+++ b/libs/editor/src/lib/component/file-name-display/file-name-display.component.ts
@@ -1,4 +1,9 @@
-import { Component, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
+import {
+  EDITOR_SAVE_STATUS_LABEL,
+  EditorSaveStatus,
+  isEditorDirtyStatus,
+} from '../editor-page/editor-save-status';
 
 @Component({
   selector: 'choh-file-name-display',
@@ -6,5 +11,12 @@ import { Component, input } from '@angular/core';
 })
 export class FileNameDisplayComponent {
   fileName = input<string | null>(null);
-  isDirty = input(false);
+  saveStatus = input<EditorSaveStatus | null>(null);
+
+  readonly isDirty = computed(() => isEditorDirtyStatus(this.saveStatus()));
+
+  readonly statusLabel = computed(() => {
+    const status = this.saveStatus();
+    return status ? EDITOR_SAVE_STATUS_LABEL[status] : null;
+  });
 }

--- a/libs/editor/src/lib/component/index.ts
+++ b/libs/editor/src/lib/component/index.ts
@@ -1,3 +1,4 @@
+export * from './editor-draft-resolve-dialog/editor-draft-resolve-dialog.component';
 export * from './editor-page/editor-page.component';
 export * from './editor-toolbar/editor-toolbar.component';
 export * from './file-name-display/file-name-display.component';

--- a/libs/editor/src/lib/guards/editor-can-deactivate.guard.ts
+++ b/libs/editor/src/lib/guards/editor-can-deactivate.guard.ts
@@ -1,0 +1,6 @@
+import { CanDeactivateFn } from '@angular/router';
+import { EditorPageComponent } from '../component/editor-page/editor-page.component';
+
+export const editorCanDeactivateGuard: CanDeactivateFn<EditorPageComponent> = (
+  component,
+) => component.canDeactivate();

--- a/libs/editor/src/lib/guards/index.ts
+++ b/libs/editor/src/lib/guards/index.ts
@@ -1,0 +1,1 @@
+export * from './editor-can-deactivate.guard';

--- a/libs/editor/src/lib/service/editor-draft.service.spec.ts
+++ b/libs/editor/src/lib/service/editor-draft.service.spec.ts
@@ -29,36 +29,77 @@ describe('EditorDraftService', () => {
     }).get(EditorDraftService);
   }
 
-  it('stores and restores an unsaved draft', () => {
+  it('stores and restores a draft for a path', () => {
     const service = createService();
 
     service.save('/home/pi/example.js', 'console.log("draft");');
 
-    expect(service.read()).toEqual({
+    expect(service.read('/home/pi/example.js')).toEqual({
       path: '/home/pi/example.js',
       content: 'console.log("draft");',
-      dirty: true,
+      updatedAt: expect.any(Number),
     });
+    expect(service.has('/home/pi/example.js')).toBe(true);
   });
 
-  it('clears a stored draft', () => {
+  it('keeps drafts for different paths separate', () => {
     const service = createService();
-    service.save('/home/pi/example.js', 'draft');
 
-    service.clear();
+    service.save('/home/pi/a/main.js', 'a');
+    service.save('/home/pi/b/main.js', 'b');
 
-    expect(service.read()).toBeNull();
+    expect(service.read('/home/pi/a/main.js')?.content).toBe('a');
+    expect(service.read('/home/pi/b/main.js')?.content).toBe('b');
+    expect(service.list()).toHaveLength(2);
+  });
+
+  it('clears a single path without removing others', () => {
+    const service = createService();
+    service.save('/home/pi/a.js', 'a');
+    service.save('/home/pi/b.js', 'b');
+
+    service.clear('/home/pi/a.js');
+
+    expect(service.read('/home/pi/a.js')).toBeNull();
+    expect(service.read('/home/pi/b.js')?.content).toBe('b');
+  });
+
+  it('clears all drafts', () => {
+    const service = createService();
+    service.save('/home/pi/a.js', 'a');
+    service.save('/home/pi/b.js', 'b');
+
+    service.clearAll();
+
+    expect(service.list()).toEqual([]);
   });
 
   it('ignores and removes malformed storage values', () => {
     const storage = createStorage();
     storage.setItem(
-      'chirimen-lite-console.editor-draft',
-      JSON.stringify({ path: '', content: 1 }),
+      'chirimen-lite-console.editor-drafts',
+      JSON.stringify({ '/bad': { content: 1 } }),
     );
     const service = createService(storage);
 
-    expect(service.read()).toBeNull();
-    expect(storage.length).toBe(0);
+    expect(service.read('/bad')).toBeNull();
+    expect(storage.getItem('chirimen-lite-console.editor-drafts')).toBeNull();
+  });
+
+  it('migrates a legacy single-draft entry', () => {
+    const storage = createStorage();
+    storage.setItem(
+      'chirimen-lite-console.editor-draft',
+      JSON.stringify({
+        path: '/home/pi/legacy.js',
+        content: 'legacy draft',
+        dirty: true,
+      }),
+    );
+    const service = createService(storage);
+
+    expect(service.read('/home/pi/legacy.js')?.content).toBe('legacy draft');
+    expect(storage.getItem('chirimen-lite-console.editor-draft')).toBeNull();
+    expect(storage.getItem('chirimen-lite-console.editor-drafts')).not.toBeNull();
   });
 });

--- a/libs/editor/src/lib/service/editor-draft.service.ts
+++ b/libs/editor/src/lib/service/editor-draft.service.ts
@@ -1,12 +1,20 @@
 import { Injectable, InjectionToken, inject } from '@angular/core';
 
+export interface EditorDraftEntry {
+  content: string;
+  updatedAt: number;
+}
+
+export type EditorDraftMap = Record<string, EditorDraftEntry>;
+
 export interface EditorDraft {
   path: string;
   content: string;
-  dirty: true;
+  updatedAt: number;
 }
 
-const EDITOR_DRAFT_STORAGE_KEY = 'chirimen-lite-console.editor-draft';
+const EDITOR_DRAFT_STORAGE_KEY = 'chirimen-lite-console.editor-drafts';
+const LEGACY_EDITOR_DRAFT_STORAGE_KEY = 'chirimen-lite-console.editor-draft';
 
 export const EDITOR_DRAFT_STORAGE = new InjectionToken<Storage>(
   'EDITOR_DRAFT_STORAGE',
@@ -22,45 +30,142 @@ export const EDITOR_DRAFT_STORAGE = new InjectionToken<Storage>(
 export class EditorDraftService {
   private readonly storage = inject(EDITOR_DRAFT_STORAGE);
 
-  read(): EditorDraft | null {
-    try {
-      const serialized = this.storage.getItem(EDITOR_DRAFT_STORAGE_KEY);
-      if (!serialized) {
-        return null;
-      }
-      const value: unknown = JSON.parse(serialized);
-      if (!this.isEditorDraft(value)) {
-        this.clear();
-        return null;
-      }
-      return value;
-    } catch {
+  read(path: string): EditorDraft | null {
+    const entry = this.readMap()[path];
+    if (!entry) {
       return null;
     }
+    return { path, content: entry.content, updatedAt: entry.updatedAt };
+  }
+
+  has(path: string): boolean {
+    return this.read(path) !== null;
+  }
+
+  list(): EditorDraft[] {
+    return Object.entries(this.readMap()).map(([path, entry]) => ({
+      path,
+      content: entry.content,
+      updatedAt: entry.updatedAt,
+    }));
   }
 
   save(path: string, content: string): void {
-    const draft: EditorDraft = { path, content, dirty: true };
-    try {
-      this.storage.setItem(EDITOR_DRAFT_STORAGE_KEY, JSON.stringify(draft));
-    } catch {
-      // Storage unavailable or full: editing must remain usable in memory.
+    if (!path) {
+      return;
     }
+    const map = this.readMap();
+    map[path] = { content, updatedAt: Date.now() };
+    this.writeMap(map);
   }
 
-  clear(): void {
+  clear(path: string): void {
+    if (!path) {
+      return;
+    }
+    const map = this.readMap();
+    if (!(path in map)) {
+      return;
+    }
+    delete map[path];
+    this.writeMap(map);
+  }
+
+  clearAll(): void {
     try {
       this.storage.removeItem(EDITOR_DRAFT_STORAGE_KEY);
+      this.storage.removeItem(LEGACY_EDITOR_DRAFT_STORAGE_KEY);
     } catch {
       // Storage may be unavailable in restricted browser contexts.
     }
   }
 
-  private isEditorDraft(value: unknown): value is EditorDraft {
+  private readMap(): EditorDraftMap {
+    try {
+      const serialized = this.storage.getItem(EDITOR_DRAFT_STORAGE_KEY);
+      if (serialized) {
+        const value: unknown = JSON.parse(serialized);
+        if (!this.isEditorDraftMap(value)) {
+          this.clearAll();
+          return {};
+        }
+        return { ...value };
+      }
+
+      return this.migrateLegacyDraft();
+    } catch {
+      return {};
+    }
+  }
+
+  private writeMap(map: EditorDraftMap): void {
+    try {
+      if (Object.keys(map).length === 0) {
+        this.storage.removeItem(EDITOR_DRAFT_STORAGE_KEY);
+        this.storage.removeItem(LEGACY_EDITOR_DRAFT_STORAGE_KEY);
+        return;
+      }
+      this.storage.setItem(EDITOR_DRAFT_STORAGE_KEY, JSON.stringify(map));
+      this.storage.removeItem(LEGACY_EDITOR_DRAFT_STORAGE_KEY);
+    } catch {
+      // Storage unavailable or full: editing must remain usable in memory.
+    }
+  }
+
+  private migrateLegacyDraft(): EditorDraftMap {
+    try {
+      const serialized = this.storage.getItem(LEGACY_EDITOR_DRAFT_STORAGE_KEY);
+      if (!serialized) {
+        return {};
+      }
+      const value: unknown = JSON.parse(serialized);
+      if (!this.isLegacyEditorDraft(value)) {
+        this.storage.removeItem(LEGACY_EDITOR_DRAFT_STORAGE_KEY);
+        return {};
+      }
+      const map: EditorDraftMap = {
+        [value.path]: {
+          content: value.content,
+          updatedAt: Date.now(),
+        },
+      };
+      this.writeMap(map);
+      return map;
+    } catch {
+      return {};
+    }
+  }
+
+  private isEditorDraftMap(value: unknown): value is EditorDraftMap {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      return false;
+    }
+    return Object.entries(value).every(([path, entry]) => {
+      if (typeof path !== 'string' || path.length === 0) {
+        return false;
+      }
+      if (typeof entry !== 'object' || entry === null) {
+        return false;
+      }
+      const candidate = entry as Partial<EditorDraftEntry>;
+      return (
+        typeof candidate.content === 'string' &&
+        typeof candidate.updatedAt === 'number'
+      );
+    });
+  }
+
+  private isLegacyEditorDraft(
+    value: unknown,
+  ): value is { path: string; content: string; dirty: true } {
     if (typeof value !== 'object' || value === null) {
       return false;
     }
-    const candidate = value as Partial<EditorDraft>;
+    const candidate = value as Partial<{
+      path: string;
+      content: string;
+      dirty: true;
+    }>;
     return (
       typeof candidate.path === 'string' &&
       candidate.path.length > 0 &&

--- a/libs/editor/vitest.config.ts
+++ b/libs/editor/vitest.config.ts
@@ -28,6 +28,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@libs-editor': resolve(__dirname, './src/index.ts'),
+      '@libs-dialogs': resolve(__dirname, '../dialogs/src/index.ts'),
+      '@libs-shared': resolve(__dirname, '../shared/src/index.ts'),
     },
   },
 });


### PR DESCRIPTION
## Summary

- Editor の未保存・ローカル Draft・実ファイル保存の状態を区別し、パス単位で Draft を管理できるようにしました
- Draft 検出時は自動復元せず Restore / Discard / Reload from device を選択できるようにしました
- 別ファイル選択・別ページ遷移・ブラウザ終了時の未保存確認と、Discard 操作を追加しました

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #806
- Parent: #804

## What changed?

- `EditorDraftService` をパス単位の `sessionStorage` マップに拡張（旧単一 Draft は移行）
- `EditorSaveStatus`（Loading / Saved to device / Unsaved changes / Draft saved locally / Saving / Save failed）と baseline を導入
- Draft 解決ダイアログ、ファイル切替・破棄確認、`canDeactivate` / `beforeunload` を追加
- Toolbar に Discard を追加し、保存失敗時も内容と Draft を維持
- `docs/serial-architecture.md` の Draft 仕様を更新

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details: `EditorDraftService` の API を `read(path)` / `list()` / `clear(path)` / `clearAll()` に変更。旧単一キー形式は読取時に移行します
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. ファイルを開き 1 文字編集すると `Unsaved changes` のあと `Draft saved locally` になり、`Saved to device` にならないことを確認する
2. ページを再読込し、Draft 解決ダイアログから復元できることを確認する
3. 未保存のまま別ファイルを選択すると確認ダイアログが出ること、キャンセルで切替されないことを確認する
4. Discard で baseline に戻り、実ファイル保存成功後は Draft が消えて `Saved to device` になることを確認する
5. 保存失敗時も Editor 内容が残り `Save failed` になることを確認する
6. Editor から他ページへ遷移する際、未保存なら確認が出ることを確認する
7. `pnpm nx test libs-editor` / `pnpm nx test libs-console-shell` が通ることを確認する

## Environment (if relevant)

- Browser: Chrome (Web Serial)
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)