### PR TITLE
feat(editor): safely save files to device via atomic write

### DIFF
--- a/docs/serial-architecture.md
+++ b/docs/serial-architecture.md
@@ -205,6 +205,7 @@ Web Serial の物理接続と Linux シェルのログイン状態は別であ�
 - **`logout` 失敗でシェルが残る場合はリセットしない**（末尾がシェルプロンプトのままなら `logoutCompletedEpoch` は増えない）。
 - **再接続時**は新しい connection epoch と `resetSession()` によりオートログイン（`runAfterConnect$`）を再実行できる。
 - **Editor 未保存内容**はデバイスへ書き戻せず失われるため、`EditorDraftService` が同じタブの `sessionStorage` に **ファイルパス単位**でドラフトを保持する。Editor 再表示時は自動復元せず、Restore / Discard / Reload from device を選択できる。保存状態は `Saved to device` / `Unsaved changes` / `Draft saved locally` / `Saving` / `Save failed` を区別し、Draft 保存だけではデバイス保存済みとはみなさない。未保存のまま別ファイル選択・別ページ遷移・ブラウザ終了する場合は確認する（Draft 自体は同一タブの sessionStorage に残る）。
+- **Editor 実ファイル保存**（[#807](https://github.com/gurezo/chirimen-lite-console/issues/807)）は `FileContentService.writeTextFile` が **一時ファイルへ書込 → サイズ検証 → `mv` で対象へ置換 → 保存後検証** する。置換成功まで元ファイルは触れない。長い内容は heredoc ではなく base64 チャンク転送を使う。失敗時は一時ファイルをベストエフォートで削除し、Editor 側は内容と Draft を維持したまま `Save failed` にする。未接続・権限・容量・タイムアウト・検証不一致は判別しやすいメッセージへ正規化する。
 - **ユーザー通知**: ログアウト検出時に `SerialNotificationService.notifyLogoutDetected()` でトーストを表示する（接続成功／失敗トーストと同系統）。
 - **入力ブロック（ログアウト）**: Terminal で `logout` / `exit` を送ると `logoutPending` が立ち、Console 全体にローダーオーバーレイを表示して操作をブロックする。失敗してシェルへ戻った場合、または 30 秒タイムアウト時はローダーを解除する。
 - **入力ブロック（接続中）**: `isConnecting`、または接続済みかつシェル未準備（`isLoggedIn === false` かつ `setupStatus !== 'failed'`）の間、ログアウトと同様のローダーオーバーレイで UI / ターミナル入力をブロックする（issue #755）。初期化失敗時はオーバーレイを解除し再操作を許可する。

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -155,7 +155,7 @@ describe('EditorPageComponent', () => {
     component.onCodeChange('updated');
     component.onContentEdited();
     editorServiceMock.saveTextFile.mockRejectedValueOnce(
-      new Error('device busy'),
+      new Error('Save failed: write permission was denied for the target file.'),
     );
 
     await component.saveCurrentFile();
@@ -163,7 +163,27 @@ describe('EditorPageComponent', () => {
     expect(component.code()).toBe('updated');
     expect(component.isDirty()).toBe(true);
     expect(component.saveStatus()).toBe('saveFailed');
-    expect(component.saveError()).toBe('device busy');
+    expect(component.saveError()).toBe(
+      'Save failed: write permission was denied for the target file.',
+    );
+    expect(draftServiceMock.clear).not.toHaveBeenCalled();
+  });
+
+  it('should surface disconnect errors without clearing draft', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
+    component.onCodeChange('updated');
+    component.onContentEdited();
+    editorServiceMock.saveTextFile.mockRejectedValueOnce(
+      new Error(
+        'Save failed: serial connection was lost or cancelled. Reconnect and try again.',
+      ),
+    );
+
+    await component.saveCurrentFile();
+
+    expect(component.saveStatus()).toBe('saveFailed');
+    expect(component.saveError()).toContain('connection was lost or cancelled');
+    expect(component.code()).toBe('updated');
     expect(draftServiceMock.clear).not.toHaveBeenCalled();
   });
 

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.ts
@@ -289,8 +289,11 @@ export class EditorPageComponent implements OnInit {
       this.draftService.clear(path);
     } catch (error: unknown) {
       const message =
-        error instanceof Error ? error.message : 'Failed to save file';
+        error instanceof Error
+          ? error.message
+          : 'Save failed: unexpected error while writing to the device';
       this.saveError.set(message);
+      // Keep editor content and local draft so the user can retry after reconnect.
       this.saveStatus.set('saveFailed');
     }
   }

--- a/libs/editor/src/lib/service/editor.service.spec.ts
+++ b/libs/editor/src/lib/service/editor.service.spec.ts
@@ -1,0 +1,54 @@
+import { TestBed } from '@angular/core/testing';
+import { FileContentService, SerialFacadeService } from '@libs-web-serial';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EditorService } from './editor.service';
+
+describe('EditorService.saveTextFile', () => {
+  let service: EditorService;
+  let writeTextFile: ReturnType<typeof vi.fn>;
+  let isConnected: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    writeTextFile = vi.fn().mockResolvedValue(undefined);
+    isConnected = vi.fn().mockReturnValue(true);
+
+    TestBed.configureTestingModule({
+      providers: [
+        EditorService,
+        {
+          provide: FileContentService,
+          useValue: { writeTextFile, readFile: vi.fn() },
+        },
+        {
+          provide: SerialFacadeService,
+          useValue: { isConnected },
+        },
+      ],
+    });
+
+    service = TestBed.inject(EditorService);
+  });
+
+  it('delegates to FileContentService when connected', async () => {
+    await service.saveTextFile('/home/pi/a.js', 'x = 1');
+    expect(writeTextFile).toHaveBeenCalledWith('/home/pi/a.js', 'x = 1');
+  });
+
+  it('fails without writing when disconnected', async () => {
+    isConnected.mockReturnValue(false);
+
+    await expect(
+      service.saveTextFile('/home/pi/a.js', 'x = 1'),
+    ).rejects.toThrow(/connection was lost or cancelled/);
+
+    expect(writeTextFile).not.toHaveBeenCalled();
+  });
+
+  it('classifies underlying write failures', async () => {
+    writeTextFile.mockRejectedValueOnce(new Error('Permission denied'));
+
+    await expect(
+      service.saveTextFile('/home/pi/a.js', 'x = 1'),
+    ).rejects.toThrow(/write permission was denied/);
+  });
+});

--- a/libs/editor/src/lib/service/editor.service.ts
+++ b/libs/editor/src/lib/service/editor.service.ts
@@ -1,6 +1,10 @@
 import { Injectable, inject } from '@angular/core';
 import type { editor } from 'monaco-editor';
-import { FileContentService } from '@libs-web-serial';
+import {
+  classifyFileWriteError,
+  FileContentService,
+  SerialFacadeService,
+} from '@libs-web-serial';
 
 /**
  * エディターサービス
@@ -16,6 +20,7 @@ export class EditorService {
   private editedFlag = false;
   private saveDisabled = false;
   private fileContent = inject(FileContentService);
+  private serial = inject(SerialFacadeService);
 
   /**
    * Monaco Editor を初期化
@@ -45,9 +50,18 @@ export class EditorService {
   }
 
   /**
-   * デバイス上のテキストファイルを保存します。
+   * デバイス上のテキストファイルを安全に保存します。
+   * 未接続時は実ファイルへ書き込まず失敗します。
    */
   async saveTextFile(path: string, content: string): Promise<void> {
-    await this.fileContent.writeTextFile(path, content);
+    if (!this.serial.isConnected()) {
+      throw classifyFileWriteError(new Error('not connected'));
+    }
+
+    try {
+      await this.fileContent.writeTextFile(path, content);
+    } catch (error: unknown) {
+      throw classifyFileWriteError(error);
+    }
   }
 }

--- a/libs/web-serial/src/lib/functions/classify-file-write-error.spec.ts
+++ b/libs/web-serial/src/lib/functions/classify-file-write-error.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { classifyFileWriteError } from './classify-file-write-error';
+
+describe('classifyFileWriteError', () => {
+  it('classifies disconnect / cancel', () => {
+    expect(classifyFileWriteError(new Error('All commands cancelled')).message)
+      .toContain('connection was lost or cancelled');
+    expect(classifyFileWriteError(new Error('not connected')).message)
+      .toContain('connection was lost or cancelled');
+  });
+
+  it('classifies timeout', () => {
+    expect(
+      classifyFileWriteError(new Error('Command execution timeout')).message,
+    ).toContain('timed out');
+  });
+
+  it('classifies permission denied', () => {
+    expect(
+      classifyFileWriteError(new Error('Permission denied')).message,
+    ).toContain('write permission was denied');
+  });
+
+  it('classifies disk full', () => {
+    expect(
+      classifyFileWriteError(new Error('No space left on device')).message,
+    ).toContain('insufficient disk space');
+  });
+
+  it('classifies missing path', () => {
+    expect(
+      classifyFileWriteError(new Error('No such file or directory')).message,
+    ).toContain('target path does not exist');
+  });
+
+  it('classifies verify mismatch', () => {
+    expect(
+      classifyFileWriteError(
+        new Error('size mismatch: expected 3 bytes but got 1'),
+      ).message,
+    ).toContain('did not match');
+  });
+
+  it('preserves already classified Save failed messages', () => {
+    const msg = 'Save failed: write permission was denied for the target file.';
+    expect(classifyFileWriteError(new Error(msg)).message).toBe(msg);
+  });
+});

--- a/libs/web-serial/src/lib/functions/classify-file-write-error.ts
+++ b/libs/web-serial/src/lib/functions/classify-file-write-error.ts
@@ -1,0 +1,66 @@
+/**
+ * ファイル保存失敗の原因を判別しやすいメッセージへ正規化する。
+ */
+export function classifyFileWriteError(error: unknown): Error {
+  const raw = error instanceof Error ? error.message : String(error);
+  const lower = raw.toLowerCase();
+
+  if (
+    lower.includes('not connected') ||
+    lower.includes('all commands cancelled') ||
+    lower.includes('connection lost')
+  ) {
+    return new Error(
+      'Save failed: serial connection was lost or cancelled. Reconnect and try again.',
+    );
+  }
+
+  if (lower.includes('timeout') || lower.includes('timed out')) {
+    return new Error(
+      'Save failed: the write timed out. Check the connection and try again.',
+    );
+  }
+
+  if (
+    lower.includes('permission denied') ||
+    lower.includes('operation not permitted')
+  ) {
+    return new Error(
+      'Save failed: write permission was denied for the target file.',
+    );
+  }
+
+  if (
+    lower.includes('no space left') ||
+    lower.includes('disk quota exceeded')
+  ) {
+    return new Error(
+      'Save failed: the device has insufficient disk space.',
+    );
+  }
+
+  if (
+    lower.includes('no such file or directory') ||
+    lower.includes('not a directory')
+  ) {
+    return new Error(
+      'Save failed: the target path does not exist or is not writable.',
+    );
+  }
+
+  if (
+    lower.includes('size mismatch') ||
+    lower.includes('content mismatch') ||
+    lower.includes('verify')
+  ) {
+    return new Error(
+      'Save failed: written content did not match the editor content.',
+    );
+  }
+
+  if (raw.startsWith('Save failed:')) {
+    return error instanceof Error ? error : new Error(raw);
+  }
+
+  return new Error(`Save failed: ${raw}`);
+}

--- a/libs/web-serial/src/lib/functions/file.utils.spec.ts
+++ b/libs/web-serial/src/lib/functions/file.utils.spec.ts
@@ -56,3 +56,58 @@ describe('FileUtils heredoc helpers', () => {
     });
   });
 });
+
+describe('FileUtils atomic save helpers', () => {
+  describe('buildTempSavePath', () => {
+    it('places a hidden temp file in the same directory', () => {
+      expect(FileUtils.buildTempSavePath('/home/pi/app.js', 'abc')).toBe(
+        '/home/pi/.app.js.chirimen-saving.abc',
+      );
+    });
+
+    it('supports relative paths without a directory', () => {
+      expect(FileUtils.buildTempSavePath('edited.js', 'xyz')).toBe(
+        '.edited.js.chirimen-saving.xyz',
+      );
+    });
+
+    it('keeps spaces and unicode in the basename', () => {
+      expect(
+        FileUtils.buildTempSavePath('/tmp/日本語 file.js', 's1'),
+      ).toBe('/tmp/.日本語 file.js.chirimen-saving.s1');
+    });
+  });
+
+  describe('utf8ByteLength', () => {
+    it('counts ascii as one byte per character', () => {
+      expect(FileUtils.utf8ByteLength('abc')).toBe(3);
+    });
+
+    it('counts multibyte characters correctly', () => {
+      expect(FileUtils.utf8ByteLength('日本語')).toBe(9);
+    });
+  });
+
+  describe('generateByteSizeCommand', () => {
+    it('escapes the path for wc -c', () => {
+      const command = FileUtils.generateByteSizeCommand('/tmp/a b.js');
+      expect(command).toBe(
+        `wc -c -- ${FileUtils.escapePath('/tmp/a b.js')}`,
+      );
+    });
+  });
+
+  describe('parseByteSizeOutput', () => {
+    it('parses wc -c output with a path', () => {
+      expect(FileUtils.parseByteSizeOutput('12 /tmp/file.js\n')).toBe(12);
+    });
+
+    it('parses a bare number', () => {
+      expect(FileUtils.parseByteSizeOutput('0\n')).toBe(0);
+    });
+
+    it('returns null when no size is found', () => {
+      expect(FileUtils.parseByteSizeOutput('error: missing\n')).toBeNull();
+    });
+  });
+});

--- a/libs/web-serial/src/lib/functions/file.utils.ts
+++ b/libs/web-serial/src/lib/functions/file.utils.ts
@@ -147,4 +147,53 @@ export class FileUtils {
     const jsonString = JSON.stringify(String(path));
     return jsonString.replace(/^"/, `$$'`).replace(/"$/, `'`);
   }
+
+  /**
+   * 同一ディレクトリ上の一時保存パスを生成する（`mv` で atomic 置換するため）。
+   */
+  static buildTempSavePath(
+    targetPath: string,
+    suffix: string = FileUtils.createTempSaveSuffix(),
+  ): string {
+    const dir = FileUtils.getDirectoryPath(targetPath);
+    const base = FileUtils.getFileName(targetPath);
+    const tempName = `.${base}.chirimen-saving.${suffix}`;
+    return dir === '.' ? tempName : `${dir}/${tempName}`;
+  }
+
+  static createTempSaveSuffix(): string {
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  /** UTF-8 バイト長（シリアル転送・サイズ検証用） */
+  static utf8ByteLength(content: string): number {
+    return new TextEncoder().encode(content).byteLength;
+  }
+
+  /**
+   * heredoc ではなくチャンク転送へ切り替えるサイズしきい値（UTF-8 バイト）。
+   */
+  static readonly TEXT_CHUNK_THRESHOLD_BYTES = 16 * 1024;
+
+  static generateByteSizeCommand(path: string): string {
+    return `wc -c -- ${FileUtils.escapePath(path)}`;
+  }
+
+  /**
+   * `wc -c -- path` の stdout からバイト数を取り出す。
+   * 例: `12 /path/to/file` / `12`
+   */
+  static parseByteSizeOutput(stdout: string): number | null {
+    const cleaned = String(stdout)
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean);
+    for (const line of cleaned) {
+      const match = /^(\d+)\b/.exec(line);
+      if (match) {
+        return Number(match[1]);
+      }
+    }
+    return null;
+  }
 }

--- a/libs/web-serial/src/lib/functions/index.ts
+++ b/libs/web-serial/src/lib/functions/index.ts
@@ -1,3 +1,4 @@
+export * from './classify-file-write-error';
 export * from './file.utils';
 export * from './pi-zero-shell-exec-options';
 export * from './sanitize-serial-stdout';

--- a/libs/web-serial/src/lib/service/file-content.service.spec.ts
+++ b/libs/web-serial/src/lib/service/file-content.service.spec.ts
@@ -1,0 +1,160 @@
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { FileUtils } from '../functions/file.utils';
+import { FileContentService } from './file-content.service';
+import { PiZeroPromptDetectorService } from './pi-zero-prompt-detector.service';
+import { SerialFacadeService } from './serial-facade.service';
+
+describe('FileContentService.writeTextFile', () => {
+  let service: FileContentService;
+  let exec$: ReturnType<typeof vi.fn>;
+  let send$: ReturnType<typeof vi.fn>;
+  let isConnected: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    exec$ = vi.fn();
+    send$ = vi.fn().mockReturnValue(of(undefined));
+    isConnected = vi.fn().mockReturnValue(true);
+
+    TestBed.configureTestingModule({
+      providers: [
+        FileContentService,
+        {
+          provide: SerialFacadeService,
+          useValue: { exec$, send$, isConnected },
+        },
+        {
+          provide: PiZeroPromptDetectorService,
+          useValue: {
+            isCommandCompleted: () => true,
+          },
+        },
+      ],
+    });
+
+    service = TestBed.inject(FileContentService);
+    vi.spyOn(FileUtils, 'buildTempSavePath').mockReturnValue(
+      '/home/pi/.main.js.chirimen-saving.test',
+    );
+  });
+
+  function setupSuccessfulSmallWrite(content: string): void {
+    const expected = FileUtils.utf8ByteLength(content);
+    const b64 = FileUtils.arrayBufferToBase64(
+      new TextEncoder().encode(content).buffer,
+    );
+
+    exec$.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.startsWith('cat >')) {
+        return of({ stdout: '' });
+      }
+      if (typeof cmd === 'string' && cmd.startsWith('wc -c')) {
+        return of({ stdout: `${expected} /home/pi/.main.js.chirimen-saving.test\n` });
+      }
+      if (typeof cmd === 'string' && cmd.startsWith('mv --')) {
+        return of({ stdout: '' });
+      }
+      if (typeof cmd === 'string' && cmd.startsWith('base64 --')) {
+        return of({
+          stdout: `base64 -- /home/pi/main.js\n${b64}\npi@raspberrypi:~$ `,
+        });
+      }
+      if (typeof cmd === 'string' && cmd.startsWith('rm -f')) {
+        return of({ stdout: '' });
+      }
+      return of({ stdout: '' });
+    });
+  }
+
+  it('writes via temp file, verifies size, then replaces the target', async () => {
+    const content = "console.log('ok');\n";
+    setupSuccessfulSmallWrite(content);
+
+    await service.writeTextFile('/home/pi/main.js', content);
+
+    const commands = exec$.mock.calls.map((args: unknown[]) => args[0] as string);
+    expect(commands[0]).toContain('cat >');
+    expect(commands[0]).toContain('.main.js.chirimen-saving.test');
+    expect(commands[1]).toContain('wc -c --');
+    expect(commands[2]).toMatch(/^mv -- /);
+    expect(commands[2]).toContain('.main.js.chirimen-saving.test');
+    expect(commands[2]).toContain('main.js');
+    expect(commands.some((c) => c.startsWith('rm -f'))).toBe(false);
+  });
+
+  it('cleans up the temp file and skips mv when size verification fails', async () => {
+    exec$.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.startsWith('cat >')) {
+        return of({ stdout: '' });
+      }
+      if (typeof cmd === 'string' && cmd.startsWith('wc -c')) {
+        return of({ stdout: '1 /tmp/x\n' });
+      }
+      if (typeof cmd === 'string' && cmd.startsWith('rm -f')) {
+        return of({ stdout: '' });
+      }
+      return of({ stdout: '' });
+    });
+
+    await expect(
+      service.writeTextFile('/home/pi/main.js', 'abc'),
+    ).rejects.toThrow(/did not match|Save failed/);
+
+    const commands = exec$.mock.calls.map((args: unknown[]) => args[0] as string);
+    expect(commands.some((c) => c.startsWith('mv --'))).toBe(false);
+    expect(commands.some((c) => c.startsWith('rm -f'))).toBe(true);
+  });
+
+  it('fails fast when serial is disconnected', async () => {
+    isConnected.mockReturnValue(false);
+
+    await expect(
+      service.writeTextFile('/home/pi/main.js', 'x'),
+    ).rejects.toThrow(/connection was lost or cancelled/);
+
+    expect(exec$).not.toHaveBeenCalled();
+  });
+
+  it('classifies permission errors from the shell', async () => {
+    exec$.mockReturnValue(
+      throwError(() => new Error('Permission denied')),
+    );
+
+    await expect(
+      service.writeTextFile('/home/pi/main.js', 'x'),
+    ).rejects.toThrow(/write permission was denied/);
+
+    const commands = exec$.mock.calls.map((args: unknown[]) => args[0] as string);
+    expect(commands.some((c) => c.startsWith('rm -f'))).toBe(true);
+  });
+
+  it('uses chunked binary write for large payloads', async () => {
+    const content = 'a'.repeat(FileUtils.TEXT_CHUNK_THRESHOLD_BYTES + 1);
+    const expected = FileUtils.utf8ByteLength(content);
+
+    exec$.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('base64 -d >')) {
+        return of({ stdout: '' });
+      }
+      if (typeof cmd === 'string' && cmd.startsWith('wc -c')) {
+        return of({
+          stdout: `${expected} /home/pi/.main.js.chirimen-saving.test\n`,
+        });
+      }
+      if (typeof cmd === 'string' && cmd.startsWith('mv --')) {
+        return of({ stdout: '' });
+      }
+      // binary chunk lines and trailing prompt wait
+      return of({ stdout: '' });
+    });
+
+    await service.writeTextFile('/home/pi/main.js', content);
+
+    const commands = exec$.mock.calls.map((args: unknown[]) => args[0] as string);
+    expect(commands.some((c) => c.includes('base64 -d >'))).toBe(true);
+    expect(commands.some((c) => c.startsWith('cat >'))).toBe(false);
+    expect(commands.some((c) => c.startsWith('mv --'))).toBe(true);
+    expect(send$).toHaveBeenCalled();
+  });
+});

--- a/libs/web-serial/src/lib/service/file-content.service.ts
+++ b/libs/web-serial/src/lib/service/file-content.service.ts
@@ -1,10 +1,13 @@
 import { Injectable, inject } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import { PI_ZERO_PROMPT } from '../constants/pi-zero.const';
+import { classifyFileWriteError } from '../functions/classify-file-write-error';
+import { createPiZeroShellExecOptions } from '../functions/pi-zero-shell-exec-options';
 import { FileUtils } from '../functions/file.utils';
 import { SERIAL_TIMEOUT } from '../functions/serial-timeout';
 import { wrapSerialError } from '../functions/serial-error-wrap';
 import type { FileContentInfo } from '../models/file-content.types';
+import { PiZeroPromptDetectorService } from './pi-zero-prompt-detector.service';
 import { SerialFacadeService } from './serial-facade.service';
 
 /**
@@ -17,14 +20,21 @@ import { SerialFacadeService } from './serial-facade.service';
 })
 export class FileContentService {
   private serial = inject(SerialFacadeService);
+  private promptDetector = inject(PiZeroPromptDetectorService);
+
+  private shellExecOptions(timeout: number = SERIAL_TIMEOUT.DEFAULT) {
+    return createPiZeroShellExecOptions(this.promptDetector, { timeout });
+  }
 
   async readFile(path: string): Promise<FileContentInfo> {
     try {
       const result = (
-        await firstValueFrom(this.serial.exec$(`base64 -- ${FileUtils.escapePath(path)}`, {
-          prompt: PI_ZERO_PROMPT,
-          timeout: SERIAL_TIMEOUT.LONG,
-        }))
+        await firstValueFrom(
+          this.serial.exec$(`base64 -- ${FileUtils.escapePath(path)}`, {
+            prompt: PI_ZERO_PROMPT,
+            timeout: SERIAL_TIMEOUT.LONG,
+          }),
+        )
       ).stdout;
 
       const lines = result.split('\n').map((line) => line.trim());
@@ -57,15 +67,42 @@ export class FileContentService {
     }
   }
 
+  /**
+   * テキストファイルを一時ファイル経由で安全に保存する。
+   *
+   * 1. 一時ファイルへ書込
+   * 2. サイズ検証
+   * 3. `mv` で対象へ置換（置換成功まで元ファイルは非接触）
+   * 4. 保存後検証
+   * 失敗時は一時ファイルをベストエフォートで削除する。
+   */
   async writeTextFile(path: string, content: string): Promise<void> {
+    if (!this.serial.isConnected()) {
+      throw classifyFileWriteError(new Error('not connected'));
+    }
+
+    const expectedBytes = FileUtils.utf8ByteLength(content);
+    const tempPath = FileUtils.buildTempSavePath(path);
+    let replaced = false;
+
     try {
-      const command = FileUtils.generateHeredocCommand(path, content);
-      await firstValueFrom(this.serial.exec$(command, {
-        prompt: PI_ZERO_PROMPT,
-        timeout: SERIAL_TIMEOUT.DEFAULT,
-      }));
+      await this.writeTextPayload(tempPath, content, expectedBytes);
+      await this.assertRemoteByteSize(tempPath, expectedBytes);
+
+      await firstValueFrom(
+        this.serial.exec$(
+          `mv -- ${FileUtils.escapePath(tempPath)} ${FileUtils.escapePath(path)}`,
+          this.shellExecOptions(SERIAL_TIMEOUT.FILE_TRANSFER),
+        ),
+      );
+      replaced = true;
+
+      await this.verifySavedTextFile(path, content, expectedBytes);
     } catch (error: unknown) {
-      throw wrapSerialError('Failed to write text file', error);
+      if (!replaced) {
+        await this.cleanupTempFile(tempPath);
+      }
+      throw classifyFileWriteError(error);
     }
   }
 
@@ -76,27 +113,33 @@ export class FileContentService {
       await firstValueFrom(this.serial.send$('\x03'));
       await this.sleep(100);
 
-      await firstValueFrom(this.serial.exec$(`base64 -d > ${FileUtils.escapePath(path)}`, {
-        prompt: '\n',
-        timeout: SERIAL_TIMEOUT.DEFAULT,
-      }));
+      await firstValueFrom(
+        this.serial.exec$(`base64 -d > ${FileUtils.escapePath(path)}`, {
+          prompt: '\n',
+          timeout: SERIAL_TIMEOUT.DEFAULT,
+        }),
+      );
 
       const lineLength = 512;
       for (let i = 0; i <= Math.floor(base64.length / lineLength); i++) {
         const line = base64.substring(i * lineLength, (i + 1) * lineLength);
-        await firstValueFrom(this.serial.exec$(line, {
-          prompt: '\n',
-          timeout: SERIAL_TIMEOUT.LINE,
-        }));
+        await firstValueFrom(
+          this.serial.exec$(line, {
+            prompt: '\n',
+            timeout: SERIAL_TIMEOUT.LINE,
+          }),
+        );
         await this.sleep(1);
       }
 
       await firstValueFrom(this.serial.send$('\x04'));
       await this.sleep(10);
-      await firstValueFrom(this.serial.exec$('', {
-        prompt: '\\$',
-        timeout: SERIAL_TIMEOUT.LINE,
-      }));
+      await firstValueFrom(
+        this.serial.exec$('', {
+          prompt: '\\$',
+          timeout: SERIAL_TIMEOUT.LINE,
+        }),
+      );
     } catch (error: unknown) {
       throw wrapSerialError('Failed to write binary file', error);
     }
@@ -105,12 +148,92 @@ export class FileContentService {
   async appendToFile(path: string, content: string): Promise<void> {
     try {
       const command = FileUtils.generateAppendCommand(path, content);
-      await firstValueFrom(this.serial.exec$(command, {
-        prompt: PI_ZERO_PROMPT,
-        timeout: SERIAL_TIMEOUT.DEFAULT,
-      }));
+      await firstValueFrom(
+        this.serial.exec$(command, {
+          prompt: PI_ZERO_PROMPT,
+          timeout: SERIAL_TIMEOUT.DEFAULT,
+        }),
+      );
     } catch (error: unknown) {
       throw wrapSerialError('Failed to append to file', error);
+    }
+  }
+
+  private async writeTextPayload(
+    path: string,
+    content: string,
+    expectedBytes: number,
+  ): Promise<void> {
+    if (expectedBytes > FileUtils.TEXT_CHUNK_THRESHOLD_BYTES) {
+      const buffer = new TextEncoder().encode(content).buffer;
+      await this.writeBinaryFile(path, buffer);
+      return;
+    }
+
+    const command = FileUtils.generateHeredocCommand(path, content);
+    await firstValueFrom(
+      this.serial.exec$(
+        command,
+        this.shellExecOptions(SERIAL_TIMEOUT.FILE_TRANSFER),
+      ),
+    );
+  }
+
+  private async assertRemoteByteSize(
+    path: string,
+    expectedBytes: number,
+  ): Promise<void> {
+    const stdout = (
+      await firstValueFrom(
+        this.serial.exec$(
+          FileUtils.generateByteSizeCommand(path),
+          this.shellExecOptions(SERIAL_TIMEOUT.FILE_TRANSFER),
+        ),
+      )
+    ).stdout;
+
+    const actual = FileUtils.parseByteSizeOutput(stdout);
+    if (actual === null) {
+      throw new Error(
+        `size mismatch: could not parse byte size for ${path}`,
+      );
+    }
+    if (actual !== expectedBytes) {
+      throw new Error(
+        `size mismatch: expected ${expectedBytes} bytes but got ${actual}`,
+      );
+    }
+  }
+
+  private async verifySavedTextFile(
+    path: string,
+    content: string,
+    expectedBytes: number,
+  ): Promise<void> {
+    if (expectedBytes > FileUtils.TEXT_CHUNK_THRESHOLD_BYTES) {
+      await this.assertRemoteByteSize(path, expectedBytes);
+      return;
+    }
+
+    const info = await this.readFile(path);
+    if (!info.isText || typeof info.content !== 'string') {
+      throw new Error('content mismatch: saved file is not text');
+    }
+    if (info.content !== content) {
+      throw new Error('content mismatch: saved file differs from editor content');
+    }
+  }
+
+  private async cleanupTempFile(tempPath: string): Promise<void> {
+    try {
+      await firstValueFrom(
+        this.serial.exec$(
+          `rm -f -- ${FileUtils.escapePath(tempPath)}`,
+          this.shellExecOptions(SERIAL_TIMEOUT.DEFAULT),
+        ),
+      );
+    } catch {
+      // best-effort cleanup
     }
   }
 


### PR DESCRIPTION
## Summary

- Monaco Editor の保存を、一時ファイル書込 → サイズ検証 → `mv` 置換 → 保存後検証の安全フローに強化しました
- 長い内容は heredoc ではなく base64 チャンク転送を使い、失敗時は一時ファイルをクリーンアップして元ファイルを可能な限り保護します
- 未接続・権限・容量・タイムアウト・検証不一致を判別しやすいメッセージにし、失敗時も Editor 内容と Draft を維持します

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #807
- Parent: #804

## What changed?

- `FileUtils` に一時保存パス / UTF-8 バイト長 / `wc -c` パースヘルパーを追加
- `FileContentService.writeTextFile` を atomic 保存（temp → verify → `mv` → post-verify）に置換
- 保存失敗の分類ヘルパー `classifyFileWriteError` を追加
- `EditorService` で未接続時の事前失敗とエラー正規化を追加
- unit test と `docs/serial-architecture.md` を更新

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details: `FileContentService.writeTextFile` の内部挙動が atomic 化（呼び出しシグネチャは互換）。`classifyFileWriteError` と `FileUtils` ヘルパーを公開 export
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. CHIRIMEN Lite に接続し、テキストファイルを開いて編集後に Save する
2. 保存成功後に再読込し、Editor 内容と一致することを確認する
3. 日本語・引用符・複数行を含むファイルを保存できることを確認する
4. 保存中に切断すると `Save failed` になり、内容と Draft が残ることを確認する
5. Save 連打しても並行保存されないことを確認する
6. `pnpm nx test libs-web-serial -- file-content.service.spec.ts classify-file-write-error.spec.ts file.utils.spec.ts`
7. `pnpm nx test libs-editor -- editor-page.component.spec.ts editor.service.spec.ts`

## Environment (if relevant)

- Browser: Chrome (Web Serial)
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)