### PR TITLE
fix(editor): make editor and side panels responsive

### DIFF
--- a/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.html
+++ b/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.html
@@ -4,6 +4,7 @@
   @if (leftNavOpen()) {
     @if (isOverlay()) {
       <div
+        id="console-shell-left-pane"
         class="absolute top-0 bottom-0 left-full z-40 flex min-h-0 min-w-0 flex-col overflow-hidden border-r border-gray-200 bg-white shadow-lg"
         [style.width]="overlayWidth()"
       >
@@ -28,6 +29,7 @@
       </div>
     } @else {
       <div
+        id="console-shell-left-pane"
         class="flex min-h-0 min-w-0 flex-col overflow-hidden bg-white"
         [style.width.px]="treeWidthPx()"
       >
@@ -52,6 +54,8 @@
       type="button"
       [matTooltip]="panelToggleLabel()"
       [attr.aria-label]="panelToggleLabel()"
+      [attr.aria-expanded]="leftNavOpen()"
+      aria-controls="console-shell-left-pane"
       (click)="toggleLeftSidebar.emit()"
     >
       <mat-icon>folder</mat-icon>
@@ -61,6 +65,8 @@
       type="button"
       [matTooltip]="panelToggleLabel()"
       [attr.aria-label]="panelToggleLabel()"
+      [attr.aria-expanded]="leftNavOpen()"
+      aria-controls="console-shell-left-pane"
       (click)="toggleLeftSidebar.emit()"
     >
       <mat-icon>

--- a/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.spec.ts
+++ b/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.spec.ts
@@ -172,6 +172,7 @@ describe('LeftSidebarComponent', () => {
     expect(openButton.injector.get(MatTooltip).message).toBe(
       'ファイツリー閉じる',
     );
+    expect(openButton.attributes['aria-expanded']).toBe('true');
 
     fixture.componentRef.setInput('leftNavOpen', false);
     fixture.detectChanges();
@@ -183,5 +184,6 @@ describe('LeftSidebarComponent', () => {
     expect(closedButton.injector.get(MatTooltip).message).toBe(
       'ファイツリー開く',
     );
+    expect(closedButton.attributes['aria-expanded']).toBe('false');
   });
 });

--- a/libs/console-shell/src/lib/component/right-sidebar/right-sidebar.component.html
+++ b/libs/console-shell/src/lib/component/right-sidebar/right-sidebar.component.html
@@ -9,6 +9,8 @@
       type="button"
       [matTooltip]="panelToggleLabel()"
       [attr.aria-label]="panelToggleLabel()"
+      [attr.aria-expanded]="rightNavOpen()"
+      aria-controls="console-shell-right-pane"
       (click)="toggleRightSidebar.emit()"
     >
       <mat-icon>fiber_pin</mat-icon>
@@ -18,6 +20,8 @@
       type="button"
       [matTooltip]="panelToggleLabel()"
       [attr.aria-label]="panelToggleLabel()"
+      [attr.aria-expanded]="rightNavOpen()"
+      aria-controls="console-shell-right-pane"
       (click)="toggleRightSidebar.emit()"
     >
       <mat-icon>
@@ -42,6 +46,7 @@
   @if (rightNavOpen()) {
     @if (isOverlay()) {
       <div
+        id="console-shell-right-pane"
         class="absolute top-0 right-full bottom-0 z-40 flex min-h-0 min-w-0 flex-col overflow-hidden border-l border-gray-200 bg-white shadow-lg"
         [style.width]="overlayWidth()"
       >
@@ -57,6 +62,7 @@
       </div>
     } @else {
       <div
+        id="console-shell-right-pane"
         class="flex min-h-0 min-w-0 flex-col overflow-hidden bg-white"
         [style.width.px]="diagramWidthPx()"
       >

--- a/libs/console-shell/src/lib/component/right-sidebar/right-sidebar.component.spec.ts
+++ b/libs/console-shell/src/lib/component/right-sidebar/right-sidebar.component.spec.ts
@@ -57,6 +57,7 @@ describe('RightSidebarComponent', () => {
     );
     expect(openButton).not.toBeNull();
     expect(openButton.injector.get(MatTooltip).message).toBe('ピン配置閉じる');
+    expect(openButton.attributes['aria-expanded']).toBe('true');
 
     fixture.componentRef.setInput('rightNavOpen', false);
     fixture.detectChanges();
@@ -66,5 +67,6 @@ describe('RightSidebarComponent', () => {
     );
     expect(closedButton).not.toBeNull();
     expect(closedButton.injector.get(MatTooltip).message).toBe('ピン配置開く');
+    expect(closedButton.attributes['aria-expanded']).toBe('false');
   });
 });

--- a/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.html
+++ b/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.html
@@ -1,12 +1,12 @@
 <div
-  class="editor-toolbar flex flex-wrap items-center gap-2 border-b border-gray-200 px-3 py-2"
+  class="editor-toolbar flex min-w-0 flex-wrap items-center gap-2 overflow-x-auto border-b border-gray-200 px-3 py-2"
   role="toolbar"
   aria-label="Editor actions"
 >
   <button
     mat-button
     type="button"
-    class="editor-toolbar__button"
+    class="editor-toolbar__button shrink-0"
     [disabled]="newFileDisabled()"
     [matTooltip]="newFileTooltip"
     [attr.aria-label]="newFileTooltip"
@@ -18,7 +18,7 @@
   <button
     mat-button
     type="button"
-    class="editor-toolbar__button"
+    class="editor-toolbar__button shrink-0"
     [disabled]="saveDisabled()"
     [matTooltip]="saveTooltip()"
     [attr.aria-label]="saveTooltip()"
@@ -38,7 +38,7 @@
   <button
     mat-button
     type="button"
-    class="editor-toolbar__button"
+    class="editor-toolbar__button shrink-0"
     [disabled]="formatDisabled()"
     [matTooltip]="formatTooltip()"
     [attr.aria-label]="formatTooltip()"
@@ -50,7 +50,7 @@
   <button
     mat-button
     type="button"
-    class="editor-toolbar__button"
+    class="editor-toolbar__button shrink-0"
     [disabled]="discardDisabled()"
     [matTooltip]="discardTooltip"
     [attr.aria-label]="discardTooltip"

--- a/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.ts
+++ b/libs/editor/src/lib/component/editor-toolbar/editor-toolbar.component.ts
@@ -17,6 +17,9 @@ const isApplePlatform = (): boolean => {
   imports: [MatButtonModule, MatTooltip, MatProgressSpinner],
   templateUrl: './editor-toolbar.component.html',
   styleUrl: './editor-toolbar.component.css',
+  host: {
+    class: 'block min-w-0',
+  },
 })
 export class EditorToolbarComponent {
   saveDisabled = input(false);

--- a/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.html
+++ b/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.html
@@ -1,4 +1,7 @@
-<div class="flex h-full min-h-0 min-w-0 flex-col">
+<div
+  #monacoHost
+  class="flex h-full min-h-0 min-w-0 flex-col"
+>
   <ngx-monaco-editor
     class="block min-h-0 min-w-0 flex-1"
     [options]="editorOptions()"

--- a/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.spec.ts
+++ b/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.spec.ts
@@ -1,13 +1,33 @@
 /// <reference types="vitest/globals" />
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideMonacoEditor } from 'ngx-monaco-editor-v2';
+import type { editor } from 'monaco-editor';
 import { MonacoEditorComponent } from './monaco-editor.component';
 
 describe('MonacoEditorComponent', () => {
   let component: MonacoEditorComponent;
   let fixture: ComponentFixture<MonacoEditorComponent>;
+  let resizeCallback: ResizeObserverCallback | undefined;
+  let observeSpy: ReturnType<typeof vi.fn>;
+  let disconnectSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
+    observeSpy = vi.fn();
+    disconnectSpy = vi.fn();
+    resizeCallback = undefined;
+
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        constructor(callback: ResizeObserverCallback) {
+          resizeCallback = callback;
+        }
+        observe = observeSpy;
+        unobserve = vi.fn();
+        disconnect = disconnectSpy;
+      },
+    );
+
     await TestBed.configureTestingModule({
       imports: [MonacoEditorComponent],
       providers: [provideMonacoEditor({})],
@@ -18,7 +38,48 @@ describe('MonacoEditorComponent', () => {
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should call layout when the container resizes', () => {
+    const layout = vi.fn();
+    const editorInstance = {
+      layout,
+      updateOptions: vi.fn(),
+      getModel: () => null,
+      onDidChangeModelContent: vi.fn(),
+    } as unknown as editor.IStandaloneCodeEditor;
+
+    component.onEditorInit(editorInstance);
+
+    expect(observeSpy).toHaveBeenCalled();
+    expect(layout).toHaveBeenCalled();
+
+    layout.mockClear();
+    resizeCallback?.(
+      [] as unknown as ResizeObserverEntry[],
+      {} as ResizeObserver,
+    );
+    expect(layout).toHaveBeenCalledTimes(1);
+  });
+
+  it('should disconnect ResizeObserver on destroy', () => {
+    const layout = vi.fn();
+    const editorInstance = {
+      layout,
+      updateOptions: vi.fn(),
+      getModel: () => null,
+      onDidChangeModelContent: vi.fn(),
+    } as unknown as editor.IStandaloneCodeEditor;
+
+    component.onEditorInit(editorInstance);
+    fixture.destroy();
+
+    expect(disconnectSpy).toHaveBeenCalled();
   });
 });

--- a/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.ts
+++ b/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.ts
@@ -1,10 +1,14 @@
 import {
   Component,
+  DestroyRef,
+  ElementRef,
   effect,
+  inject,
   output,
   input,
   model,
   untracked,
+  viewChild,
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
@@ -30,8 +34,17 @@ declare const monaco: {
   selector: 'choh-monaco-editor',
   imports: [FormsModule, MonacoEditorModule],
   templateUrl: './monaco-editor.component.html',
+  host: {
+    class: 'block h-full min-h-0 min-w-0',
+  },
 })
 export class MonacoEditorComponent {
+  private readonly destroyRef = inject(DestroyRef);
+
+  private readonly hostRef = viewChild.required<ElementRef<HTMLElement>>(
+    'monacoHost',
+  );
+
   code = model<string>('');
   contentEdited = output<void>();
   editorInitialized = output<editor.IStandaloneCodeEditor>();
@@ -44,6 +57,7 @@ export class MonacoEditorComponent {
   });
 
   private editorInstance: editor.IStandaloneCodeEditor | null = null;
+  private resizeObserver?: ResizeObserver;
 
   constructor() {
     effect(() => {
@@ -54,18 +68,46 @@ export class MonacoEditorComponent {
       }
       this.applyEditorOptions(instance, options);
     });
+
+    this.destroyRef.onDestroy(() => this.teardownResizeObserver());
   }
 
   onEditorInit(editorInstance: editor.IStandaloneCodeEditor): void {
     this.editorInstance = editorInstance;
     this.applyEditorOptions(editorInstance, this.editorOptions());
     this.editorInitialized.emit(editorInstance);
+    this.observeContainerResize(editorInstance);
     editorInstance.onDidChangeModelContent((event) => {
       if (event.isFlush) {
         return;
       }
       this.contentEdited.emit();
     });
+  }
+
+  private observeContainerResize(
+    editorInstance: editor.IStandaloneCodeEditor,
+  ): void {
+    this.teardownResizeObserver();
+    const host = this.hostRef().nativeElement;
+    this.resizeObserver = new ResizeObserver(() => {
+      try {
+        editorInstance.layout();
+      } catch {
+        // Dimensions may be zero before layout stabilizes
+      }
+    });
+    this.resizeObserver.observe(host);
+    try {
+      editorInstance.layout();
+    } catch {
+      // Dimensions may be zero before layout stabilizes
+    }
+  }
+
+  private teardownResizeObserver(): void {
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = undefined;
   }
 
   private applyEditorOptions(

--- a/libs/editor/src/test-setup.ts
+++ b/libs/editor/src/test-setup.ts
@@ -2,4 +2,18 @@ import '@angular/compiler';
 import '@analogjs/vitest-angular/setup-snapshots';
 import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed';
 
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe(): void {
+      void 0;
+    }
+    unobserve(): void {
+      void 0;
+    }
+    disconnect(): void {
+      void 0;
+    }
+  };
+}
+
 setupTestBed({ zoneless: false });

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.html
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.html
@@ -23,7 +23,7 @@
         </button>
       </div>
 
-      <p class="text-xs text-gray-500 break-all">
+      <p class="min-w-0 truncate text-xs text-gray-500" [attr.title]="currentPath()">
         current: {{ currentPath() }}
       </p>
 

--- a/libs/file-manager/src/lib/component/file-tree/file-tree.component.html
+++ b/libs/file-manager/src/lib/component/file-tree/file-tree.component.html
@@ -16,10 +16,10 @@
           >
             @if (node.isDirectory) {
               <mat-icon aria-hidden="true" class="shrink-0 text-amber-500">folder</mat-icon>
-              <span>{{ node.name }}</span>
+              <span class="min-w-0 truncate" [attr.title]="node.name">{{ node.name }}</span>
             } @else {
               <mat-icon aria-hidden="true" class="shrink-0">article</mat-icon>
-              <span>{{ node.name }}</span>
+              <span class="min-w-0 truncate" [attr.title]="node.name">{{ node.name }}</span>
             }
           </button>
         </li>

--- a/libs/pin-assign-panel/src/lib/component/pin-assign/pin-assign.component.html
+++ b/libs/pin-assign-panel/src/lib/component/pin-assign/pin-assign.component.html
@@ -1,5 +1,5 @@
 <div
-  class="flex min-h-0 w-full min-w-0 flex-1 flex-col items-stretch overflow-y-auto overflow-x-hidden p-2"
+  class="flex min-h-0 w-full min-w-0 flex-1 flex-col items-stretch justify-start overflow-y-auto overflow-x-hidden p-1"
 >
   <img
     ngSrc="wallpaperS.png"
@@ -7,6 +7,6 @@
     height="654"
     priority
     alt="Pin Assign"
-    class="box-border mx-auto block h-auto w-full max-w-full object-contain"
+    class="box-border mx-auto block h-auto w-full max-w-full object-contain object-top"
   />
 </div>

--- a/libs/pin-assign-panel/src/lib/component/pin-assign/pin-assign.component.ts
+++ b/libs/pin-assign-panel/src/lib/component/pin-assign/pin-assign.component.ts
@@ -5,7 +5,7 @@ import { Component } from '@angular/core';
   selector: 'choh-pin-assign',
   imports: [NgOptimizedImage],
   host: {
-    class: 'flex min-h-0 min-w-0 flex-1 flex-col',
+    class: 'flex h-full min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden',
   },
   templateUrl: './pin-assign.component.html',
 })

--- a/libs/shared/src/lib/service/console-shell.store.spec.ts
+++ b/libs/shared/src/lib/service/console-shell.store.spec.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
+  CONSOLE_SHELL_LEFT_PANE_WIDTH_STORAGE_KEY,
+  CONSOLE_SHELL_RIGHT_DIAGRAM_WIDTH_STORAGE_KEY,
   ConsoleShellStore,
   DEFAULT_CONSOLE_SHELL_STATE,
   LEFT_PANE_WIDTH,
@@ -10,6 +12,8 @@ describe('ConsoleShellStore', () => {
   let store: ConsoleShellStore;
 
   beforeEach(() => {
+    localStorage.removeItem(CONSOLE_SHELL_LEFT_PANE_WIDTH_STORAGE_KEY);
+    localStorage.removeItem(CONSOLE_SHELL_RIGHT_DIAGRAM_WIDTH_STORAGE_KEY);
     store = new ConsoleShellStore();
   });
 
@@ -80,5 +84,36 @@ describe('ConsoleShellStore', () => {
     store.applyConnectedLayout();
     expect(store.leftPaneWidthPx()).toBe(320);
     expect(store.rightDiagramWidthPx()).toBe(260);
+  });
+
+  it('persists pane widths to localStorage', () => {
+    store.setLeftPaneWidth(340);
+    store.setRightDiagramWidth(220);
+    expect(localStorage.getItem(CONSOLE_SHELL_LEFT_PANE_WIDTH_STORAGE_KEY)).toBe(
+      '340',
+    );
+    expect(
+      localStorage.getItem(CONSOLE_SHELL_RIGHT_DIAGRAM_WIDTH_STORAGE_KEY),
+    ).toBe('220');
+  });
+
+  it('restores persisted pane widths on init', () => {
+    localStorage.setItem(CONSOLE_SHELL_LEFT_PANE_WIDTH_STORAGE_KEY, '360');
+    localStorage.setItem(CONSOLE_SHELL_RIGHT_DIAGRAM_WIDTH_STORAGE_KEY, '240');
+
+    const restored = new ConsoleShellStore();
+
+    expect(restored.leftPaneWidthPx()).toBe(360);
+    expect(restored.rightDiagramWidthPx()).toBe(240);
+  });
+
+  it('falls back to defaults for invalid persisted widths', () => {
+    localStorage.setItem(CONSOLE_SHELL_LEFT_PANE_WIDTH_STORAGE_KEY, 'abc');
+    localStorage.setItem(CONSOLE_SHELL_RIGHT_DIAGRAM_WIDTH_STORAGE_KEY, 'NaN');
+
+    const restored = new ConsoleShellStore();
+
+    expect(restored.leftPaneWidthPx()).toBe(LEFT_PANE_WIDTH.default);
+    expect(restored.rightDiagramWidthPx()).toBe(RIGHT_DIAGRAM_WIDTH.default);
   });
 });

--- a/libs/shared/src/lib/service/console-shell.store.spec.ts
+++ b/libs/shared/src/lib/service/console-shell.store.spec.ts
@@ -60,18 +60,18 @@ describe('ConsoleShellStore', () => {
     expect(store.rightNavOpen()).toBe(true);
   });
 
-  it('setLeftPaneWidth clamps to min only', () => {
+  it('setLeftPaneWidth clamps to min and max', () => {
     store.setLeftPaneWidth(50);
     expect(store.leftPaneWidthPx()).toBe(LEFT_PANE_WIDTH.min);
     store.setLeftPaneWidth(9999);
-    expect(store.leftPaneWidthPx()).toBe(9999);
+    expect(store.leftPaneWidthPx()).toBe(LEFT_PANE_WIDTH.max);
   });
 
-  it('setRightDiagramWidth clamps to min only', () => {
+  it('setRightDiagramWidth clamps to min and max', () => {
     store.setRightDiagramWidth(10);
     expect(store.rightDiagramWidthPx()).toBe(RIGHT_DIAGRAM_WIDTH.min);
     store.setRightDiagramWidth(9999);
-    expect(store.rightDiagramWidthPx()).toBe(9999);
+    expect(store.rightDiagramWidthPx()).toBe(RIGHT_DIAGRAM_WIDTH.max);
   });
 
   it('applyConnectedLayout preserves custom pane widths', () => {

--- a/libs/shared/src/lib/service/console-shell.store.ts
+++ b/libs/shared/src/lib/service/console-shell.store.ts
@@ -6,16 +6,18 @@ type ConsoleShellDialog = 'none' | 'setup' | 'remote';
 /** docked: in-flow side panes; overlay: rails only in-flow, panes float over center. */
 export type ConsoleShellLayoutMode = 'docked' | 'overlay';
 
-/** Left column width (tree + rail) default and minimum (px). No upper bound. */
+/** Left column width (tree + rail) default, minimum, and maximum (px). */
 export const LEFT_PANE_WIDTH = {
   default: 280,
   min: 180,
+  max: 480,
 } as const;
 
-/** Right pin-diagram track width (excludes chrome rail) default and minimum (px). No upper bound. */
+/** Right pin-diagram track width (excludes chrome rail) default, minimum, and maximum (px). */
 export const RIGHT_DIAGRAM_WIDTH = {
   default: 300,
   min: 160,
+  max: 480,
 } as const;
 
 export const RAIL_WIDTH_PX = 48;
@@ -48,8 +50,8 @@ export const DEFAULT_CONSOLE_SHELL_STATE: ConsoleShellState = {
   rightDiagramWidthPx: RIGHT_DIAGRAM_WIDTH.default,
 };
 
-function clampMin(value: number, min: number): number {
-  return Math.max(min, Math.round(value));
+function clampPaneWidth(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, Math.round(value)));
 }
 
 @Injectable({
@@ -176,14 +178,22 @@ export class ConsoleShellStore {
   setLeftPaneWidth(widthPx: number): void {
     this.stateSignal.update((state) => ({
       ...state,
-      leftPaneWidthPx: clampMin(widthPx, LEFT_PANE_WIDTH.min),
+      leftPaneWidthPx: clampPaneWidth(
+        widthPx,
+        LEFT_PANE_WIDTH.min,
+        LEFT_PANE_WIDTH.max,
+      ),
     }));
   }
 
   setRightDiagramWidth(widthPx: number): void {
     this.stateSignal.update((state) => ({
       ...state,
-      rightDiagramWidthPx: clampMin(widthPx, RIGHT_DIAGRAM_WIDTH.min),
+      rightDiagramWidthPx: clampPaneWidth(
+        widthPx,
+        RIGHT_DIAGRAM_WIDTH.min,
+        RIGHT_DIAGRAM_WIDTH.max,
+      ),
     }));
   }
 

--- a/libs/shared/src/lib/service/console-shell.store.ts
+++ b/libs/shared/src/lib/service/console-shell.store.ts
@@ -22,6 +22,11 @@ export const RIGHT_DIAGRAM_WIDTH = {
 
 export const RAIL_WIDTH_PX = 48;
 
+export const CONSOLE_SHELL_LEFT_PANE_WIDTH_STORAGE_KEY =
+  'chirimen.console-shell.leftPaneWidthPx';
+export const CONSOLE_SHELL_RIGHT_DIAGRAM_WIDTH_STORAGE_KEY =
+  'chirimen.console-shell.rightDiagramWidthPx';
+
 export interface ConsoleShellState {
   activePanel: ConsoleShellPanel;
   leftNavOpen: boolean;
@@ -54,13 +59,72 @@ function clampPaneWidth(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, Math.round(value)));
 }
 
+function readLocalStorageItem(key: string): string | null {
+  try {
+    const storage = globalThis.localStorage;
+    if (!storage) {
+      return null;
+    }
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function writeLocalStorageItem(key: string, value: string): void {
+  try {
+    const storage = globalThis.localStorage;
+    if (!storage) {
+      return;
+    }
+    storage.setItem(key, value);
+  } catch {
+    // Ignore quota / private-mode failures
+  }
+}
+
+function readPersistedPaneWidth(
+  key: string,
+  min: number,
+  max: number,
+  fallback: number,
+): number {
+  const raw = readLocalStorageItem(key);
+  if (raw === null) {
+    return fallback;
+  }
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+  return clampPaneWidth(parsed, min, max);
+}
+
+function createInitialConsoleShellState(): ConsoleShellState {
+  return {
+    ...DEFAULT_CONSOLE_SHELL_STATE,
+    leftPaneWidthPx: readPersistedPaneWidth(
+      CONSOLE_SHELL_LEFT_PANE_WIDTH_STORAGE_KEY,
+      LEFT_PANE_WIDTH.min,
+      LEFT_PANE_WIDTH.max,
+      LEFT_PANE_WIDTH.default,
+    ),
+    rightDiagramWidthPx: readPersistedPaneWidth(
+      CONSOLE_SHELL_RIGHT_DIAGRAM_WIDTH_STORAGE_KEY,
+      RIGHT_DIAGRAM_WIDTH.min,
+      RIGHT_DIAGRAM_WIDTH.max,
+      RIGHT_DIAGRAM_WIDTH.default,
+    ),
+  };
+}
+
 @Injectable({
   providedIn: 'root',
 })
 export class ConsoleShellStore {
-  private readonly stateSignal = signal<ConsoleShellState>({
-    ...DEFAULT_CONSOLE_SHELL_STATE,
-  });
+  private readonly stateSignal = signal<ConsoleShellState>(
+    createInitialConsoleShellState(),
+  );
 
   readonly state = this.stateSignal.asReadonly();
 
@@ -176,25 +240,35 @@ export class ConsoleShellStore {
   }
 
   setLeftPaneWidth(widthPx: number): void {
+    const leftPaneWidthPx = clampPaneWidth(
+      widthPx,
+      LEFT_PANE_WIDTH.min,
+      LEFT_PANE_WIDTH.max,
+    );
     this.stateSignal.update((state) => ({
       ...state,
-      leftPaneWidthPx: clampPaneWidth(
-        widthPx,
-        LEFT_PANE_WIDTH.min,
-        LEFT_PANE_WIDTH.max,
-      ),
+      leftPaneWidthPx,
     }));
+    writeLocalStorageItem(
+      CONSOLE_SHELL_LEFT_PANE_WIDTH_STORAGE_KEY,
+      String(leftPaneWidthPx),
+    );
   }
 
   setRightDiagramWidth(widthPx: number): void {
+    const rightDiagramWidthPx = clampPaneWidth(
+      widthPx,
+      RIGHT_DIAGRAM_WIDTH.min,
+      RIGHT_DIAGRAM_WIDTH.max,
+    );
     this.stateSignal.update((state) => ({
       ...state,
-      rightDiagramWidthPx: clampPaneWidth(
-        widthPx,
-        RIGHT_DIAGRAM_WIDTH.min,
-        RIGHT_DIAGRAM_WIDTH.max,
-      ),
+      rightDiagramWidthPx,
     }));
+    writeLocalStorageItem(
+      CONSOLE_SHELL_RIGHT_DIAGRAM_WIDTH_STORAGE_KEY,
+      String(rightDiagramWidthPx),
+    );
   }
 
   setSelectedFilePath(selectedFilePath: string | null): void {


### PR DESCRIPTION
## Summary

- Monaco Editor がパネル開閉・幅変更・ウィンドウリサイズに追従するよう、コンテナの `ResizeObserver` から `layout()` を呼び出すようにしました
- 左右パネルに最大幅（480px）を設け、ドラッグ幅を localStorage に永続化するようにしました
- 狭い画面での Toolbar 折り返し、ピン画像のはみ出し防止、長いファイル名の truncate、パネル開閉ボタンの `aria-expanded` を改善しました

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #811
- Refs #804

## What changed?

- Monaco Editor: ホストコンテナのリサイズを監視し `editor.layout()` を実行
- ConsoleShellStore: 左右パネル幅の min/max clamp と localStorage 永続化を追加
- Console Shell: 左右パネル開閉ボタンに `aria-expanded` / `aria-controls` を付与
- Pin Assign: パネル幅へ追従する画像レイアウトを調整
- Editor Toolbar: `min-w-0` / `flex-wrap` / `overflow-x-auto` / `shrink-0` で狭い幅に対応
- File Manager: 長いファイル名・パスを truncate 表示

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `/editor` を開き、左右パネルを開閉しても Monaco の右端・カーソル・スクロールが崩れないことを確認する
2. 左右パネルをドラッグでリサイズし、リロード後も幅が復元されることを確認する
3. ピン画像がパネルからはみ出さず、アスペクト比を維持することを確認する
4. ブラウザ幅 1920 / 1440 / 1280 / 1024 / 768 / 390 で Editor 領域が確保できることを確認する（1024px 未満は overlay で自動折りたたみ）
5. Tab + Enter/Space で左右パネルを開閉できること、`aria-expanded` が切り替わることを確認する
6. 長いファイル名を持つファイルをツリーに表示し、レイアウトが崩れないことを確認する

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)