### PR TITLE
feat(editor): add save and format actions to editor toolbar

### DIFF
--- a/libs/editor/src/lib/component/editor-page/editor-page.component.html
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.html
@@ -5,8 +5,11 @@
     class="shrink-0"
     [saveDisabled]="!isDirty() || isSaving() || !currentFileName()"
     [discardDisabled]="!isDirty() || isSaving() || !currentFileName()"
+    [formatDisabled]="!currentFileName() || isLoading() || isSaving()"
+    [isSaving]="isSaving()"
     (saveRequested)="saveCurrentFile()"
     (discardRequested)="discardChanges()"
+    (formatRequested)="formatCurrentFile()"
   />
   <choh-file-name-display
     class="shrink-0"

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.html
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.html
@@ -3,7 +3,9 @@
 >
   <choh-editor-toolbar
     class="shrink-0"
-    [saveDisabled]="!isDirty() || isSaving() || !currentFileName()"
+    [saveDisabled]="
+      !isDirty() || isSaving() || !currentFileName() || !isSerialConnected()
+    "
     [discardDisabled]="!isDirty() || isSaving() || !currentFileName()"
     [formatDisabled]="!currentFileName() || isLoading() || isSaving()"
     [isSaving]="isSaving()"

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -3,6 +3,7 @@ import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DialogService } from '@libs-dialogs';
 import { ConsoleShellStore } from '@libs-shared';
+import { SerialFacadeService } from '@libs-web-serial';
 import { provideMonacoEditor } from 'ngx-monaco-editor-v2';
 import { Subject } from 'rxjs';
 import { EditorDraftService, EditorService } from '../../service';
@@ -12,6 +13,7 @@ describe('EditorPageComponent', () => {
   let component: EditorPageComponent;
   let fixture: ComponentFixture<EditorPageComponent>;
   const selectedFilePathSignal = signal<string | null>(null);
+  const isConnectedSignal = signal(true);
   const editorServiceMock = {
     loadTextFile: vi.fn().mockResolvedValue('loaded content'),
     saveTextFile: vi.fn().mockResolvedValue(undefined),
@@ -34,6 +36,9 @@ describe('EditorPageComponent', () => {
   const dialogServiceMock = {
     open: vi.fn(),
   };
+  const serialFacadeMock = {
+    isConnected: () => isConnectedSignal(),
+  };
 
   async function loadPath(path: string, content = 'loaded content'): Promise<void> {
     editorServiceMock.loadTextFile.mockResolvedValue(content);
@@ -53,6 +58,7 @@ describe('EditorPageComponent', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     selectedFilePathSignal.set(null);
+    isConnectedSignal.set(true);
     draftServiceMock.read.mockReturnValue(null);
     draftServiceMock.list.mockReturnValue([]);
     editorServiceMock.loadTextFile.mockResolvedValue('loaded content');
@@ -65,6 +71,7 @@ describe('EditorPageComponent', () => {
       .overrideProvider(EditorDraftService, { useValue: draftServiceMock })
       .overrideProvider(ConsoleShellStore, { useValue: shellStoreMock })
       .overrideProvider(DialogService, { useValue: dialogServiceMock })
+      .overrideProvider(SerialFacadeService, { useValue: serialFacadeMock })
       .compileComponents();
 
     fixture = TestBed.createComponent(EditorPageComponent);
@@ -193,6 +200,33 @@ describe('EditorPageComponent', () => {
     await component.saveCurrentFile();
 
     expect(editorServiceMock.saveTextFile).not.toHaveBeenCalled();
+  });
+
+  it('should skip save when serial is disconnected', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
+    component.onCodeChange('updated');
+    component.onContentEdited();
+    isConnectedSignal.set(false);
+
+    await component.saveCurrentFile();
+
+    expect(editorServiceMock.saveTextFile).not.toHaveBeenCalled();
+    expect(component.isDirty()).toBe(true);
+  });
+
+  it('should disable save in the toolbar when serial is disconnected', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
+    component.onCodeChange('updated');
+    component.onContentEdited();
+    isConnectedSignal.set(false);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const saveButton = fixture.nativeElement.querySelector(
+      'choh-editor-toolbar button',
+    ) as HTMLButtonElement;
+
+    expect(saveButton.disabled).toBe(true);
   });
 
   it('should mark unsaved then draft-saved without claiming device save', async () => {

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -18,6 +18,8 @@ describe('EditorPageComponent', () => {
     loadTextFile: vi.fn().mockResolvedValue('loaded content'),
     saveTextFile: vi.fn().mockResolvedValue(undefined),
     initializeEditor: vi.fn(),
+    formatDocument: vi.fn().mockResolvedValue(true),
+    getValue: vi.fn().mockReturnValue(null),
   };
   const shellStoreMock = {
     selectedFilePath: () => selectedFilePathSignal(),

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -2,7 +2,7 @@
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DialogService } from '@libs-dialogs';
-import { ConsoleShellStore } from '@libs-shared';
+import { ConsoleShellStore, NotificationService } from '@libs-shared';
 import { SerialFacadeService } from '@libs-web-serial';
 import { provideMonacoEditor } from 'ngx-monaco-editor-v2';
 import { Subject } from 'rxjs';
@@ -39,6 +39,12 @@ describe('EditorPageComponent', () => {
   const serialFacadeMock = {
     isConnected: () => isConnectedSignal(),
   };
+  const notifyMock = {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  };
 
   async function loadPath(path: string, content = 'loaded content'): Promise<void> {
     editorServiceMock.loadTextFile.mockResolvedValue(content);
@@ -72,6 +78,7 @@ describe('EditorPageComponent', () => {
       .overrideProvider(ConsoleShellStore, { useValue: shellStoreMock })
       .overrideProvider(DialogService, { useValue: dialogServiceMock })
       .overrideProvider(SerialFacadeService, { useValue: serialFacadeMock })
+      .overrideProvider(NotificationService, { useValue: notifyMock })
       .compileComponents();
 
     fixture = TestBed.createComponent(EditorPageComponent);
@@ -155,6 +162,7 @@ describe('EditorPageComponent', () => {
     expect(component.isDirty()).toBe(false);
     expect(component.saveStatus()).toBe('savedToDevice');
     expect(draftServiceMock.clear).toHaveBeenCalledWith('/home/pi/main.js');
+    expect(notifyMock.success).toHaveBeenCalledWith('Save', 'Saved to device');
   });
 
   it('should keep edits and draft when save fails', async () => {
@@ -174,6 +182,10 @@ describe('EditorPageComponent', () => {
       'Save failed: write permission was denied for the target file.',
     );
     expect(draftServiceMock.clear).not.toHaveBeenCalled();
+    expect(notifyMock.error).toHaveBeenCalledWith(
+      'Save',
+      'Save failed: write permission was denied for the target file.',
+    );
   });
 
   it('should surface disconnect errors without clearing draft', async () => {

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -55,7 +55,7 @@ describe('EditorPageComponent', () => {
     await fixture.whenStable();
   }
 
-  function mockDialogResult(result: unknown): Subject<unknown> {
+  function mockDialogResult(_result: unknown): Subject<unknown> {
     const closed = new Subject<unknown>();
     dialogServiceMock.open.mockReturnValueOnce({
       closed: closed.asObservable(),
@@ -360,5 +360,39 @@ describe('EditorPageComponent', () => {
     closed.complete();
 
     await expect(deactivatePromise).resolves.toBe(false);
+  });
+
+  it('should format the current file and mark it dirty', async () => {
+    await loadPath('/home/pi/main.js', 'const x=1');
+    editorServiceMock.formatDocument.mockResolvedValueOnce(true);
+    editorServiceMock.getValue.mockReturnValueOnce('const x = 1;\n');
+
+    await component.formatCurrentFile();
+
+    expect(editorServiceMock.formatDocument).toHaveBeenCalledTimes(1);
+    expect(component.code()).toBe('const x = 1;\n');
+    expect(component.isDirty()).toBe(true);
+    expect(component.saveStatus()).toBe('draftSavedLocally');
+    expect(notifyMock.warning).not.toHaveBeenCalled();
+  });
+
+  it('should warn when no formatter is available', async () => {
+    await loadPath('/home/pi/main.js', 'const x=1');
+    editorServiceMock.formatDocument.mockResolvedValueOnce(false);
+
+    await component.formatCurrentFile();
+
+    expect(notifyMock.warning).toHaveBeenCalledWith(
+      'Format',
+      'No formatter is available for this language.',
+    );
+    expect(component.code()).toBe('const x=1');
+    expect(component.isDirty()).toBe(false);
+  });
+
+  it('should skip format when no file is selected', async () => {
+    await component.formatCurrentFile();
+
+    expect(editorServiceMock.formatDocument).not.toHaveBeenCalled();
   });
 });

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.ts
@@ -298,6 +298,11 @@ export class EditorPageComponent implements OnInit {
     }
   }
 
+  /** Wired to Format toolbar action; implementation lands with formatDocument. */
+  async formatCurrentFile(): Promise<void> {
+    return;
+  }
+
   async discardChanges(): Promise<void> {
     const path = this.currentFilePath();
     if (!path || !this.isDirty()) {

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.ts
@@ -310,9 +310,24 @@ export class EditorPageComponent implements OnInit {
     }
   }
 
-  /** Wired to Format toolbar action; implementation lands with formatDocument. */
   async formatCurrentFile(): Promise<void> {
-    return;
+    if (!this.currentFilePath() || this.isLoading() || this.isSaving()) {
+      return;
+    }
+
+    const formatted = await this.editorService.formatDocument();
+    if (!formatted) {
+      this.notify.warning(
+        'Format',
+        'No formatter is available for this language.',
+      );
+      return;
+    }
+
+    const value = this.editorService.getValue();
+    if (value !== null) {
+      this.onCodeChange(value);
+    }
   }
 
   async discardChanges(): Promise<void> {
@@ -397,9 +412,23 @@ export class EditorPageComponent implements OnInit {
   async onKeydown(event: KeyboardEvent): Promise<void> {
     const isSaveShortcut =
       (event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's';
-    if (!isSaveShortcut) return;
+    if (isSaveShortcut) {
+      event.preventDefault();
+      await this.saveCurrentFile();
+      return;
+    }
+
+    const isFormatShortcut =
+      event.shiftKey &&
+      event.altKey &&
+      !event.ctrlKey &&
+      !event.metaKey &&
+      event.key.toLowerCase() === 'f';
+    if (!isFormatShortcut) {
+      return;
+    }
 
     event.preventDefault();
-    await this.saveCurrentFile();
+    await this.formatCurrentFile();
   }
 }

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.ts
@@ -9,7 +9,7 @@ import {
 } from '@angular/core';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { ConfirmDialogComponent, DialogService } from '@libs-dialogs';
-import { ConsoleShellStore } from '@libs-shared';
+import { ConsoleShellStore, NotificationService } from '@libs-shared';
 import { SerialFacadeService } from '@libs-web-serial';
 import type { editor } from 'monaco-editor';
 import { firstValueFrom } from 'rxjs';
@@ -53,6 +53,7 @@ export class EditorPageComponent implements OnInit {
   private shellStore = inject(ConsoleShellStore);
   private dialog = inject(DialogService);
   private readonly serial = inject(SerialFacadeService);
+  private readonly notify = inject(NotificationService);
 
   readonly isSerialConnected = this.serial.isConnected;
   private readonly activeFilePath = signal<string | null>(null);
@@ -296,6 +297,7 @@ export class EditorPageComponent implements OnInit {
       this.baselineReady = true;
       this.saveStatus.set('savedToDevice');
       this.draftService.clear(path);
+      this.notify.success('Save', 'Saved to device');
     } catch (error: unknown) {
       const message =
         error instanceof Error
@@ -304,6 +306,7 @@ export class EditorPageComponent implements OnInit {
       this.saveError.set(message);
       // Keep editor content and local draft so the user can retry after reconnect.
       this.saveStatus.set('saveFailed');
+      this.notify.error('Save', message);
     }
   }
 

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.ts
@@ -10,6 +10,7 @@ import {
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { ConfirmDialogComponent, DialogService } from '@libs-dialogs';
 import { ConsoleShellStore } from '@libs-shared';
+import { SerialFacadeService } from '@libs-web-serial';
 import type { editor } from 'monaco-editor';
 import { firstValueFrom } from 'rxjs';
 import { EditorDraft, EditorDraftService, EditorService } from '../../service';
@@ -51,6 +52,9 @@ export class EditorPageComponent implements OnInit {
   private draftService = inject(EditorDraftService);
   private shellStore = inject(ConsoleShellStore);
   private dialog = inject(DialogService);
+  private readonly serial = inject(SerialFacadeService);
+
+  readonly isSerialConnected = this.serial.isConnected;
   private readonly activeFilePath = signal<string | null>(null);
   private baselineContent = '';
   private baselineReady = false;
@@ -275,7 +279,12 @@ export class EditorPageComponent implements OnInit {
 
   async saveCurrentFile(): Promise<void> {
     const path = this.currentFilePath();
-    if (!path || !this.isDirty() || this.isSaving()) {
+    if (
+      !path ||
+      !this.isDirty() ||
+      this.isSaving() ||
+      !this.isSerialConnected()
+    ) {
       return;
     }
 

--- a/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.css
+++ b/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.css
@@ -1,0 +1,10 @@
+.editor-toolbar__button:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.editor-toolbar__spinner {
+  display: inline-block;
+  margin-right: 0.5rem;
+  vertical-align: middle;
+}

--- a/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.html
+++ b/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.html
@@ -1,10 +1,47 @@
-<div class="editor-toolbar flex gap-2 px-3 py-2">
-  <button type="button" [disabled]="saveDisabled()" (click)="saveRequested.emit()">
+<div
+  class="editor-toolbar flex flex-wrap items-center gap-2 border-b border-gray-200 px-3 py-2"
+  role="toolbar"
+  aria-label="Editor actions"
+>
+  <button
+    mat-button
+    type="button"
+    class="editor-toolbar__button"
+    [disabled]="saveDisabled()"
+    [matTooltip]="saveTooltip()"
+    [attr.aria-label]="saveTooltip()"
+    (click)="saveRequested.emit()"
+  >
+    @if (isSaving()) {
+      <mat-progress-spinner
+        class="editor-toolbar__spinner"
+        mode="indeterminate"
+        diameter="16"
+        aria-hidden="true"
+      />
+    }
     Save
   </button>
+
   <button
+    mat-button
     type="button"
+    class="editor-toolbar__button"
+    [disabled]="formatDisabled()"
+    [matTooltip]="formatTooltip()"
+    [attr.aria-label]="formatTooltip()"
+    (click)="formatRequested.emit()"
+  >
+    Format
+  </button>
+
+  <button
+    mat-button
+    type="button"
+    class="editor-toolbar__button"
     [disabled]="discardDisabled()"
+    [matTooltip]="discardTooltip"
+    [attr.aria-label]="discardTooltip"
     (click)="discardRequested.emit()"
   >
     Discard

--- a/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.spec.ts
@@ -16,17 +16,31 @@ describe('EditorToolbarComponent', () => {
     fixture.detectChanges();
   });
 
+  const buttons = (): NodeListOf<HTMLButtonElement> =>
+    fixture.nativeElement.querySelectorAll(
+      'button',
+    ) as NodeListOf<HTMLButtonElement>;
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
   it('should emit saveRequested when save button is clicked', () => {
     const emitSpy = vi.spyOn(component.saveRequested, 'emit');
-    const buttons = fixture.nativeElement.querySelectorAll(
-      'button',
-    ) as NodeListOf<HTMLButtonElement>;
 
-    buttons[0].click();
+    buttons()[0].click();
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should emit formatRequested when format button is clicked', async () => {
+    fixture.componentRef.setInput('formatDisabled', false);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const emitSpy = vi.spyOn(component.formatRequested, 'emit');
+
+    buttons()[1].click();
 
     expect(emitSpy).toHaveBeenCalledTimes(1);
   });
@@ -37,11 +51,8 @@ describe('EditorToolbarComponent', () => {
     await fixture.whenStable();
 
     const emitSpy = vi.spyOn(component.discardRequested, 'emit');
-    const buttons = fixture.nativeElement.querySelectorAll(
-      'button',
-    ) as NodeListOf<HTMLButtonElement>;
 
-    buttons[1].click();
+    buttons()[2].click();
 
     expect(emitSpy).toHaveBeenCalledTimes(1);
   });
@@ -51,10 +62,32 @@ describe('EditorToolbarComponent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    const buttons = fixture.nativeElement.querySelectorAll(
-      'button',
-    ) as NodeListOf<HTMLButtonElement>;
+    expect(buttons()[0].disabled).toBe(true);
+  });
 
-    expect(buttons[0].disabled).toBe(true);
+  it('should disable format button when formatDisabled is true', async () => {
+    fixture.componentRef.setInput('formatDisabled', true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(buttons()[1].disabled).toBe(true);
+  });
+
+  it('should set aria-label from tooltips', () => {
+    const [save, format, discard] = Array.from(buttons());
+
+    expect(save.getAttribute('aria-label')).toBe(component.saveTooltip());
+    expect(format.getAttribute('aria-label')).toBe(component.formatTooltip());
+    expect(discard.getAttribute('aria-label')).toBe(component.discardTooltip);
+  });
+
+  it('should show a spinner while saving', async () => {
+    fixture.componentRef.setInput('isSaving', true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(
+      fixture.nativeElement.querySelector('mat-progress-spinner'),
+    ).toBeTruthy();
   });
 });

--- a/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.ts
+++ b/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.ts
@@ -1,12 +1,44 @@
-import { Component, input, output } from '@angular/core';
+import { Component, computed, input, output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { MatTooltip } from '@angular/material/tooltip';
+
+const isApplePlatform = (): boolean => {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+  return /Mac|iPhone|iPod|iPad/i.test(
+    navigator.platform || navigator.userAgent,
+  );
+};
 
 @Component({
   selector: 'choh-editor-toolbar',
+  imports: [MatButtonModule, MatTooltip, MatProgressSpinner],
   templateUrl: './editor-toolbar.component.html',
+  styleUrl: './editor-toolbar.component.css',
 })
 export class EditorToolbarComponent {
   saveDisabled = input(false);
   discardDisabled = input(true);
+  formatDisabled = input(true);
+  isSaving = input(false);
+
   saveRequested = output<void>();
   discardRequested = output<void>();
+  formatRequested = output<void>();
+
+  private readonly applePlatform = isApplePlatform();
+
+  readonly saveTooltip = computed(() =>
+    this.applePlatform ? 'Save (Cmd+S)' : 'Save (Ctrl+S)',
+  );
+
+  readonly formatTooltip = computed(() =>
+    this.applePlatform
+      ? 'Format (Shift+Option+F)'
+      : 'Format (Shift+Alt+F)',
+  );
+
+  readonly discardTooltip = 'Discard local changes';
 }

--- a/libs/editor/src/lib/service/editor.service.spec.ts
+++ b/libs/editor/src/lib/service/editor.service.spec.ts
@@ -52,3 +52,60 @@ describe('EditorService.saveTextFile', () => {
     ).rejects.toThrow(/write permission was denied/);
   });
 });
+
+describe('EditorService.formatDocument', () => {
+  let service: EditorService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        EditorService,
+        {
+          provide: FileContentService,
+          useValue: { writeTextFile: vi.fn(), readFile: vi.fn() },
+        },
+        {
+          provide: SerialFacadeService,
+          useValue: { isConnected: vi.fn().mockReturnValue(true) },
+        },
+      ],
+    });
+
+    service = TestBed.inject(EditorService);
+  });
+
+  it('returns false when the editor is not initialized', async () => {
+    await expect(service.formatDocument()).resolves.toBe(false);
+  });
+
+  it('returns false when format action is unsupported', async () => {
+    const run = vi.fn();
+    service.initializeEditor({
+      onDidChangeModelContent: vi.fn(),
+      getAction: vi.fn().mockReturnValue({
+        isSupported: () => false,
+        run,
+      }),
+      getValue: vi.fn().mockReturnValue(''),
+    } as never);
+
+    await expect(service.formatDocument()).resolves.toBe(false);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('runs the format document action when supported', async () => {
+    const run = vi.fn().mockResolvedValue(undefined);
+    service.initializeEditor({
+      onDidChangeModelContent: vi.fn(),
+      getAction: vi.fn().mockReturnValue({
+        isSupported: () => true,
+        run,
+      }),
+      getValue: vi.fn().mockReturnValue('formatted'),
+    } as never);
+
+    await expect(service.formatDocument()).resolves.toBe(true);
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(service.getValue()).toBe('formatted');
+  });
+});

--- a/libs/editor/src/lib/service/editor.service.ts
+++ b/libs/editor/src/lib/service/editor.service.ts
@@ -64,4 +64,27 @@ export class EditorService {
       throw classifyFileWriteError(error);
     }
   }
+
+  /**
+   * Monaco の Document Format Action を実行します。
+   * Formatter が無い／未対応の場合は false を返します。
+   */
+  async formatDocument(): Promise<boolean> {
+    if (!this.editor) {
+      return false;
+    }
+
+    const action = this.editor.getAction('editor.action.formatDocument');
+    if (!action || !action.isSupported()) {
+      return false;
+    }
+
+    await action.run();
+    return true;
+  }
+
+  /** 現在の Monaco バッファ内容。未初期化時は null。 */
+  getValue(): string | null {
+    return this.editor?.getValue() ?? null;
+  }
 }


### PR DESCRIPTION
## Summary

Editor Toolbar に Save / Format 操作を実装し、未接続時の無効化・保存通知・a11y（ツールチップ / aria-label / フォーカス）を整えました。

- Editor Toolbar をラベル付き Material ボタンに更新し、Format を追加
- 未接続・未選択・未変更・保存中は Save を無効化（保存中はスピナー表示）
- 保存成功・失敗を `NotificationService` で通知
- Monaco の Document Format Action を Toolbar / `Shift+Alt+F` から実行

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Closes #808
- Refs #804

## What changed?

- `EditorToolbarComponent` に Format・tooltip・aria-label・保存中スピナーを追加
- `EditorPageComponent` で接続状態に応じた Save 無効化と Toast 通知を追加
- `EditorService.formatDocument()` を追加し、Format 後は未保存（draft）状態へ遷移
- Toolbar / Page / Service のユニットテストを拡充

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx test libs-editor` / `pnpm nx lint libs-editor` が通ること
2. `/editor` でファイルを開き、編集後に Save（ボタン / Cmd+S or Ctrl+S）で保存できること
3. 未接続・ファイル未選択・未変更時に Save が無効化されること
4. Format（ボタン / Shift+Alt+F）で整形され、未保存状態になること
5. Formatter 非対応時に warning Toast が出ること
6. 各ボタンのツールチップ・キーボードフォーカスが確認できること

## Environment (if relevant)

- Browser: Chromium (Web Serial)
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)