### PR TITLE
feat(editor): implement file create rename and delete

### DIFF
--- a/apps/console/src/app/app.config.ts
+++ b/apps/console/src/app/app.config.ts
@@ -4,7 +4,8 @@ import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { MAT_ICON_DEFAULT_OPTIONS } from '@angular/material/icon';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideRouter } from '@angular/router';
-import { monacoConfig } from '@libs-editor';
+import { EditorDraftService, monacoConfig } from '@libs-editor';
+import { EDITOR_DRAFT_LIFECYCLE } from '@libs-shared';
 import { provideRouterStore } from '@ngrx/router-store';
 import { provideStore } from '@ngrx/store';
 import { provideStoreDevtools } from '@ngrx/store-devtools';
@@ -33,6 +34,10 @@ export const appConfig: ApplicationConfig = {
     }),
     provideHttpClient(),
     provideMonacoEditor(monacoConfig),
+    {
+      provide: EDITOR_DRAFT_LIFECYCLE,
+      useExisting: EditorDraftService,
+    },
     provideStore({}),
     provideStoreDevtools({
       maxAge: 25,

--- a/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.html
+++ b/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.html
@@ -10,8 +10,12 @@
         <lib-file-tree-feature
           [currentPath]="shellStore.fileManagerCurrentPath()"
           [selectedPath]="shellStore.selectedFilePath()"
+          [hasUnsavedDraft]="hasUnsavedDraft"
           (currentPathChange)="onCurrentPathChange($event)"
           (fileSelected)="onFileSelected($event)"
+          (fileCreated)="onFileCreated($event)"
+          (fileRenamed)="onFileRenamed($event)"
+          (fileDeleted)="onFileDeleted($event)"
         />
         <div
           role="separator"
@@ -30,8 +34,12 @@
         <lib-file-tree-feature
           [currentPath]="shellStore.fileManagerCurrentPath()"
           [selectedPath]="shellStore.selectedFilePath()"
+          [hasUnsavedDraft]="hasUnsavedDraft"
           (currentPathChange)="onCurrentPathChange($event)"
           (fileSelected)="onFileSelected($event)"
+          (fileCreated)="onFileCreated($event)"
+          (fileRenamed)="onFileRenamed($event)"
+          (fileDeleted)="onFileDeleted($event)"
         />
       </div>
     }

--- a/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.spec.ts
+++ b/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.spec.ts
@@ -12,7 +12,7 @@ import {
 import { signal } from '@angular/core';
 import { EMPTY } from 'rxjs';
 import { LeftSidebarComponent } from './left-sidebar.component';
-import { ConsoleShellStore } from '@libs-shared';
+import { ConsoleShellStore, EDITOR_DRAFT_LIFECYCLE } from '@libs-shared';
 
 const baseVm: SerialConnectionViewModel = {
   isBrowserSupported: true,
@@ -27,8 +27,17 @@ const baseVm: SerialConnectionViewModel = {
 describe('LeftSidebarComponent', () => {
   let component: LeftSidebarComponent;
   let fixture: ComponentFixture<LeftSidebarComponent>;
+  const draftLifecycle = {
+    has: vi.fn<(path: string) => boolean>().mockReturnValue(false),
+    rename: vi.fn(),
+    clear: vi.fn(),
+  };
 
   beforeEach(async () => {
+    draftLifecycle.has.mockReset().mockReturnValue(false);
+    draftLifecycle.rename.mockReset();
+    draftLifecycle.clear.mockReset();
+
     const activatedRoute = {
       firstChild: null,
       snapshot: { url: [] },
@@ -56,6 +65,10 @@ describe('LeftSidebarComponent', () => {
         {
           provide: FileService,
           useValue: { listTree: vi.fn().mockResolvedValue([]) },
+        },
+        {
+          provide: EDITOR_DRAFT_LIFECYCLE,
+          useValue: draftLifecycle,
         },
       ],
     }).compileComponents();
@@ -98,7 +111,7 @@ describe('LeftSidebarComponent', () => {
     ).toBeNull();
   });
 
-  it('updates store path and clears selected file on currentPathChange', () => {
+  it('updates store path on currentPathChange without clearing selection', () => {
     const store = TestBed.inject(ConsoleShellStore);
     store.setSelectedFilePath('./docs/readme.md');
     store.setFileManagerCurrentPath('./docs');
@@ -106,6 +119,26 @@ describe('LeftSidebarComponent', () => {
     component.onCurrentPathChange('./home');
 
     expect(store.fileManagerCurrentPath()).toBe('./home');
+    expect(store.selectedFilePath()).toBe('./docs/readme.md');
+  });
+
+  it('renames draft and selected path when the open file is renamed', () => {
+    const store = TestBed.inject(ConsoleShellStore);
+    store.setSelectedFilePath('./old.js');
+
+    component.onFileRenamed({ from: './old.js', to: './new.js' });
+
+    expect(draftLifecycle.rename).toHaveBeenCalledWith('./old.js', './new.js');
+    expect(store.selectedFilePath()).toBe('./new.js');
+  });
+
+  it('clears draft and selection when the open file is deleted', () => {
+    const store = TestBed.inject(ConsoleShellStore);
+    store.setSelectedFilePath('./gone.js');
+
+    component.onFileDeleted('./gone.js');
+
+    expect(draftLifecycle.clear).toHaveBeenCalledWith('./gone.js');
     expect(store.selectedFilePath()).toBeNull();
   });
 

--- a/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.ts
+++ b/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.ts
@@ -3,12 +3,12 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
-import { EditorDraftService } from '@libs-editor';
 import type { FileRenamedEvent } from '@libs-file-manager';
 import { FileTreeFeatureComponent } from '@libs-file-manager';
 import {
   ConsoleShellLayoutMode,
   ConsoleShellStore,
+  EDITOR_DRAFT_LIFECYCLE,
   LEFT_PANE_WIDTH,
   RAIL_WIDTH_PX,
 } from '@libs-shared';
@@ -47,12 +47,14 @@ export class LeftSidebarComponent {
   );
 
   readonly shellStore = inject(ConsoleShellStore);
-  private readonly draftService = inject(EditorDraftService);
+  private readonly draftLifecycle = inject(EDITOR_DRAFT_LIFECYCLE, {
+    optional: true,
+  });
   private router = inject(Router);
   private route = inject(ActivatedRoute);
 
   readonly hasUnsavedDraft = (path: string): boolean =>
-    this.draftService.has(path);
+    this.draftLifecycle?.has(path) ?? false;
 
   onCurrentPathChange(path: string): void {
     this.shellStore.setFileManagerCurrentPath(path);
@@ -68,14 +70,14 @@ export class LeftSidebarComponent {
   }
 
   onFileRenamed({ from, to }: FileRenamedEvent): void {
-    this.draftService.rename(from, to);
+    this.draftLifecycle?.rename(from, to);
     if (this.shellStore.selectedFilePath() === from) {
       this.shellStore.setSelectedFilePath(to);
     }
   }
 
   onFileDeleted(path: string): void {
-    this.draftService.clear(path);
+    this.draftLifecycle?.clear(path);
     if (this.shellStore.selectedFilePath() === path) {
       this.shellStore.setSelectedFilePath(null);
     }

--- a/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.ts
+++ b/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.ts
@@ -3,13 +3,15 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
+import { EditorDraftService } from '@libs-editor';
+import type { FileRenamedEvent } from '@libs-file-manager';
+import { FileTreeFeatureComponent } from '@libs-file-manager';
 import {
   ConsoleShellLayoutMode,
   ConsoleShellStore,
   LEFT_PANE_WIDTH,
   RAIL_WIDTH_PX,
 } from '@libs-shared';
-import { FileTreeFeatureComponent } from '@libs-file-manager';
 
 @Component({
   selector: 'lib-left-sidebar',
@@ -45,17 +47,38 @@ export class LeftSidebarComponent {
   );
 
   readonly shellStore = inject(ConsoleShellStore);
+  private readonly draftService = inject(EditorDraftService);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
 
+  readonly hasUnsavedDraft = (path: string): boolean =>
+    this.draftService.has(path);
+
   onCurrentPathChange(path: string): void {
     this.shellStore.setFileManagerCurrentPath(path);
-    this.shellStore.setSelectedFilePath(null);
   }
 
   onFileSelected(path: string): void {
     this.shellStore.setSelectedFilePath(path);
     void this.router.navigate(['editor'], { relativeTo: this.route });
+  }
+
+  onFileCreated(path: string): void {
+    this.onFileSelected(path);
+  }
+
+  onFileRenamed({ from, to }: FileRenamedEvent): void {
+    this.draftService.rename(from, to);
+    if (this.shellStore.selectedFilePath() === from) {
+      this.shellStore.setSelectedFilePath(to);
+    }
+  }
+
+  onFileDeleted(path: string): void {
+    this.draftService.clear(path);
+    if (this.shellStore.selectedFilePath() === path) {
+      this.shellStore.setSelectedFilePath(null);
+    }
   }
 
   onResizePointerDown(event: PointerEvent): void {

--- a/libs/editor/project.json
+++ b/libs/editor/project.json
@@ -11,7 +11,8 @@
   "implicitDependencies": [
     "libs-shared",
     "libs-web-serial",
-    "libs-dialogs"
+    "libs-dialogs",
+    "libs-file-manager"
   ],
   "targets": {
     "build": {

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.html
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.html
@@ -8,10 +8,12 @@
     "
     [discardDisabled]="!isDirty() || isSaving() || !currentFileName()"
     [formatDisabled]="!currentFileName() || isLoading() || isSaving()"
+    [newFileDisabled]="!isSerialConnected() || isSaving() || isLoading()"
     [isSaving]="isSaving()"
     (saveRequested)="saveCurrentFile()"
     (discardRequested)="discardChanges()"
     (formatRequested)="formatCurrentFile()"
+    (newFileRequested)="createNewFile()"
   />
   <choh-file-name-display
     class="shrink-0"

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -2,6 +2,7 @@
 import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DialogService } from '@libs-dialogs';
+import { FileService } from '@libs-file-manager';
 import { ConsoleShellStore, NotificationService } from '@libs-shared';
 import { SerialFacadeService } from '@libs-web-serial';
 import { provideMonacoEditor } from 'ngx-monaco-editor-v2';
@@ -23,6 +24,7 @@ describe('EditorPageComponent', () => {
   };
   const shellStoreMock = {
     selectedFilePath: () => selectedFilePathSignal(),
+    fileManagerCurrentPath: () => '.',
     setSelectedFilePath: vi.fn((path: string | null) => {
       selectedFilePathSignal.set(path);
     }),
@@ -34,9 +36,14 @@ describe('EditorPageComponent', () => {
     save: vi.fn(),
     clear: vi.fn(),
     clearAll: vi.fn(),
+    rename: vi.fn(),
   };
   const dialogServiceMock = {
     open: vi.fn(),
+  };
+  const fileServiceMock = {
+    exists: vi.fn().mockResolvedValue(false),
+    touch: vi.fn().mockResolvedValue(undefined),
   };
   const serialFacadeMock = {
     isConnected: () => isConnectedSignal(),
@@ -69,7 +76,10 @@ describe('EditorPageComponent', () => {
     isConnectedSignal.set(true);
     draftServiceMock.read.mockReturnValue(null);
     draftServiceMock.list.mockReturnValue([]);
+    draftServiceMock.has.mockReturnValue(false);
     editorServiceMock.loadTextFile.mockResolvedValue('loaded content');
+    fileServiceMock.exists.mockResolvedValue(false);
+    fileServiceMock.touch.mockResolvedValue(undefined);
 
     await TestBed.configureTestingModule({
       imports: [EditorPageComponent],
@@ -79,6 +89,7 @@ describe('EditorPageComponent', () => {
       .overrideProvider(EditorDraftService, { useValue: draftServiceMock })
       .overrideProvider(ConsoleShellStore, { useValue: shellStoreMock })
       .overrideProvider(DialogService, { useValue: dialogServiceMock })
+      .overrideProvider(FileService, { useValue: fileServiceMock })
       .overrideProvider(SerialFacadeService, { useValue: serialFacadeMock })
       .overrideProvider(NotificationService, { useValue: notifyMock })
       .compileComponents();
@@ -458,5 +469,67 @@ describe('EditorPageComponent', () => {
 
     expect(component.isReadOnly()).toBe(false);
     expect(component.lastDeviceSavedAt()).toBeNull();
+  });
+
+  it('should clear the editor when selection becomes null', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
+    expect(component.currentFilePath()).toBe('/home/pi/main.js');
+
+    selectedFilePathSignal.set(null);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.currentFilePath()).toBeNull();
+    expect(component.code()).toBe('');
+    expect(component.saveStatus()).toBeNull();
+  });
+
+  it('should retarget the open path after a draft rename without reloading', async () => {
+    await loadPath('/home/pi/old.js', 'body');
+    component.onCodeChange('dirty body');
+    component.onContentEdited();
+    draftServiceMock.has.mockImplementation(
+      (path: string) => path === '/home/pi/new.js',
+    );
+    draftServiceMock.read.mockImplementation((path: string) =>
+      path === '/home/pi/new.js'
+        ? { path, content: 'dirty body', updatedAt: 1 }
+        : null,
+    );
+    editorServiceMock.loadTextFile.mockClear();
+
+    selectedFilePathSignal.set('/home/pi/new.js');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(component.currentFilePath()).toBe('/home/pi/new.js');
+    expect(component.code()).toBe('dirty body');
+    expect(editorServiceMock.loadTextFile).not.toHaveBeenCalled();
+  });
+
+  it('should create a new file from the toolbar and open it', async () => {
+    const closed = mockDialogResult('created.js');
+    const createPromise = component.createNewFile();
+    closed.next('created.js');
+    closed.complete();
+    await createPromise;
+
+    expect(fileServiceMock.exists).toHaveBeenCalledWith('./created.js');
+    expect(fileServiceMock.touch).toHaveBeenCalledWith('./created.js');
+    expect(shellStoreMock.setSelectedFilePath).toHaveBeenCalledWith(
+      './created.js',
+    );
+  });
+
+  it('should not create a file when the destination already exists', async () => {
+    fileServiceMock.exists.mockResolvedValueOnce(true);
+    const closed = mockDialogResult('dup.js');
+    const createPromise = component.createNewFile();
+    closed.next('dup.js');
+    closed.complete();
+    await createPromise;
+
+    expect(fileServiceMock.touch).not.toHaveBeenCalled();
+    expect(notifyMock.error).toHaveBeenCalled();
   });
 });

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.ts
@@ -9,6 +9,11 @@ import {
 } from '@angular/core';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { ConfirmDialogComponent, DialogService } from '@libs-dialogs';
+import {
+  FileNameDialogComponent,
+  FileService,
+  joinPath,
+} from '@libs-file-manager';
 import { ConsoleShellStore, NotificationService } from '@libs-shared';
 import { SerialFacadeService } from '@libs-web-serial';
 import type { editor } from 'monaco-editor';
@@ -76,6 +81,7 @@ export class EditorPageComponent implements OnInit {
   private draftService = inject(EditorDraftService);
   private shellStore = inject(ConsoleShellStore);
   private dialog = inject(DialogService);
+  private readonly fileService = inject(FileService);
   private readonly serial = inject(SerialFacadeService);
   private readonly notify = inject(NotificationService);
 
@@ -91,11 +97,20 @@ export class EditorPageComponent implements OnInit {
   constructor() {
     effect(() => {
       const selectedPath = this.shellStore.selectedFilePath();
-      if (!this.initialized || !selectedPath) {
+      if (!this.initialized) {
+        return;
+      }
+      if (!selectedPath) {
+        if (this.activeFilePath()) {
+          this.clearOpenFile();
+        }
         return;
       }
       if (this.ignoreNextSelection) {
         this.ignoreNextSelection = false;
+        return;
+      }
+      if (this.tryRetargetAfterRename(selectedPath)) {
         return;
       }
       void this.loadFile(selectedPath);
@@ -142,6 +157,40 @@ export class EditorPageComponent implements OnInit {
       return null;
     }
     return path.split('/').pop() ?? path;
+  }
+
+  /**
+   * After a tree rename, the draft key is moved first and selection updates to
+   * the new path. Keep editor content and only retarget the open path.
+   */
+  private tryRetargetAfterRename(selectedPath: string): boolean {
+    const previousPath = this.activeFilePath();
+    if (!previousPath || previousPath === selectedPath) {
+      return false;
+    }
+    if (this.draftService.has(previousPath)) {
+      return false;
+    }
+    const draft = this.draftService.read(selectedPath);
+    if (!draft || draft.content !== this.code()) {
+      return false;
+    }
+    this.activeFilePath.set(selectedPath);
+    this.loadError.set(null);
+    return true;
+  }
+
+  private clearOpenFile(): void {
+    this.loadGeneration += 1;
+    this.activeFilePath.set(null);
+    this.code.set('');
+    this.baselineContent = '';
+    this.baselineReady = false;
+    this.saveStatus.set(null);
+    this.loadError.set(null);
+    this.saveError.set(null);
+    this.lastDeviceSavedAt.set(null);
+    this.isReadOnly.set(false);
   }
 
   private async loadFile(
@@ -306,6 +355,41 @@ export class EditorPageComponent implements OnInit {
   private revertSelection(): void {
     this.ignoreNextSelection = true;
     this.shellStore.setSelectedFilePath(this.activeFilePath());
+  }
+
+  async createNewFile(): Promise<void> {
+    if (!this.isSerialConnected() || this.isSaving() || this.isLoading()) {
+      return;
+    }
+
+    const parent = this.shellStore.fileManagerCurrentPath();
+    const ref = this.dialog.open(FileNameDialogComponent, {
+      width: '360px',
+      data: {
+        title: '新規ファイル',
+        confirmLabel: '作成',
+        label: 'ファイル名',
+        description: `作成先: ${parent}`,
+      },
+    });
+    const result = await firstValueFrom(ref.closed);
+    if (typeof result !== 'string' || !result) {
+      return;
+    }
+
+    const path = joinPath(parent, result);
+    try {
+      if (await this.fileService.exists(path)) {
+        this.notify.error('New File', `「${result}」は既に存在します`);
+        return;
+      }
+      await this.fileService.touch(path);
+      this.shellStore.setSelectedFilePath(path);
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to create file';
+      this.notify.error('New File', message);
+    }
   }
 
   async saveCurrentFile(): Promise<void> {

--- a/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.html
+++ b/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.html
@@ -7,6 +7,18 @@
     mat-button
     type="button"
     class="editor-toolbar__button"
+    [disabled]="newFileDisabled()"
+    [matTooltip]="newFileTooltip"
+    [attr.aria-label]="newFileTooltip"
+    (click)="newFileRequested.emit()"
+  >
+    New File
+  </button>
+
+  <button
+    mat-button
+    type="button"
+    class="editor-toolbar__button"
     [disabled]="saveDisabled()"
     [matTooltip]="saveTooltip()"
     [attr.aria-label]="saveTooltip()"

--- a/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.spec.ts
@@ -25,10 +25,18 @@ describe('EditorToolbarComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should emit newFileRequested when new file button is clicked', () => {
+    const emitSpy = vi.spyOn(component.newFileRequested, 'emit');
+
+    buttons()[0].click();
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('should emit saveRequested when save button is clicked', () => {
     const emitSpy = vi.spyOn(component.saveRequested, 'emit');
 
-    buttons()[0].click();
+    buttons()[1].click();
 
     expect(emitSpy).toHaveBeenCalledTimes(1);
   });
@@ -40,7 +48,7 @@ describe('EditorToolbarComponent', () => {
 
     const emitSpy = vi.spyOn(component.formatRequested, 'emit');
 
-    buttons()[1].click();
+    buttons()[2].click();
 
     expect(emitSpy).toHaveBeenCalledTimes(1);
   });
@@ -52,7 +60,7 @@ describe('EditorToolbarComponent', () => {
 
     const emitSpy = vi.spyOn(component.discardRequested, 'emit');
 
-    buttons()[2].click();
+    buttons()[3].click();
 
     expect(emitSpy).toHaveBeenCalledTimes(1);
   });
@@ -62,7 +70,7 @@ describe('EditorToolbarComponent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(buttons()[0].disabled).toBe(true);
+    expect(buttons()[1].disabled).toBe(true);
   });
 
   it('should disable format button when formatDisabled is true', async () => {
@@ -70,12 +78,13 @@ describe('EditorToolbarComponent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(buttons()[1].disabled).toBe(true);
+    expect(buttons()[2].disabled).toBe(true);
   });
 
   it('should set aria-label from tooltips', () => {
-    const [save, format, discard] = Array.from(buttons());
+    const [newFile, save, format, discard] = Array.from(buttons());
 
+    expect(newFile.getAttribute('aria-label')).toBe(component.newFileTooltip);
     expect(save.getAttribute('aria-label')).toBe(component.saveTooltip());
     expect(format.getAttribute('aria-label')).toBe(component.formatTooltip());
     expect(discard.getAttribute('aria-label')).toBe(component.discardTooltip);

--- a/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.ts
+++ b/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.ts
@@ -22,11 +22,13 @@ export class EditorToolbarComponent {
   saveDisabled = input(false);
   discardDisabled = input(true);
   formatDisabled = input(true);
+  newFileDisabled = input(false);
   isSaving = input(false);
 
   saveRequested = output<void>();
   discardRequested = output<void>();
   formatRequested = output<void>();
+  newFileRequested = output<void>();
 
   private readonly applePlatform = isApplePlatform();
 
@@ -41,4 +43,5 @@ export class EditorToolbarComponent {
   );
 
   readonly discardTooltip = 'Discard local changes';
+  readonly newFileTooltip = 'New file';
 }

--- a/libs/editor/src/lib/service/editor-draft.service.spec.ts
+++ b/libs/editor/src/lib/service/editor-draft.service.spec.ts
@@ -64,6 +64,27 @@ describe('EditorDraftService', () => {
     expect(service.read('/home/pi/b.js')?.content).toBe('b');
   });
 
+  it('renames a draft key without changing content', () => {
+    const service = createService();
+    service.save('/home/pi/old.js', 'body');
+
+    service.rename('/home/pi/old.js', '/home/pi/new.js');
+
+    expect(service.read('/home/pi/old.js')).toBeNull();
+    expect(service.read('/home/pi/new.js')?.content).toBe('body');
+  });
+
+  it('does not overwrite an existing draft at the destination', () => {
+    const service = createService();
+    service.save('/home/pi/old.js', 'old');
+    service.save('/home/pi/new.js', 'new');
+
+    service.rename('/home/pi/old.js', '/home/pi/new.js');
+
+    expect(service.read('/home/pi/old.js')?.content).toBe('old');
+    expect(service.read('/home/pi/new.js')?.content).toBe('new');
+  });
+
   it('clears all drafts', () => {
     const service = createService();
     service.save('/home/pi/a.js', 'a');

--- a/libs/editor/src/lib/service/editor-draft.service.ts
+++ b/libs/editor/src/lib/service/editor-draft.service.ts
@@ -71,6 +71,28 @@ export class EditorDraftService {
     this.writeMap(map);
   }
 
+  /**
+   * Moves a draft from one path key to another.
+   * No-op when `from` has no draft or paths are equal.
+   * Does not overwrite an existing draft at `to`.
+   */
+  rename(from: string, to: string): void {
+    if (!from || !to || from === to) {
+      return;
+    }
+    const map = this.readMap();
+    const entry = map[from];
+    if (!entry) {
+      return;
+    }
+    if (to in map) {
+      return;
+    }
+    map[to] = entry;
+    delete map[from];
+    this.writeMap(map);
+  }
+
   clearAll(): void {
     try {
       this.storage.removeItem(EDITOR_DRAFT_STORAGE_KEY);

--- a/libs/editor/src/lib/service/editor-draft.service.ts
+++ b/libs/editor/src/lib/service/editor-draft.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, InjectionToken, inject } from '@angular/core';
+import type { EditorDraftLifecycle } from '@libs-shared';
 
 export interface EditorDraftEntry {
   content: string;
@@ -27,7 +28,7 @@ export const EDITOR_DRAFT_STORAGE = new InjectionToken<Storage>(
 @Injectable({
   providedIn: 'root',
 })
-export class EditorDraftService {
+export class EditorDraftService implements EditorDraftLifecycle {
   private readonly storage = inject(EDITOR_DRAFT_STORAGE);
 
   read(path: string): EditorDraft | null {

--- a/libs/file-manager/src/lib/component/file-name-dialog/file-name-dialog.component.html
+++ b/libs/file-manager/src/lib/component/file-name-dialog/file-name-dialog.component.html
@@ -2,6 +2,9 @@
   class="flex min-w-[280px] flex-col gap-4 rounded-lg bg-white p-4 text-gray-900 shadow-lg"
 >
   <h2 class="m-0 text-lg font-medium">{{ title }}</h2>
+  @if (description) {
+    <p class="m-0 text-sm text-gray-600 break-all">{{ description }}</p>
+  }
   <form
     class="flex flex-col gap-3"
     (ngSubmit)="$event.preventDefault(); submit()"

--- a/libs/file-manager/src/lib/component/file-name-dialog/file-name-dialog.component.ts
+++ b/libs/file-manager/src/lib/component/file-name-dialog/file-name-dialog.component.ts
@@ -22,12 +22,14 @@ export class FileNameDialogComponent implements OnInit {
   title = '名前を入力';
   confirmLabel = 'OK';
   label = '名前';
+  description: string | null = null;
   readonly validationError = signal<string | null>(null);
 
   ngOnInit(): void {
     this.title = this.data?.title?.trim() || this.title;
     this.confirmLabel = this.data?.confirmLabel?.trim() || this.confirmLabel;
     this.label = this.data?.label?.trim() || this.label;
+    this.description = this.data?.description?.trim() || null;
     this.name = this.data?.initialValue ?? '';
   }
 

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
@@ -425,6 +425,73 @@ describe('FileTreeFeatureComponent', () => {
     expect(moveMock).not.toHaveBeenCalled();
   });
 
+  it('emits fileCreated after creating a file', async () => {
+    dialogOpen.mockReturnValue({ closed: of('root.txt') });
+    const fixture = await compileAndCreate();
+    await connectReady(fixture);
+    fixture.componentInstance.onBackgroundContextMenu(
+      new MouseEvent('contextmenu', {
+        bubbles: true,
+        cancelable: true,
+        clientX: 3,
+        clientY: 4,
+      }),
+    );
+    const createdSpy = vi.spyOn(fixture.componentInstance.fileCreated, 'emit');
+
+    fixture.componentInstance.onMenuAction('new-file');
+    await vi.waitFor(() => {
+      expect(createdSpy).toHaveBeenCalledWith('./root.txt');
+    });
+  });
+
+  it('emits fileRenamed after renaming a node', async () => {
+    dialogOpen.mockReturnValue({ closed: of('app.ts') });
+    const fixture = await compileAndCreate();
+    await connectReady(fixture);
+    fixture.componentInstance.contextTarget = treeNodes[1];
+    const renamedSpy = vi.spyOn(fixture.componentInstance.fileRenamed, 'emit');
+
+    fixture.componentInstance.onMenuAction('rename');
+    await vi.waitFor(() => {
+      expect(renamedSpy).toHaveBeenCalledWith({
+        from: './main.ts',
+        to: './app.ts',
+      });
+    });
+  });
+
+  it('emits fileDeleted after deleting a node', async () => {
+    dialogOpen.mockReturnValue({ closed: of(true) });
+    const fixture = await compileAndCreate();
+    await connectReady(fixture);
+    const deletedSpy = vi.spyOn(fixture.componentInstance.fileDeleted, 'emit');
+
+    fixture.componentInstance.onMenuAction('delete');
+    await vi.waitFor(() => {
+      expect(deletedSpy).toHaveBeenCalledWith('./docs');
+    });
+  });
+
+  it('warns about unsaved drafts in the delete confirm message', async () => {
+    dialogOpen.mockReturnValue({ closed: of(false) });
+    const fixture = await compileAndCreate();
+    fixture.componentRef.setInput('pathsWithUnsavedDrafts', ['./docs']);
+    await connectReady(fixture);
+
+    fixture.componentInstance.onMenuAction('delete');
+    await fixture.whenStable();
+
+    expect(dialogOpen).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        data: expect.objectContaining({
+          message: '「docs」には未保存の変更があります。削除しますか？',
+        }),
+      }),
+    );
+  });
+
   it('deletes a directory recursively after confirm', async () => {
     dialogOpen.mockReturnValue({ closed: of(true) });
     const fixture = await compileAndCreate();

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
@@ -19,6 +19,7 @@ describe('FileTreeFeatureComponent', () => {
   const moveMock = vi.fn<() => Promise<void>>();
   const removeMock = vi.fn<() => Promise<void>>();
   const existsMock = vi.fn<() => Promise<boolean>>();
+  const hasUnsavedDraftMock = vi.fn<(path: string) => boolean>();
   const dialogOpen = vi.fn();
   let vmSignal: ReturnType<typeof signal<SerialConnectionViewModel>>;
 
@@ -100,6 +101,8 @@ describe('FileTreeFeatureComponent', () => {
     removeMock.mockResolvedValue(undefined);
     existsMock.mockReset();
     existsMock.mockResolvedValue(false);
+    hasUnsavedDraftMock.mockReset();
+    hasUnsavedDraftMock.mockReturnValue(false);
     dialogOpen.mockReset();
   });
 
@@ -475,8 +478,9 @@ describe('FileTreeFeatureComponent', () => {
 
   it('warns about unsaved drafts in the delete confirm message', async () => {
     dialogOpen.mockReturnValue({ closed: of(false) });
+    hasUnsavedDraftMock.mockReturnValue(true);
     const fixture = await compileAndCreate();
-    fixture.componentRef.setInput('pathsWithUnsavedDrafts', ['./docs']);
+    fixture.componentRef.setInput('hasUnsavedDraft', hasUnsavedDraftMock);
     await connectReady(fixture);
 
     fixture.componentInstance.onMenuAction('delete');

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
@@ -18,6 +18,7 @@ describe('FileTreeFeatureComponent', () => {
   const mkdirMock = vi.fn<() => Promise<void>>();
   const moveMock = vi.fn<() => Promise<void>>();
   const removeMock = vi.fn<() => Promise<void>>();
+  const existsMock = vi.fn<() => Promise<boolean>>();
   const dialogOpen = vi.fn();
   let vmSignal: ReturnType<typeof signal<SerialConnectionViewModel>>;
 
@@ -52,6 +53,7 @@ describe('FileTreeFeatureComponent', () => {
             mkdir: mkdirMock,
             move: moveMock,
             remove: removeMock,
+            exists: existsMock,
           },
         },
         {
@@ -96,6 +98,8 @@ describe('FileTreeFeatureComponent', () => {
     moveMock.mockResolvedValue(undefined);
     removeMock.mockReset();
     removeMock.mockResolvedValue(undefined);
+    existsMock.mockReset();
+    existsMock.mockResolvedValue(false);
     dialogOpen.mockReset();
   });
 
@@ -387,6 +391,38 @@ describe('FileTreeFeatureComponent', () => {
     await vi.waitFor(() => {
       expect(moveMock).toHaveBeenCalledWith('./main.ts', './app.ts');
     });
+  });
+
+  it('does not create a file when the path already exists', async () => {
+    dialogOpen.mockReturnValue({ closed: of('main.ts') });
+    existsMock.mockResolvedValue(true);
+    const fixture = await compileAndCreate();
+    await connectReady(fixture);
+    fixture.componentInstance.contextTarget = treeNodes[1];
+
+    fixture.componentInstance.onMenuAction('new-file');
+    await vi.waitFor(() => {
+      expect(fixture.componentInstance.errorMessage).toBe(
+        '「main.ts」は既に存在します',
+      );
+    });
+    expect(touchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not rename when the destination already exists', async () => {
+    dialogOpen.mockReturnValue({ closed: of('docs') });
+    existsMock.mockResolvedValue(true);
+    const fixture = await compileAndCreate();
+    await connectReady(fixture);
+    fixture.componentInstance.contextTarget = treeNodes[1];
+
+    fixture.componentInstance.onMenuAction('rename');
+    await vi.waitFor(() => {
+      expect(fixture.componentInstance.errorMessage).toBe(
+        '「docs」は既に存在します',
+      );
+    });
+    expect(moveMock).not.toHaveBeenCalled();
   });
 
   it('deletes a directory recursively after confirm', async () => {

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
@@ -224,7 +224,11 @@ export class FileTreeFeatureComponent {
       return;
     }
     const parent = this.createParentPath(target);
-    await this.file.touch(joinPath(parent, name));
+    const path = joinPath(parent, name);
+    if (await this.file.exists(path)) {
+      throw new Error(`「${name}」は既に存在します`);
+    }
+    await this.file.touch(path);
     await this.refreshAfterCreate(parent);
   }
 
@@ -272,6 +276,9 @@ export class FileTreeFeatureComponent {
       return;
     }
     const destination = joinPath(parentPathOf(target.path), name);
+    if (await this.file.exists(destination)) {
+      throw new Error(`「${name}」は既に存在します`);
+    }
     await this.file.move(target.path, destination);
     await this.reload();
   }

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
@@ -45,8 +45,10 @@ export class FileTreeFeatureComponent {
   readonly currentPath = input<string>('.');
   /** Currently open file path for tree highlight (issue #805). */
   readonly selectedPath = input<string | null>(null);
-  /** Paths that currently have an unsaved editor draft (issue #810). */
-  readonly pathsWithUnsavedDrafts = input<readonly string[]>([]);
+  /** Returns true when the path has an unsaved editor draft (issue #810). */
+  readonly hasUnsavedDraft = input<(path: string) => boolean>(
+    (_path: string) => false,
+  );
   readonly currentPathChange = output<string>();
   readonly fileSelected = output<string>();
   readonly fileCreated = output<string>();
@@ -317,7 +319,7 @@ export class FileTreeFeatureComponent {
   }
 
   private async confirmDelete(target: FileTreeNode): Promise<boolean> {
-    const hasUnsavedDraft = this.pathsWithUnsavedDrafts().includes(target.path);
+    const hasUnsavedDraft = this.hasUnsavedDraft()(target.path);
     const message = hasUnsavedDraft
       ? `「${target.name}」には未保存の変更があります。削除しますか？`
       : `「${target.name}」を削除しますか？`;

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
@@ -14,6 +14,7 @@ import { SerialConnectionViewModelFacade } from '@libs-web-serial';
 import { firstValueFrom } from 'rxjs';
 import { joinPath, parentPathOf } from '../../functions';
 import type { FileContextMenuAction } from '../../models/file-context-menu.types';
+import type { FileRenamedEvent } from '../../models/file-lifecycle.types';
 import type { FileNameDialogData } from '../../models/file-name-dialog.types';
 import { FileTreeNode } from '../../models';
 import { FileService } from '../../service';
@@ -44,8 +45,13 @@ export class FileTreeFeatureComponent {
   readonly currentPath = input<string>('.');
   /** Currently open file path for tree highlight (issue #805). */
   readonly selectedPath = input<string | null>(null);
+  /** Paths that currently have an unsaved editor draft (issue #810). */
+  readonly pathsWithUnsavedDrafts = input<readonly string[]>([]);
   readonly currentPathChange = output<string>();
   readonly fileSelected = output<string>();
+  readonly fileCreated = output<string>();
+  readonly fileRenamed = output<FileRenamedEvent>();
+  readonly fileDeleted = output<string>();
 
   nodes: FileTreeNode[] = [];
   loading = false;
@@ -215,21 +221,23 @@ export class FileTreeFeatureComponent {
   }
 
   private async createFile(target: FileTreeNode): Promise<void> {
+    const parent = this.createParentPath(target);
     const name = await this.promptName({
       title: '新規ファイル',
       confirmLabel: '作成',
       label: 'ファイル名',
+      description: `作成先: ${parent}`,
     });
     if (!name) {
       return;
     }
-    const parent = this.createParentPath(target);
     const path = joinPath(parent, name);
     if (await this.file.exists(path)) {
       throw new Error(`「${name}」は既に存在します`);
     }
     await this.file.touch(path);
     await this.refreshAfterCreate(parent);
+    this.fileCreated.emit(path);
   }
 
   private async createDirectory(target: FileTreeNode): Promise<void> {
@@ -271,6 +279,7 @@ export class FileTreeFeatureComponent {
       initialValue: target.name,
       confirmLabel: '変更',
       label: '新しい名前',
+      description: `変更前: ${target.path}`,
     });
     if (!name || name === target.name) {
       return;
@@ -281,10 +290,11 @@ export class FileTreeFeatureComponent {
     }
     await this.file.move(target.path, destination);
     await this.reload();
+    this.fileRenamed.emit({ from: target.path, to: destination });
   }
 
   private async deleteNode(target: FileTreeNode): Promise<void> {
-    const confirmed = await this.confirmDelete(target.name);
+    const confirmed = await this.confirmDelete(target);
     if (!confirmed) {
       return;
     }
@@ -292,6 +302,7 @@ export class FileTreeFeatureComponent {
       recursive: target.isDirectory,
     });
     await this.reload();
+    this.fileDeleted.emit(target.path);
   }
 
   private async promptName(
@@ -305,12 +316,16 @@ export class FileTreeFeatureComponent {
     return typeof result === 'string' ? result : null;
   }
 
-  private async confirmDelete(name: string): Promise<boolean> {
+  private async confirmDelete(target: FileTreeNode): Promise<boolean> {
+    const hasUnsavedDraft = this.pathsWithUnsavedDrafts().includes(target.path);
+    const message = hasUnsavedDraft
+      ? `「${target.name}」には未保存の変更があります。削除しますか？`
+      : `「${target.name}」を削除しますか？`;
     const ref = this.dialog.open(ConfirmDialogComponent, {
       width: '400px',
       data: {
         title: '削除の確認',
-        message: `「${name}」を削除しますか？`,
+        message,
         confirmLabel: '削除',
         cancelLabel: 'キャンセル',
       },

--- a/libs/file-manager/src/lib/models/file-lifecycle.types.ts
+++ b/libs/file-manager/src/lib/models/file-lifecycle.types.ts
@@ -1,0 +1,4 @@
+export interface FileRenamedEvent {
+  from: string;
+  to: string;
+}

--- a/libs/file-manager/src/lib/models/file-name-dialog.types.ts
+++ b/libs/file-manager/src/lib/models/file-name-dialog.types.ts
@@ -3,4 +3,6 @@ export interface FileNameDialogData {
   initialValue?: string;
   confirmLabel?: string;
   label?: string;
+  /** Optional hint shown under the title (e.g. current path before rename). */
+  description?: string;
 }

--- a/libs/file-manager/src/lib/models/index.ts
+++ b/libs/file-manager/src/lib/models/index.ts
@@ -1,3 +1,4 @@
 export * from './file-context-menu.types';
+export * from './file-lifecycle.types';
 export * from './file-name-dialog.types';
 export * from './file-tree.model';

--- a/libs/file-manager/src/lib/service/file.service.spec.ts
+++ b/libs/file-manager/src/lib/service/file.service.spec.ts
@@ -142,6 +142,22 @@ describe('FileService', () => {
     });
   });
 
+  describe('exists', () => {
+    it('returns true when stdout contains __EXISTS__', async () => {
+      exec.mockResolvedValue({ stdout: '__EXISTS__\n' });
+      await expect(svc.exists('./file.txt')).resolves.toBe(true);
+      expect(exec).toHaveBeenCalledWith(
+        `if test -e -- ${FileUtils.escapePath('./file.txt')}; then echo __EXISTS__; else echo __MISSING__; fi`,
+        expect.objectContaining({ timeout: SERIAL_TIMEOUT.DEFAULT }),
+      );
+    });
+
+    it('returns false when stdout contains __MISSING__', async () => {
+      exec.mockResolvedValue({ stdout: '__MISSING__\n' });
+      await expect(svc.exists('./missing.txt')).resolves.toBe(false);
+    });
+  });
+
   describe('remove', () => {
     it('runs rm with escaped path', async () => {
       await svc.remove('./old.txt');

--- a/libs/file-manager/src/lib/service/file.service.ts
+++ b/libs/file-manager/src/lib/service/file.service.ts
@@ -73,6 +73,26 @@ export class FileService {
     );
   }
 
+  /**
+   * Returns whether a path exists on the device.
+   * Uses `test -e` with stdout markers because serial exec may not expose exit codes.
+   */
+  async exists(path: string): Promise<boolean> {
+    const escaped = FileUtils.escapePath(path);
+    const command = `if test -e -- ${escaped}; then echo __EXISTS__; else echo __MISSING__; fi`;
+    const stdout = (
+      await firstValueFrom(
+        this.serial.exec$(command, this.shellExecOptions()),
+      )
+    ).stdout;
+    const cleaned = sanitizeSerialStdout(
+      typeof stdout === 'string' ? stdout : '',
+      command,
+      '',
+    );
+    return cleaned.split('\n').some((line) => line.trim() === '__EXISTS__');
+  }
+
   async remove(
     path: string,
     options?: { recursive?: boolean },

--- a/libs/shared/src/lib/service/editor-draft-lifecycle.ts
+++ b/libs/shared/src/lib/service/editor-draft-lifecycle.ts
@@ -1,0 +1,15 @@
+import { InjectionToken } from '@angular/core';
+
+/**
+ * Minimal draft lifecycle API used by shell / file-tree without importing
+ * the lazy-loaded editor library (issue #810).
+ */
+export interface EditorDraftLifecycle {
+  has(path: string): boolean;
+  rename(from: string, to: string): void;
+  clear(path: string): void;
+}
+
+export const EDITOR_DRAFT_LIFECYCLE = new InjectionToken<EditorDraftLifecycle>(
+  'EDITOR_DRAFT_LIFECYCLE',
+);

--- a/libs/shared/src/lib/service/index.ts
+++ b/libs/shared/src/lib/service/index.ts
@@ -1,2 +1,3 @@
 export * from './console-shell.store';
+export * from './editor-draft-lifecycle';
 export * from './notification.service';


### PR DESCRIPTION
## Summary

ファイルツリーおよび Editor Toolbar から、CHIRIMEN Lite 上のファイルの新規作成・名称変更・削除を安全に行えるようにしました。作成後の Editor オープン、改名時の Draft / 選択パス移行、削除時の未保存警告と Editor クローズを含め、ツリーと Editor の状態を同期します。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #810
- Refs #804

## What changed?

- `FileService.exists` を追加し、作成・改名前に同名パスがあればエラーで中止（上書きしない）
- ファイルツリー操作後に `fileCreated` / `fileRenamed` / `fileDeleted` を emit
- `LeftSidebar` で `ConsoleShellStore` と `EditorDraftService` を同期
- `EditorDraftService.rename` と Editor の clear / retarget を追加
- Editor Toolbar に New File を追加
- 改名ダイアログに変更前パス、削除確認に未保存警告を表示

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. デバイス接続後、ファイルツリーのコンテキストメニューから `.js` を新規作成し、Editor で開くことを確認する
2. 開いているファイルを名称変更し、パス表示・未保存 Draft が新パスへ移ることを確認する
3. 同名ファイルへの作成・改名がエラーになり、上書きされないことを確認する
4. 未保存のファイルを削除するとき警告が出ること、削除後に Editor が閉じることを確認する
5. Toolbar の New File からも同様に作成・オープンできることを確認する
6. `pnpm nx run-many -t test -p libs-file-manager,libs-editor` が通ることを確認する

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)