### PR TITLE
feat(editor): improve file path language and save status display

### DIFF
--- a/libs/editor/src/lib/component/editor-page/editor-page.component.html
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.html
@@ -15,8 +15,11 @@
   />
   <choh-file-name-display
     class="shrink-0"
-    [fileName]="currentFileName()"
+    [filePath]="currentFilePath()"
+    [languageLabel]="languageLabel()"
     [saveStatus]="saveStatus()"
+    [lastSavedAt]="lastDeviceSavedAt()"
+    [readOnly]="isReadOnly()"
   />
 
   @if (loadError(); as error) {
@@ -57,6 +60,7 @@
     <choh-monaco-editor
       class="flex h-full min-h-0 min-w-0"
       [code]="code()"
+      [editorOptions]="monacoOptions()"
       (codeChange)="onCodeChange($event)"
       (editorInitialized)="onEditorInitialized($event)"
       (contentEdited)="onContentEdited()"

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -395,4 +395,68 @@ describe('EditorPageComponent', () => {
 
     expect(editorServiceMock.formatDocument).not.toHaveBeenCalled();
   });
+
+  it('should resolve monaco language from the open file extension', async () => {
+    await loadPath('/home/pi/readme.md', '# hi');
+
+    expect(component.languageLabel()).toBe('Markdown');
+    expect(component.monacoOptions().language).toBe('markdown');
+    expect(component.currentFilePath()).toBe('/home/pi/readme.md');
+  });
+
+  it('should fall back to plaintext for unknown extensions', async () => {
+    await loadPath('/home/pi/data.bin', 'raw');
+
+    expect(component.languageLabel()).toBe('Plain Text');
+    expect(component.monacoOptions().language).toBe('plaintext');
+  });
+
+  it('should record last device save time after a successful save', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
+    expect(component.lastDeviceSavedAt()).toBeNull();
+
+    component.onCodeChange('updated');
+    component.onContentEdited();
+    await component.saveCurrentFile();
+
+    expect(component.saveStatus()).toBe('savedToDevice');
+    expect(component.lastDeviceSavedAt()).toEqual(expect.any(Number));
+  });
+
+  it('should mark read-only when save fails with permission denied', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
+    component.onCodeChange('updated');
+    component.onContentEdited();
+    editorServiceMock.saveTextFile.mockRejectedValueOnce(
+      new Error('Save failed: write permission was denied for the target file.'),
+    );
+
+    await component.saveCurrentFile();
+
+    expect(component.isReadOnly()).toBe(true);
+    expect(component.monacoOptions().readOnly).toBe(true);
+  });
+
+  it('should clear read-only when opening another file', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
+    component.onCodeChange('updated');
+    component.onContentEdited();
+    editorServiceMock.saveTextFile.mockRejectedValueOnce(
+      new Error('Save failed: write permission was denied for the target file.'),
+    );
+    await component.saveCurrentFile();
+    expect(component.isReadOnly()).toBe(true);
+
+    const closed = mockDialogResult(true);
+    const switchPromise = (
+      component as unknown as { loadFile: (path: string) => Promise<void> }
+    ).loadFile('/home/pi/other.js');
+    closed.next(true);
+    closed.complete();
+    await switchPromise;
+    await fixture.whenStable();
+
+    expect(component.isReadOnly()).toBe(false);
+    expect(component.lastDeviceSavedAt()).toBeNull();
+  });
 });

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.ts
@@ -13,6 +13,7 @@ import { ConsoleShellStore, NotificationService } from '@libs-shared';
 import { SerialFacadeService } from '@libs-web-serial';
 import type { editor } from 'monaco-editor';
 import { firstValueFrom } from 'rxjs';
+import { resolveEditorLanguage } from '../../functions';
 import { EditorDraft, EditorDraftService, EditorService } from '../../service';
 import {
   EditorDraftResolveChoice,
@@ -20,7 +21,10 @@ import {
 } from '../editor-draft-resolve-dialog/editor-draft-resolve-dialog.component';
 import { EditorToolbarComponent } from '../editor-toolbar/editor-toolbar.component';
 import { FileNameDisplayComponent } from '../file-name-display/file-name-display.component';
-import { MonacoEditorComponent } from '../monaco-editor/monaco-editor.component';
+import {
+  MonacoEditorComponent,
+  MonacoEditorOptions,
+} from '../monaco-editor/monaco-editor.component';
 import { EditorSaveStatus, isEditorDirtyStatus } from './editor-save-status';
 
 export interface EditorLoadError {
@@ -43,10 +47,30 @@ export class EditorPageComponent implements OnInit {
   saveStatus = signal<EditorSaveStatus | null>(null);
   loadError = signal<EditorLoadError | null>(null);
   saveError = signal<string | null>(null);
+  lastDeviceSavedAt = signal<number | null>(null);
+  isReadOnly = signal(false);
 
   readonly isDirty = computed(() => isEditorDirtyStatus(this.saveStatus()));
   readonly isSaving = computed(() => this.saveStatus() === 'saving');
   readonly isLoading = computed(() => this.saveStatus() === 'loading');
+
+  readonly languageInfo = computed(() =>
+    resolveEditorLanguage(this.activeFilePath()),
+  );
+
+  readonly languageLabel = computed(() => {
+    if (!this.activeFilePath()) {
+      return null;
+    }
+    return this.languageInfo().label;
+  });
+
+  readonly monacoOptions = computed<MonacoEditorOptions>(() => ({
+    theme: 'vs-dark',
+    language: this.languageInfo().monacoLanguage,
+    automaticLayout: true,
+    readOnly: this.isReadOnly(),
+  }));
 
   private editorService = inject(EditorService);
   private draftService = inject(EditorDraftService);
@@ -108,7 +132,7 @@ export class EditorPageComponent implements OnInit {
     );
   }
 
-  private currentFilePath(): string | null {
+  currentFilePath(): string | null {
     return this.activeFilePath();
   }
 
@@ -168,6 +192,8 @@ export class EditorPageComponent implements OnInit {
     this.saveStatus.set('loading');
     this.loadError.set(null);
     this.saveError.set(null);
+    this.lastDeviceSavedAt.set(null);
+    this.isReadOnly.set(false);
 
     try {
       const loaded = await this.editorService.loadTextFile(path);
@@ -197,6 +223,8 @@ export class EditorPageComponent implements OnInit {
     this.baselineReady = true;
     this.saveStatus.set('savedToDevice');
     this.saveError.set(null);
+    this.lastDeviceSavedAt.set(null);
+    this.isReadOnly.set(false);
   }
 
   private async resolveDraft(draft: EditorDraft): Promise<void> {
@@ -223,6 +251,8 @@ export class EditorPageComponent implements OnInit {
     this.saveStatus.set('draftSavedLocally');
     this.saveError.set(null);
     this.loadError.set(null);
+    this.lastDeviceSavedAt.set(null);
+    this.isReadOnly.set(false);
 
     try {
       this.baselineContent = await this.editorService.loadTextFile(draft.path);
@@ -295,6 +325,8 @@ export class EditorPageComponent implements OnInit {
       await this.editorService.saveTextFile(path, this.code());
       this.baselineContent = this.code();
       this.baselineReady = true;
+      this.lastDeviceSavedAt.set(Date.now());
+      this.isReadOnly.set(false);
       this.saveStatus.set('savedToDevice');
       this.draftService.clear(path);
       this.notify.success('Save', 'Saved to device');
@@ -307,6 +339,9 @@ export class EditorPageComponent implements OnInit {
       // Keep editor content and local draft so the user can retry after reconnect.
       this.saveStatus.set('saveFailed');
       this.notify.error('Save', message);
+      if (isWritePermissionDenied(message)) {
+        this.isReadOnly.set(true);
+      }
     }
   }
 
@@ -431,4 +466,12 @@ export class EditorPageComponent implements OnInit {
     event.preventDefault();
     await this.formatCurrentFile();
   }
+}
+
+function isWritePermissionDenied(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('write permission was denied') ||
+    lower.includes('permission denied')
+  );
 }

--- a/libs/editor/src/lib/component/file-name-display/file-name-display.component.html
+++ b/libs/editor/src/lib/component/file-name-display/file-name-display.component.html
@@ -1,23 +1,52 @@
-<div class="file-name-display flex flex-wrap items-center gap-x-2 gap-y-1 px-3 py-1 text-sm">
-  @if (fileName()) {
-    <span>
-      {{ fileName() }}
+<div
+  class="file-name-display flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 px-3 py-1 text-sm"
+>
+  @if (hasFile()) {
+    <span
+      class="min-w-0 max-w-full truncate font-medium"
+      [attr.title]="filePath()"
+      data-testid="editor-file-path"
+    >
+      {{ filePath() }}
       @if (isDirty()) {
         <span aria-hidden="true"> *</span>
       }
     </span>
-  } @else {
-    <span>—</span>
-  }
 
-  @if (statusLabel(); as label) {
+    @if (languageLabel(); as language) {
+      <span
+        class="shrink-0 text-xs text-neutral-600"
+        data-testid="editor-language-label"
+      >
+        {{ language }}
+      </span>
+    }
+
+    @if (readOnly()) {
+      <span
+        class="shrink-0 rounded border border-neutral-300 px-1.5 py-0.5 text-xs text-neutral-700"
+        data-testid="editor-readonly-badge"
+      >
+        Read-only
+      </span>
+    }
+
+    @if (statusLabel(); as label) {
+      <span
+        class="shrink-0 text-xs text-neutral-600"
+        role="status"
+        aria-live="polite"
+        data-testid="editor-save-status"
+      >
+        {{ label }}
+      </span>
+    }
+  } @else {
     <span
-      class="text-xs text-neutral-600"
-      role="status"
-      aria-live="polite"
-      data-testid="editor-save-status"
+      class="text-neutral-500"
+      data-testid="editor-no-file-selected"
     >
-      {{ label }}
+      No file selected
     </span>
   }
 </div>

--- a/libs/editor/src/lib/component/file-name-display/file-name-display.component.spec.ts
+++ b/libs/editor/src/lib/component/file-name-display/file-name-display.component.spec.ts
@@ -20,24 +20,81 @@ describe('FileNameDisplayComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should render file name with dirty marker and status label', async () => {
-    fixture.componentRef.setInput('fileName', 'main.js');
+  it('should show empty state when no file is selected', () => {
+    expect(
+      fixture.nativeElement.querySelector(
+        '[data-testid="editor-no-file-selected"]',
+      )?.textContent,
+    ).toContain('No file selected');
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="editor-file-path"]'),
+    ).toBeNull();
+  });
+
+  it('should render full path with dirty marker, language, and status', async () => {
+    fixture.componentRef.setInput('filePath', '/home/pi/examples/i2c/main.js');
+    fixture.componentRef.setInput('languageLabel', 'JavaScript');
     fixture.componentRef.setInput('saveStatus', 'unsavedChanges');
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(fixture.nativeElement.textContent).toContain('main.js');
-    expect(fixture.nativeElement.textContent).toContain('*');
-    expect(fixture.nativeElement.textContent).toContain('Unsaved changes');
+    const pathEl = fixture.nativeElement.querySelector(
+      '[data-testid="editor-file-path"]',
+    ) as HTMLElement;
+    expect(pathEl.textContent).toContain('/home/pi/examples/i2c/main.js');
+    expect(pathEl.textContent).toContain('*');
+    expect(pathEl.getAttribute('title')).toBe('/home/pi/examples/i2c/main.js');
+    expect(
+      fixture.nativeElement.querySelector(
+        '[data-testid="editor-language-label"]',
+      )?.textContent,
+    ).toContain('JavaScript');
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="editor-save-status"]')
+        ?.textContent,
+    ).toContain('Unsaved changes');
   });
 
-  it('should show saved to device without dirty marker', async () => {
-    fixture.componentRef.setInput('fileName', 'main.js');
+  it('should show saved to device with last saved time', async () => {
+    const noon = new Date(2026, 7, 3, 20, 42, 0).getTime();
+    fixture.componentRef.setInput('filePath', '/home/pi/main.js');
+    fixture.componentRef.setInput('languageLabel', 'JavaScript');
     fixture.componentRef.setInput('saveStatus', 'savedToDevice');
+    fixture.componentRef.setInput('lastSavedAt', noon);
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(fixture.nativeElement.textContent).toContain('Saved to device');
+    const status = fixture.nativeElement.querySelector(
+      '[data-testid="editor-save-status"]',
+    )?.textContent;
+    expect(status).toContain('Saved to device');
+    expect(status).toContain('20:42');
     expect(fixture.nativeElement.textContent).not.toContain('*');
+  });
+
+  it('should show draft saved locally without conflating device save', async () => {
+    fixture.componentRef.setInput('filePath', '/home/pi/main.js');
+    fixture.componentRef.setInput('saveStatus', 'draftSavedLocally');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(
+      fixture.nativeElement.querySelector('[data-testid="editor-save-status"]')
+        ?.textContent,
+    ).toContain('Draft saved locally');
+    expect(fixture.nativeElement.textContent).not.toContain('Saved to device');
+  });
+
+  it('should show read-only badge when readOnly is true', async () => {
+    fixture.componentRef.setInput('filePath', '/etc/hosts');
+    fixture.componentRef.setInput('readOnly', true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(
+      fixture.nativeElement.querySelector(
+        '[data-testid="editor-readonly-badge"]',
+      )?.textContent,
+    ).toContain('Read-only');
   });
 });

--- a/libs/editor/src/lib/component/file-name-display/file-name-display.component.ts
+++ b/libs/editor/src/lib/component/file-name-display/file-name-display.component.ts
@@ -10,13 +10,40 @@ import {
   templateUrl: './file-name-display.component.html',
 })
 export class FileNameDisplayComponent {
-  fileName = input<string | null>(null);
+  /** Full path of the open file. Null/empty means no file selected. */
+  filePath = input<string | null>(null);
+  languageLabel = input<string | null>(null);
   saveStatus = input<EditorSaveStatus | null>(null);
+  /** Epoch ms of the last successful device save; shown only for savedToDevice. */
+  lastSavedAt = input<number | null>(null);
+  readOnly = input(false);
 
   readonly isDirty = computed(() => isEditorDirtyStatus(this.saveStatus()));
 
+  readonly hasFile = computed(() => {
+    const path = this.filePath();
+    return !!path && path.length > 0;
+  });
+
   readonly statusLabel = computed(() => {
     const status = this.saveStatus();
-    return status ? EDITOR_SAVE_STATUS_LABEL[status] : null;
+    if (!status) {
+      return null;
+    }
+    const base = EDITOR_SAVE_STATUS_LABEL[status];
+    if (status === 'savedToDevice') {
+      const at = this.lastSavedAt();
+      if (at != null) {
+        return `${base} ${formatTimeHm(at)}`;
+      }
+    }
+    return base;
   });
+}
+
+function formatTimeHm(epochMs: number): string {
+  const date = new Date(epochMs);
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+  return `${hours}:${minutes}`;
 }

--- a/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.ts
+++ b/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.ts
@@ -1,7 +1,30 @@
-import { Component, output, input, model } from '@angular/core';
+import {
+  Component,
+  effect,
+  output,
+  input,
+  model,
+  untracked,
+} from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import type { editor } from 'monaco-editor';
+
+export type MonacoEditorOptions = {
+  theme?: string;
+  language?: string;
+  automaticLayout?: boolean;
+  readOnly?: boolean;
+};
+
+declare const monaco: {
+  editor: {
+    setModelLanguage: (
+      model: editor.ITextModel,
+      languageId: string,
+    ) => void;
+  };
+};
 
 @Component({
   selector: 'choh-monaco-editor',
@@ -13,13 +36,29 @@ export class MonacoEditorComponent {
   contentEdited = output<void>();
   editorInitialized = output<editor.IStandaloneCodeEditor>();
 
-  editorOptions = input({
+  editorOptions = input<MonacoEditorOptions>({
     theme: 'vs-dark',
     language: 'javascript',
     automaticLayout: true,
+    readOnly: false,
   });
 
+  private editorInstance: editor.IStandaloneCodeEditor | null = null;
+
+  constructor() {
+    effect(() => {
+      const options = this.editorOptions();
+      const instance = untracked(() => this.editorInstance);
+      if (!instance) {
+        return;
+      }
+      this.applyEditorOptions(instance, options);
+    });
+  }
+
   onEditorInit(editorInstance: editor.IStandaloneCodeEditor): void {
+    this.editorInstance = editorInstance;
+    this.applyEditorOptions(editorInstance, this.editorOptions());
     this.editorInitialized.emit(editorInstance);
     editorInstance.onDidChangeModelContent((event) => {
       if (event.isFlush) {
@@ -27,5 +66,19 @@ export class MonacoEditorComponent {
       }
       this.contentEdited.emit();
     });
+  }
+
+  private applyEditorOptions(
+    instance: editor.IStandaloneCodeEditor,
+    options: MonacoEditorOptions,
+  ): void {
+    instance.updateOptions({
+      readOnly: options.readOnly ?? false,
+    });
+    const language = options.language;
+    const model = instance.getModel();
+    if (language && model && typeof monaco !== 'undefined') {
+      monaco.editor.setModelLanguage(model, language);
+    }
   }
 }

--- a/libs/editor/src/lib/functions/index.ts
+++ b/libs/editor/src/lib/functions/index.ts
@@ -1,1 +1,2 @@
 export * from './monaco-config';
+export * from './resolve-editor-language';

--- a/libs/editor/src/lib/functions/resolve-editor-language.spec.ts
+++ b/libs/editor/src/lib/functions/resolve-editor-language.spec.ts
@@ -1,0 +1,48 @@
+/// <reference types="vitest/globals" />
+import { resolveEditorLanguage } from './resolve-editor-language';
+
+describe('resolveEditorLanguage', () => {
+  it.each([
+    ['main.js', 'javascript', 'JavaScript'],
+    ['/home/pi/app.mjs', 'javascript', 'JavaScript'],
+    ['lib.cjs', 'javascript', 'JavaScript'],
+    ['package.json', 'json', 'JSON'],
+    ['index.html', 'html', 'HTML'],
+    ['page.HTM', 'html', 'HTML'],
+    ['styles.css', 'css', 'CSS'],
+    ['README.md', 'markdown', 'Markdown'],
+    ['setup.sh', 'shell', 'Shell'],
+    ['notes.txt', 'plaintext', 'Plain Text'],
+  ] as const)(
+    'maps %s to %s / %s',
+    (path, monacoLanguage, label) => {
+      expect(resolveEditorLanguage(path)).toEqual({ monacoLanguage, label });
+    },
+  );
+
+  it('falls back to Plain Text for unknown extensions', () => {
+    expect(resolveEditorLanguage('/home/pi/data.bin')).toEqual({
+      monacoLanguage: 'plaintext',
+      label: 'Plain Text',
+    });
+  });
+
+  it('falls back to Plain Text when path is empty or has no extension', () => {
+    expect(resolveEditorLanguage(null)).toEqual({
+      monacoLanguage: 'plaintext',
+      label: 'Plain Text',
+    });
+    expect(resolveEditorLanguage(undefined)).toEqual({
+      monacoLanguage: 'plaintext',
+      label: 'Plain Text',
+    });
+    expect(resolveEditorLanguage('Makefile')).toEqual({
+      monacoLanguage: 'plaintext',
+      label: 'Plain Text',
+    });
+    expect(resolveEditorLanguage('.gitignore')).toEqual({
+      monacoLanguage: 'plaintext',
+      label: 'Plain Text',
+    });
+  });
+});

--- a/libs/editor/src/lib/functions/resolve-editor-language.ts
+++ b/libs/editor/src/lib/functions/resolve-editor-language.ts
@@ -1,0 +1,51 @@
+export type EditorLanguageInfo = {
+  monacoLanguage: string;
+  label: string;
+};
+
+const EXTENSION_LANGUAGE_MAP: Record<string, EditorLanguageInfo> = {
+  '.js': { monacoLanguage: 'javascript', label: 'JavaScript' },
+  '.mjs': { monacoLanguage: 'javascript', label: 'JavaScript' },
+  '.cjs': { monacoLanguage: 'javascript', label: 'JavaScript' },
+  '.json': { monacoLanguage: 'json', label: 'JSON' },
+  '.html': { monacoLanguage: 'html', label: 'HTML' },
+  '.htm': { monacoLanguage: 'html', label: 'HTML' },
+  '.css': { monacoLanguage: 'css', label: 'CSS' },
+  '.md': { monacoLanguage: 'markdown', label: 'Markdown' },
+  '.sh': { monacoLanguage: 'shell', label: 'Shell' },
+  '.txt': { monacoLanguage: 'plaintext', label: 'Plain Text' },
+};
+
+const PLAIN_TEXT: EditorLanguageInfo = {
+  monacoLanguage: 'plaintext',
+  label: 'Plain Text',
+};
+
+function getExtension(pathOrFileName: string): string {
+  const base =
+    pathOrFileName.lastIndexOf('/') >= 0
+      ? pathOrFileName.slice(pathOrFileName.lastIndexOf('/') + 1)
+      : pathOrFileName;
+  const lastDot = base.lastIndexOf('.');
+  if (lastDot <= 0) {
+    return '';
+  }
+  return base.slice(lastDot).toLowerCase();
+}
+
+/**
+ * Resolve Monaco language id and display label from a file path or name.
+ * Unknown extensions fall back to Plain Text.
+ */
+export function resolveEditorLanguage(
+  pathOrFileName: string | null | undefined,
+): EditorLanguageInfo {
+  if (!pathOrFileName) {
+    return PLAIN_TEXT;
+  }
+  const extension = getExtension(pathOrFileName);
+  if (!extension) {
+    return PLAIN_TEXT;
+  }
+  return EXTENSION_LANGUAGE_MAP[extension] ?? PLAIN_TEXT;
+}


### PR DESCRIPTION
## Summary

Editor のステータス帯を改善し、編集中ファイルのフルパス・言語モード・保存状態を同時に確認できるようにしました。拡張子から Monaco の言語モードを自動判定し、不明な拡張子は Plain Text にフォールバックします。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Closes #809
- Refs #804

## What changed?

- 拡張子から Monaco 言語 ID / 表示名を解決する `resolveEditorLanguage` を追加
- `FileNameDisplay` にフルパス（省略 + ツールチップ）、言語ラベル、最終保存時刻、Read-only、未選択表示を追加
- `EditorPage` からパス・言語・`lastDeviceSavedAt`・`isReadOnly` を配線し、Monaco の language / readOnly を動的に切替
- 端末保存成功時に最終保存時刻を記録し、権限エラー時は Read-only として識別
- Unit テストを追加・更新（`libs-editor:test` すべて成功）

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx run libs-editor:test` が成功すること
2. `/editor` で `.js` / `.md` / `.json` / 不明拡張子のファイルを開き、ステータス帯のパス・言語ラベルとシンタックスハイライトが切り替わること
3. 編集 → 端末保存後に `Saved to device HH:mm` が表示されること
4. Draft 保存時は `Draft saved locally` と表示され、端末保存と混同しないこと
5. 書き込み権限エラーで保存失敗すると `Read-only` バッジが出ること。別ファイルを開くと解除されること
6. ファイル未選択時は `No file selected` が表示されること

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)