### PR TITLE
feat(editor): clarify connection empty and error states

### DIFF
--- a/libs/console-shell/src/lib/component/console-shell/console-shell.component.spec.ts
+++ b/libs/console-shell/src/lib/component/console-shell/console-shell.component.spec.ts
@@ -157,6 +157,7 @@ describe('ConsoleShellComponent', () => {
   let notifyLogoutDetected: ReturnType<typeof vi.fn>;
   let notifyLogoutCancelled: ReturnType<typeof vi.fn>;
   let notifyManualDisconnect: ReturnType<typeof vi.fn>;
+  let notifyUnexpectedDisconnect: ReturnType<typeof vi.fn>;
   let navigateSpy: ReturnType<typeof vi.fn>;
   let activatedRouteMock: ActivatedRoute;
 
@@ -181,6 +182,7 @@ describe('ConsoleShellComponent', () => {
     notifyLogoutDetected = vi.fn();
     notifyLogoutCancelled = vi.fn();
     notifyManualDisconnect = vi.fn();
+    notifyUnexpectedDisconnect = vi.fn();
 
     openDialog = vi.fn().mockReturnValue({ closed: of(undefined) });
     closeAllDialog = vi.fn();
@@ -216,6 +218,7 @@ describe('ConsoleShellComponent', () => {
             notifyLogoutDetected,
             notifyLogoutCancelled,
             notifyManualDisconnect,
+            notifyUnexpectedDisconnect,
           },
         },
         {
@@ -611,6 +614,7 @@ describe('ConsoleShellComponent gridTemplateColumns when right nav closed', () =
             notifyLogoutDetected: vi.fn(),
             notifyLogoutCancelled: vi.fn(),
             notifyManualDisconnect: vi.fn(),
+            notifyUnexpectedDisconnect: vi.fn(),
           },
         },
         {
@@ -707,6 +711,7 @@ describe('ConsoleShellComponent responsive layout', () => {
             notifyLogoutDetected: vi.fn(),
             notifyLogoutCancelled: vi.fn(),
             notifyManualDisconnect: vi.fn(),
+            notifyUnexpectedDisconnect: vi.fn(),
           },
         },
         {
@@ -883,6 +888,7 @@ describe('ConsoleShellComponent layout DOM (connected vs disconnected)', () => {
             notifyLogoutDetected: vi.fn(),
             notifyLogoutCancelled: vi.fn(),
             notifyManualDisconnect: vi.fn(),
+            notifyUnexpectedDisconnect: vi.fn(),
           },
         },
         ConsoleShellStore,

--- a/libs/console-shell/src/lib/component/console-shell/console-shell.component.ts
+++ b/libs/console-shell/src/lib/component/console-shell/console-shell.component.ts
@@ -161,6 +161,9 @@ export class ConsoleShellComponent implements OnInit, OnDestroy {
           this.shellStore.applyConnectedLayout();
           void this.router.navigate(['terminal'], { relativeTo: this.route });
         } else if (prev && !next) {
+          if (!this.logoutDisconnectInFlight) {
+            this.notifications.notifyUnexpectedDisconnect();
+          }
           this.logoutDisconnectInFlight = false;
           this.clearLogoutPendingTimeout();
           this.shellStore.resetLayoutAfterDisconnect();

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.html
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.html
@@ -7,7 +7,12 @@
       !isDirty() || isSaving() || !currentFileName() || !isSerialConnected()
     "
     [discardDisabled]="!isDirty() || isSaving() || !currentFileName()"
-    [formatDisabled]="!currentFileName() || isLoading() || isSaving()"
+    [formatDisabled]="
+      !currentFileName() ||
+      isLoading() ||
+      isSaving() ||
+      !isSerialConnected()
+    "
     [newFileDisabled]="!isSerialConnected() || isSaving() || isLoading()"
     [isSaving]="isSaving()"
     (saveRequested)="saveCurrentFile()"
@@ -24,24 +29,64 @@
     [readOnly]="isReadOnly()"
   />
 
+  @if (!isSerialConnected() && !isConnecting()) {
+    <div
+      class="shrink-0 border-b border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900"
+      role="status"
+      aria-live="polite"
+    >
+      <p>CHIRIMEN Lite に接続されていません。</p>
+      <p class="text-xs text-amber-800">
+        Terminal または接続操作からデバイスへ接続してください。未保存の変更は
+        Editor または Draft に保持されています。
+      </p>
+    </div>
+  }
+
+  @if (isConnecting()) {
+    <div
+      class="shrink-0 border-b border-blue-100 bg-blue-50 px-3 py-2 text-sm text-blue-900"
+      role="status"
+      aria-live="polite"
+    >
+      CHIRIMEN Lite に接続しています…
+    </div>
+  }
+
   @if (loadError(); as error) {
-    <p
-      class="shrink-0 px-3 py-2 text-sm text-red-600"
+    <div
+      class="shrink-0 space-y-2 border-b border-red-100 bg-red-50 px-3 py-2 text-sm text-red-800"
       role="alert"
       aria-live="assertive"
     >
-      Failed to load {{ error.path }}: {{ error.message }}
-    </p>
+      <p>読込失敗: {{ error.message }}</p>
+      <details class="text-xs text-red-700">
+        <summary class="cursor-pointer select-none">技術的詳細</summary>
+        <pre class="mt-1 whitespace-pre-wrap break-all">{{ error.detail }}</pre>
+      </details>
+      <button
+        type="button"
+        class="text-xs font-medium underline disabled:cursor-not-allowed disabled:no-underline disabled:opacity-50"
+        [disabled]="!isSerialConnected() || isLoading()"
+        (click)="retryLoadCurrentFile()"
+      >
+        再試行
+      </button>
+    </div>
   }
 
   @if (saveError(); as error) {
-    <p
-      class="shrink-0 px-3 py-2 text-sm text-red-600"
+    <div
+      class="shrink-0 space-y-2 border-b border-red-100 bg-red-50 px-3 py-2 text-sm text-red-800"
       role="alert"
       aria-live="assertive"
     >
-      Failed to save: {{ error }}
-    </p>
+      <p>保存失敗: {{ error.message }}</p>
+      <details class="text-xs text-red-700">
+        <summary class="cursor-pointer select-none">技術的詳細</summary>
+        <pre class="mt-1 whitespace-pre-wrap break-all">{{ error.detail }}</pre>
+      </details>
+    </div>
   }
 
   <div class="relative min-h-0 min-w-0 flex-1">

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -1,10 +1,11 @@
 /// <reference types="vitest/globals" />
-import { signal } from '@angular/core';
+import { computed, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { DialogService } from '@libs-dialogs';
 import { FileService } from '@libs-file-manager';
 import { ConsoleShellStore, NotificationService } from '@libs-shared';
-import { SerialFacadeService } from '@libs-web-serial';
+import type { SerialConnectionViewModel } from '@libs-web-serial';
+import { SerialConnectionViewModelFacade } from '@libs-web-serial';
 import { provideMonacoEditor } from 'ngx-monaco-editor-v2';
 import { Subject } from 'rxjs';
 import { EditorDraftService, EditorService } from '../../service';
@@ -14,7 +15,15 @@ describe('EditorPageComponent', () => {
   let component: EditorPageComponent;
   let fixture: ComponentFixture<EditorPageComponent>;
   const selectedFilePathSignal = signal<string | null>(null);
-  const isConnectedSignal = signal(true);
+  const connectionVmSignal = signal<SerialConnectionViewModel>({
+    isBrowserSupported: true,
+    isConnected: true,
+    isConnecting: false,
+    isLoggedIn: true,
+    isInitializing: false,
+    setupStatus: 'ready',
+    errorMessage: null,
+  });
   const editorServiceMock = {
     loadTextFile: vi.fn().mockResolvedValue('loaded content'),
     saveTextFile: vi.fn().mockResolvedValue(undefined),
@@ -45,8 +54,8 @@ describe('EditorPageComponent', () => {
     exists: vi.fn().mockResolvedValue(false),
     touch: vi.fn().mockResolvedValue(undefined),
   };
-  const serialFacadeMock = {
-    isConnected: () => isConnectedSignal(),
+  const connectionVmMock = {
+    vm: computed(() => connectionVmSignal()),
   };
   const notifyMock = {
     success: vi.fn(),
@@ -73,7 +82,15 @@ describe('EditorPageComponent', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     selectedFilePathSignal.set(null);
-    isConnectedSignal.set(true);
+    connectionVmSignal.set({
+      isBrowserSupported: true,
+      isConnected: true,
+      isConnecting: false,
+      isLoggedIn: true,
+      isInitializing: false,
+      setupStatus: 'ready',
+      errorMessage: null,
+    });
     draftServiceMock.read.mockReturnValue(null);
     draftServiceMock.list.mockReturnValue([]);
     draftServiceMock.has.mockReturnValue(false);
@@ -90,7 +107,9 @@ describe('EditorPageComponent', () => {
       .overrideProvider(ConsoleShellStore, { useValue: shellStoreMock })
       .overrideProvider(DialogService, { useValue: dialogServiceMock })
       .overrideProvider(FileService, { useValue: fileServiceMock })
-      .overrideProvider(SerialFacadeService, { useValue: serialFacadeMock })
+      .overrideProvider(SerialConnectionViewModelFacade, {
+        useValue: connectionVmMock,
+      })
       .overrideProvider(NotificationService, { useValue: notifyMock })
       .compileComponents();
 
@@ -146,7 +165,8 @@ describe('EditorPageComponent', () => {
     expect(component.currentFileName()).toBe('ok.js');
     expect(component.loadError()).toEqual({
       path: '/home/pi/binary.bin',
-      message: 'Target file is not a text file',
+      message: 'ファイルの読み込みに失敗しました: /home/pi/binary.bin',
+      detail: 'Target file is not a text file',
     });
   });
 
@@ -175,7 +195,10 @@ describe('EditorPageComponent', () => {
     expect(component.isDirty()).toBe(false);
     expect(component.saveStatus()).toBe('savedToDevice');
     expect(draftServiceMock.clear).toHaveBeenCalledWith('/home/pi/main.js');
-    expect(notifyMock.success).toHaveBeenCalledWith('Save', 'Saved to device');
+    expect(notifyMock.success).toHaveBeenCalledWith(
+      '保存成功',
+      'デバイスへ保存しました',
+    );
   });
 
   it('should keep edits and draft when save fails', async () => {
@@ -191,13 +214,14 @@ describe('EditorPageComponent', () => {
     expect(component.code()).toBe('updated');
     expect(component.isDirty()).toBe(true);
     expect(component.saveStatus()).toBe('saveFailed');
-    expect(component.saveError()).toBe(
+    expect(component.saveError()?.detail).toBe(
       'Save failed: write permission was denied for the target file.',
     );
+    expect(component.saveError()?.message).toContain('Draft');
     expect(draftServiceMock.clear).not.toHaveBeenCalled();
     expect(notifyMock.error).toHaveBeenCalledWith(
-      'Save',
-      'Save failed: write permission was denied for the target file.',
+      '保存失敗',
+      'デバイスへの保存に失敗しました',
     );
   });
 
@@ -214,7 +238,9 @@ describe('EditorPageComponent', () => {
     await component.saveCurrentFile();
 
     expect(component.saveStatus()).toBe('saveFailed');
-    expect(component.saveError()).toContain('connection was lost or cancelled');
+    expect(component.saveError()?.detail).toContain(
+      'connection was lost or cancelled',
+    );
     expect(component.code()).toBe('updated');
     expect(draftServiceMock.clear).not.toHaveBeenCalled();
   });
@@ -231,7 +257,7 @@ describe('EditorPageComponent', () => {
     await loadPath('/home/pi/main.js', 'loaded content');
     component.onCodeChange('updated');
     component.onContentEdited();
-    isConnectedSignal.set(false);
+    connectionVmSignal.update((vm) => ({ ...vm, isConnected: false }));
 
     await component.saveCurrentFile();
 
@@ -243,7 +269,7 @@ describe('EditorPageComponent', () => {
     await loadPath('/home/pi/main.js', 'loaded content');
     component.onCodeChange('updated');
     component.onContentEdited();
-    isConnectedSignal.set(false);
+    connectionVmSignal.update((vm) => ({ ...vm, isConnected: false }));
     fixture.detectChanges();
     await fixture.whenStable();
 
@@ -394,8 +420,8 @@ describe('EditorPageComponent', () => {
     await component.formatCurrentFile();
 
     expect(notifyMock.warning).toHaveBeenCalledWith(
-      'Format',
-      'No formatter is available for this language.',
+      'フォーマット',
+      'この言語向けのフォーマッターはありません。',
     );
     expect(component.code()).toBe('const x=1');
     expect(component.isDirty()).toBe(false);

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -558,4 +558,34 @@ describe('EditorPageComponent', () => {
     expect(fileServiceMock.touch).not.toHaveBeenCalled();
     expect(notifyMock.error).toHaveBeenCalled();
   });
+
+  it('should retry loading the path from loadError', async () => {
+    await loadPath('/home/pi/ok.js', 'ok');
+    component.loadError.set({
+      path: '/home/pi/binary.bin',
+      message: 'ファイルの読み込みに失敗しました: /home/pi/binary.bin',
+      detail: 'Target file is not a text file',
+    });
+
+    editorServiceMock.loadTextFile.mockClear();
+    editorServiceMock.loadTextFile.mockResolvedValue('recovered');
+
+    await component.retryLoadCurrentFile();
+
+    expect(editorServiceMock.loadTextFile).toHaveBeenCalledWith(
+      '/home/pi/binary.bin',
+    );
+    expect(component.loadError()).toBeNull();
+    expect(component.code()).toBe('recovered');
+  });
+
+  it('should skip format when serial is disconnected', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
+    connectionVmSignal.update((vm) => ({ ...vm, isConnected: false }));
+    editorServiceMock.formatDocument.mockClear();
+
+    await component.formatCurrentFile();
+
+    expect(editorServiceMock.formatDocument).not.toHaveBeenCalled();
+  });
 });

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.ts
@@ -15,7 +15,7 @@ import {
   joinPath,
 } from '@libs-file-manager';
 import { ConsoleShellStore, NotificationService } from '@libs-shared';
-import { SerialFacadeService } from '@libs-web-serial';
+import { SerialConnectionViewModelFacade } from '@libs-web-serial';
 import type { editor } from 'monaco-editor';
 import { firstValueFrom } from 'rxjs';
 import { resolveEditorLanguage } from '../../functions';
@@ -34,7 +34,15 @@ import { EditorSaveStatus, isEditorDirtyStatus } from './editor-save-status';
 
 export interface EditorLoadError {
   path: string;
+  /** User-facing summary (not color-only). */
   message: string;
+  /** Technical detail shown in an expandable section. */
+  detail: string;
+}
+
+export interface EditorSaveError {
+  message: string;
+  detail: string;
 }
 
 @Component({
@@ -51,7 +59,7 @@ export class EditorPageComponent implements OnInit {
   code = signal('');
   saveStatus = signal<EditorSaveStatus | null>(null);
   loadError = signal<EditorLoadError | null>(null);
-  saveError = signal<string | null>(null);
+  saveError = signal<EditorSaveError | null>(null);
   lastDeviceSavedAt = signal<number | null>(null);
   isReadOnly = signal(false);
 
@@ -82,10 +90,15 @@ export class EditorPageComponent implements OnInit {
   private shellStore = inject(ConsoleShellStore);
   private dialog = inject(DialogService);
   private readonly fileService = inject(FileService);
-  private readonly serial = inject(SerialFacadeService);
+  private readonly connectionVm = inject(SerialConnectionViewModelFacade);
   private readonly notify = inject(NotificationService);
 
-  readonly isSerialConnected = this.serial.isConnected;
+  readonly connection = this.connectionVm.vm;
+  readonly isSerialConnected = computed(() => this.connection().isConnected);
+  readonly isConnecting = computed(
+    () =>
+      this.connection().isConnecting || this.connection().isInitializing,
+  );
   private readonly activeFilePath = signal<string | null>(null);
   private baselineContent = '';
   private baselineReady = false;
@@ -254,15 +267,28 @@ export class EditorPageComponent implements OnInit {
       if (generation !== this.loadGeneration) {
         return;
       }
-      const message =
+      const detail =
         error instanceof Error ? error.message : 'Failed to load file';
-      this.loadError.set({ path, message });
+      this.loadError.set({
+        path,
+        message: `ファイルの読み込みに失敗しました: ${path}`,
+        detail,
+      });
+      this.notify.error('読込失敗', `ファイルの読み込みに失敗しました: ${path}`);
       if (this.activeFilePath()) {
         this.saveStatus.set(previousStatus ?? 'savedToDevice');
       } else {
         this.saveStatus.set(null);
       }
     }
+  }
+
+  async retryLoadCurrentFile(): Promise<void> {
+    const path = this.loadError()?.path ?? this.activeFilePath();
+    if (!path || !this.isSerialConnected() || this.isLoading()) {
+      return;
+    }
+    await this.fetchDeviceFile(path);
   }
 
   private applyDeviceContent(path: string, content: string): void {
@@ -413,32 +439,40 @@ export class EditorPageComponent implements OnInit {
       this.isReadOnly.set(false);
       this.saveStatus.set('savedToDevice');
       this.draftService.clear(path);
-      this.notify.success('Save', 'Saved to device');
+      this.notify.success('保存成功', 'デバイスへ保存しました');
     } catch (error: unknown) {
-      const message =
+      const detail =
         error instanceof Error
           ? error.message
           : 'Save failed: unexpected error while writing to the device';
-      this.saveError.set(message);
+      this.saveError.set({
+        message: 'デバイスへの保存に失敗しました。内容は Editor / Draft に保持されています。',
+        detail,
+      });
       // Keep editor content and local draft so the user can retry after reconnect.
       this.saveStatus.set('saveFailed');
-      this.notify.error('Save', message);
-      if (isWritePermissionDenied(message)) {
+      this.notify.error('保存失敗', 'デバイスへの保存に失敗しました');
+      if (isWritePermissionDenied(detail)) {
         this.isReadOnly.set(true);
       }
     }
   }
 
   async formatCurrentFile(): Promise<void> {
-    if (!this.currentFilePath() || this.isLoading() || this.isSaving()) {
+    if (
+      !this.currentFilePath() ||
+      this.isLoading() ||
+      this.isSaving() ||
+      !this.isSerialConnected()
+    ) {
       return;
     }
 
     const formatted = await this.editorService.formatDocument();
     if (!formatted) {
       this.notify.warning(
-        'Format',
-        'No formatter is available for this language.',
+        'フォーマット',
+        'この言語向けのフォーマッターはありません。',
       );
       return;
     }

--- a/libs/file-manager/project.json
+++ b/libs/file-manager/project.json
@@ -10,7 +10,8 @@
   ],
   "implicitDependencies": [
     "libs-web-serial",
-    "libs-dialogs"
+    "libs-dialogs",
+    "libs-shared"
   ],
   "targets": {
     "build": {

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.html
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.html
@@ -2,56 +2,146 @@
   class="flex h-full min-h-0 min-w-0 flex-col gap-2 p-2"
   aria-label="File browser"
 >
-  @if (loading) {
-    <div
-      class="flex min-h-0 flex-1 flex-col items-center justify-center"
-      role="status"
-      aria-live="polite"
-    >
-      <mat-progress-spinner
-        mode="indeterminate"
-        diameter="84"
-        aria-label="Loading files"
-      />
-    </div>
-  } @else {
-    <div class="shrink-0 space-y-2">
-      <div class="flex items-center justify-between">
-        <h2 class="font-semibold">Files</h2>
-        <button type="button" class="text-xs underline" (click)="reload()">
-          reload
-        </button>
+  @switch (viewState) {
+    @case ('neverConnected') {
+      <div
+        class="flex min-h-0 flex-1 flex-col items-start justify-center gap-1 p-3"
+        role="status"
+      >
+        <p class="text-sm text-gray-700">
+          {{ viewMessages.neverConnected.title }}
+        </p>
+        <p class="text-xs text-gray-500">
+          {{ viewMessages.neverConnected.detail }}
+        </p>
+      </div>
+    }
+    @case ('disconnected') {
+      <div
+        class="flex min-h-0 flex-1 flex-col items-start justify-center gap-1 p-3"
+        role="status"
+      >
+        <p class="text-sm text-gray-700">
+          {{ viewMessages.disconnected.title }}
+        </p>
+        <p class="text-xs text-gray-500">
+          {{ viewMessages.disconnected.detail }}
+        </p>
+      </div>
+    }
+    @case ('connecting') {
+      <div
+        class="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-3"
+        role="status"
+        aria-live="polite"
+      >
+        <mat-progress-spinner
+          mode="indeterminate"
+          diameter="84"
+          aria-label="Connecting to CHIRIMEN Lite"
+        />
+        <p class="text-sm text-gray-600">
+          {{ viewMessages.connecting.title }}
+        </p>
+      </div>
+    }
+    @case ('loading') {
+      <div
+        class="flex min-h-0 flex-1 flex-col items-center justify-center gap-3"
+        role="status"
+        aria-live="polite"
+      >
+        <mat-progress-spinner
+          mode="indeterminate"
+          diameter="84"
+          aria-label="Loading files"
+        />
+        <p class="text-sm text-gray-600">ファイル一覧を読み込んでいます…</p>
+      </div>
+    }
+    @case ('fetchFailed') {
+      <div class="flex min-h-0 flex-1 flex-col gap-2 p-3" role="alert">
+        <p class="text-sm text-red-700">
+          {{ viewMessages.fetchFailed.title }}
+        </p>
+        @if (errorMessage) {
+          <p class="text-xs text-red-600">{{ errorMessage }}</p>
+        }
+        @if (errorDetail) {
+          <details class="text-xs text-gray-600">
+            <summary class="cursor-pointer select-none">技術的詳細</summary>
+            <pre class="mt-1 whitespace-pre-wrap break-all">{{ errorDetail }}</pre>
+          </details>
+        }
+        <choh-button
+          label="再試行"
+          type="button"
+          (clickEvent)="reload()"
+        />
+      </div>
+    }
+    @default {
+      <div class="shrink-0 space-y-2">
+        <div class="flex items-center justify-between">
+          <h2 class="font-semibold">Files</h2>
+          @if (canRefresh) {
+            <button
+              type="button"
+              class="text-xs underline"
+              (click)="reload()"
+            >
+              更新
+            </button>
+          }
+        </div>
+
+        <p
+          class="min-w-0 truncate text-xs text-gray-500"
+          [attr.title]="currentPath()"
+        >
+          current: {{ currentPath() }}
+        </p>
+
+        @if (currentPath() !== '.' && !remoteOpsDisabled) {
+          <button type="button" class="text-xs underline" (click)="goParent()">
+            ← parent
+          </button>
+        }
       </div>
 
-      <p class="min-w-0 truncate text-xs text-gray-500" [attr.title]="currentPath()">
-        current: {{ currentPath() }}
-      </p>
+      <div
+        class="min-h-0 flex-1 overflow-y-auto overflow-x-hidden"
+        role="region"
+        aria-label="File list"
+        (contextmenu)="onBackgroundContextMenu($event)"
+      >
+        @if (viewState === 'empty') {
+          <p class="p-3 text-sm text-gray-600" role="status">
+            {{ viewMessages.empty.title }}
+          </p>
+        } @else {
+          <lib-file-tree
+            [nodes]="nodes"
+            [selectedPath]="selectedPath()"
+            (directorySelected)="onDirectorySelected($event)"
+            (fileSelected)="onFileSelected($event)"
+            (nodeContextMenu)="onNodeContextMenu($event)"
+          />
+        }
+      </div>
 
-      @if (currentPath() !== '.') {
-        <button type="button" class="text-xs underline" (click)="goParent()">
-          ← parent
-        </button>
+      @if (errorMessage && !listFetchFailed) {
+        <div class="shrink-0 space-y-1" role="alert">
+          <p class="text-xs text-red-600">操作に失敗しました: {{ errorMessage }}</p>
+          @if (errorDetail) {
+            <details class="text-xs text-gray-600">
+              <summary class="cursor-pointer select-none">技術的詳細</summary>
+              <pre class="mt-1 whitespace-pre-wrap break-all">{{ errorDetail }}</pre>
+            </details>
+          }
+        </div>
       }
-    </div>
-
-    <div
-      class="min-h-0 flex-1 overflow-y-auto overflow-x-hidden"
-      role="region"
-      aria-label="File list"
-      (contextmenu)="onBackgroundContextMenu($event)"
-    >
-      <lib-file-tree
-        [nodes]="nodes"
-        [selectedPath]="selectedPath()"
-        (directorySelected)="onDirectorySelected($event)"
-        (fileSelected)="onFileSelected($event)"
-        (nodeContextMenu)="onNodeContextMenu($event)"
-      />
-    </div>
-  }
-
-  @if (errorMessage) {
-    <p class="shrink-0 text-xs text-red-600">{{ errorMessage }}</p>
+    }
   }
 
   <lib-file-context-menu

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
@@ -544,4 +544,84 @@ describe('FileTreeFeatureComponent', () => {
     expect(touchMock).not.toHaveBeenCalled();
     expect(listTreeMock).not.toHaveBeenCalled();
   });
+
+  it('shows never-connected empty state before serial connects', async () => {
+    const fixture = await compileAndCreate();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.viewState).toBe('neverConnected');
+    expect(fixture.nativeElement.textContent).toContain(
+      'CHIRIMEN Lite に接続されていません',
+    );
+  });
+
+  it('shows connecting state while bootstrap is not ready', async () => {
+    const fixture = await compileAndCreate();
+    fixture.detectChanges();
+    vmSignal.set({
+      ...baseVm,
+      isConnected: true,
+      isLoggedIn: false,
+      setupStatus: 'idle',
+    });
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.viewState).toBe('connecting');
+    expect(fixture.nativeElement.textContent).toContain(
+      'CHIRIMEN Lite に接続しています',
+    );
+  });
+
+  it('shows empty directory state when listTree returns no nodes', async () => {
+    listTreeMock.mockResolvedValue([]);
+    const fixture = await compileAndCreate();
+    await connectReady(fixture);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.viewState).toBe('empty');
+    expect(fixture.nativeElement.textContent).toContain(
+      'このフォルダーにはファイルがありません',
+    );
+  });
+
+  it('shows fetch failure with retry and reloads on click', async () => {
+    listTreeMock.mockRejectedValueOnce(new Error('disk full'));
+    const fixture = await compileAndCreate();
+    fixture.detectChanges();
+    vmSignal.set({
+      ...baseVm,
+      isConnected: true,
+      isLoggedIn: true,
+      setupStatus: 'ready',
+    });
+    await vi.waitFor(() => {
+      expect(fixture.componentInstance.viewState).toBe('fetchFailed');
+    });
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain(
+      'ファイル一覧を取得できませんでした',
+    );
+    expect(fixture.nativeElement.textContent).toContain('再試行');
+
+    listTreeMock.mockResolvedValueOnce(treeNodes);
+    await fixture.componentInstance.reload();
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.viewState).toBe('ready');
+    expect(fixture.componentInstance.nodes).toEqual(treeNodes);
+  });
+
+  it('shows disconnected state after a prior connected session ends', async () => {
+    const fixture = await compileAndCreate();
+    await connectReady(fixture);
+    vmSignal.set({ ...baseVm, isConnected: false });
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.viewState).toBe('disconnected');
+    expect(fixture.nativeElement.textContent).toContain(
+      'CHIRIMEN Lite との接続が切断されました',
+    );
+    expect(fixture.componentInstance.contextMenuDisabled).toBe(true);
+  });
 });

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
@@ -10,12 +10,17 @@ import {
 } from '@angular/core';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { ConfirmDialogComponent, DialogService } from '@libs-dialogs';
+import { ButtonComponent } from '@libs-shared';
 import { SerialConnectionViewModelFacade } from '@libs-web-serial';
 import { firstValueFrom } from 'rxjs';
 import { joinPath, parentPathOf } from '../../functions';
 import type { FileContextMenuAction } from '../../models/file-context-menu.types';
 import type { FileRenamedEvent } from '../../models/file-lifecycle.types';
 import type { FileNameDialogData } from '../../models/file-name-dialog.types';
+import {
+  FILE_TREE_VIEW_MESSAGES,
+  type FileTreeViewState,
+} from '../../models/file-tree-view-state';
 import { FileTreeNode } from '../../models';
 import { FileService } from '../../service';
 import { FileContextMenuComponent } from '../file-context-menu/file-context-menu.component';
@@ -27,7 +32,12 @@ import {
 
 @Component({
   selector: 'lib-file-tree-feature',
-  imports: [FileTreeComponent, FileContextMenuComponent, MatProgressSpinner],
+  imports: [
+    FileTreeComponent,
+    FileContextMenuComponent,
+    MatProgressSpinner,
+    ButtonComponent,
+  ],
   host: {
     class: 'flex min-h-0 min-w-0 flex-1 flex-col',
   },
@@ -55,15 +65,24 @@ export class FileTreeFeatureComponent {
   readonly fileRenamed = output<FileRenamedEvent>();
   readonly fileDeleted = output<string>();
 
+  readonly viewMessages = FILE_TREE_VIEW_MESSAGES;
+
   nodes: FileTreeNode[] = [];
   loading = false;
+  /** User-facing list/operation error; technical detail may differ. */
   errorMessage: string | null = null;
+  /** Raw error detail for expandable technical info (#812). */
+  errorDetail: string | null = null;
+  /** True when the last `listTree` call failed (#812). */
+  listFetchFailed = false;
   contextTarget: FileTreeNode | null = null;
   operationBusy = false;
 
   private loadedForLogin = false;
   private lastVmKey = '';
   private lastLoadedPath: string | null = null;
+  /** Remembers a prior connected session to distinguish disconnect vs never connected. */
+  private hadConnectedSession = false;
 
   /** ログイン完了後・環境設定前の窓で初回 ls を走らせる（issue #717）。 */
   private canLoadTree(vm: {
@@ -81,16 +100,22 @@ export class FileTreeFeatureComponent {
       const vm = this.connectionVm.vm();
       const setupFailed = vm.setupStatus === 'failed' && !vm.isLoggedIn;
       const treeReady = this.canLoadTree(vm);
-      const vmKey = `${vm.isConnected}:${treeReady}:${setupFailed}`;
+      const vmKey = `${vm.isConnected}:${vm.isConnecting}:${vm.isInitializing}:${treeReady}:${setupFailed}`;
       if (vmKey === this.lastVmKey) {
         return;
       }
       this.lastVmKey = vmKey;
 
       untracked(() => {
+        if (vm.isConnected) {
+          this.hadConnectedSession = true;
+        }
+
         if (!vm.isConnected) {
           this.loading = false;
           this.errorMessage = null;
+          this.errorDetail = null;
+          this.listFetchFailed = false;
           this.nodes = [];
           this.loadedForLogin = false;
           this.lastLoadedPath = null;
@@ -104,15 +129,19 @@ export class FileTreeFeatureComponent {
 
         if (setupFailed) {
           this.loading = false;
+          this.listFetchFailed = true;
           this.errorMessage =
             'シェルの初期化に失敗しました。ターミナルを確認してください。';
+          this.errorDetail = vm.errorMessage;
           this.cdr.markForCheck();
           return;
         }
 
-        if (!treeReady) {
+        if (!treeReady || vm.isConnecting || vm.isInitializing) {
           this.loading = true;
           this.errorMessage = null;
+          this.errorDetail = null;
+          this.listFetchFailed = false;
           this.loadedForLogin = false;
           this.cdr.markForCheck();
           return;
@@ -122,6 +151,8 @@ export class FileTreeFeatureComponent {
           return;
         }
         this.loadedForLogin = true;
+        this.loading = true;
+        this.cdr.markForCheck();
         queueMicrotask(() => void this.loadAt(this.currentPath()));
       });
     });
@@ -141,8 +172,54 @@ export class FileTreeFeatureComponent {
     });
   }
 
+  get viewState(): FileTreeViewState {
+    const vm = this.connectionVm.vm();
+
+    if (!vm.isConnected) {
+      return this.hadConnectedSession ? 'disconnected' : 'neverConnected';
+    }
+
+    if (
+      vm.isConnecting ||
+      vm.isInitializing ||
+      (!this.canLoadTree(vm) && vm.setupStatus !== 'failed')
+    ) {
+      return 'connecting';
+    }
+
+    if (this.loading) {
+      return 'loading';
+    }
+
+    if (this.listFetchFailed || (vm.setupStatus === 'failed' && !vm.isLoggedIn)) {
+      return 'fetchFailed';
+    }
+
+    if (!this.nodes.length) {
+      return 'empty';
+    }
+
+    return 'ready';
+  }
+
+  get remoteOpsDisabled(): boolean {
+    const state = this.viewState;
+    return (
+      this.operationBusy ||
+      state === 'neverConnected' ||
+      state === 'disconnected' ||
+      state === 'connecting' ||
+      state === 'loading'
+    );
+  }
+
   get contextMenuDisabled(): boolean {
-    return this.operationBusy || !this.connectionVm.vm().isConnected;
+    return this.remoteOpsDisabled;
+  }
+
+  get canRefresh(): boolean {
+    const state = this.viewState;
+    return state === 'ready' || state === 'empty';
   }
 
   async reload(): Promise<void> {
@@ -193,6 +270,9 @@ export class FileTreeFeatureComponent {
   }
 
   async goParent(): Promise<void> {
+    if (this.remoteOpsDisabled) {
+      return;
+    }
     const path = this.currentPath();
     if (path === '.') {
       return;
@@ -341,12 +421,14 @@ export class FileTreeFeatureComponent {
     }
     this.operationBusy = true;
     this.errorMessage = null;
+    this.errorDetail = null;
     this.cdr.markForCheck();
     try {
       await fn();
     } catch (error: unknown) {
-      this.errorMessage =
-        error instanceof Error ? error.message : String(error);
+      const message = error instanceof Error ? error.message : String(error);
+      this.errorMessage = message;
+      this.errorDetail = message;
     } finally {
       this.operationBusy = false;
       this.cdr.markForCheck();
@@ -364,12 +446,17 @@ export class FileTreeFeatureComponent {
     this.lastLoadedPath = path;
     this.loading = true;
     this.errorMessage = null;
+    this.errorDetail = null;
+    this.listFetchFailed = false;
     this.cdr.markForCheck();
     try {
       this.nodes = await this.file.listTree(path);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
       this.errorMessage = message;
+      this.errorDetail = message;
+      this.listFetchFailed = true;
+      this.nodes = [];
       this.loadedForLogin = false;
     } finally {
       this.loading = false;

--- a/libs/file-manager/src/lib/component/file-tree/file-tree.component.html
+++ b/libs/file-manager/src/lib/component/file-tree/file-tree.component.html
@@ -1,29 +1,25 @@
 <div class="file-tree text-sm">
-  @if (!nodes().length) {
-    <p class="text-gray-500">No files</p>
-  } @else {
-    <ul class="space-y-1">
-      @for (node of nodes(); track node.path) {
-        <li>
-          <button
-            type="button"
-            class="inline-flex w-full items-center gap-1 text-left px-2 py-1 rounded hover:bg-gray-100"
-            [class.bg-blue-50]="isSelected(node)"
-            [class.font-medium]="isSelected(node)"
-            [attr.aria-current]="isSelected(node) ? 'true' : null"
-            (click)="onSelect(node)"
-            (contextmenu)="onContextMenu($event, node)"
-          >
-            @if (node.isDirectory) {
-              <mat-icon aria-hidden="true" class="shrink-0 text-amber-500">folder</mat-icon>
-              <span class="min-w-0 truncate" [attr.title]="node.name">{{ node.name }}</span>
-            } @else {
-              <mat-icon aria-hidden="true" class="shrink-0">article</mat-icon>
-              <span class="min-w-0 truncate" [attr.title]="node.name">{{ node.name }}</span>
-            }
-          </button>
-        </li>
-      }
-    </ul>
-  }
+  <ul class="space-y-1">
+    @for (node of nodes(); track node.path) {
+      <li>
+        <button
+          type="button"
+          class="inline-flex w-full items-center gap-1 text-left px-2 py-1 rounded hover:bg-gray-100"
+          [class.bg-blue-50]="isSelected(node)"
+          [class.font-medium]="isSelected(node)"
+          [attr.aria-current]="isSelected(node) ? 'true' : null"
+          (click)="onSelect(node)"
+          (contextmenu)="onContextMenu($event, node)"
+        >
+          @if (node.isDirectory) {
+            <mat-icon aria-hidden="true" class="shrink-0 text-amber-500">folder</mat-icon>
+            <span class="min-w-0 truncate" [attr.title]="node.name">{{ node.name }}</span>
+          } @else {
+            <mat-icon aria-hidden="true" class="shrink-0">article</mat-icon>
+            <span class="min-w-0 truncate" [attr.title]="node.name">{{ node.name }}</span>
+          }
+        </button>
+      </li>
+    }
+  </ul>
 </div>

--- a/libs/file-manager/src/lib/models/file-tree-view-state.ts
+++ b/libs/file-manager/src/lib/models/file-tree-view-state.ts
@@ -1,0 +1,34 @@
+/**
+ * File tree panel presentation state for connection / load / empty / error (#812).
+ */
+export type FileTreeViewState =
+  | 'disconnected'
+  | 'neverConnected'
+  | 'connecting'
+  | 'loading'
+  | 'empty'
+  | 'fetchFailed'
+  | 'ready';
+
+export const FILE_TREE_VIEW_MESSAGES: Record<
+  Exclude<FileTreeViewState, 'ready' | 'loading'>,
+  { title: string; detail?: string }
+> = {
+  neverConnected: {
+    title: 'CHIRIMEN Lite に接続されていません。',
+    detail: 'Terminal または接続操作からデバイスへ接続してください。',
+  },
+  disconnected: {
+    title: 'CHIRIMEN Lite との接続が切断されました。',
+    detail: '未保存の変更は Editor または Draft に保持されています。',
+  },
+  connecting: {
+    title: 'CHIRIMEN Lite に接続しています…',
+  },
+  empty: {
+    title: 'このフォルダーにはファイルがありません。',
+  },
+  fetchFailed: {
+    title: 'ファイル一覧を取得できませんでした。',
+  },
+};

--- a/libs/file-manager/src/lib/models/index.ts
+++ b/libs/file-manager/src/lib/models/index.ts
@@ -2,3 +2,4 @@ export * from './file-context-menu.types';
 export * from './file-lifecycle.types';
 export * from './file-name-dialog.types';
 export * from './file-tree.model';
+export * from './file-tree-view-state';

--- a/libs/shared/src/lib/service/notification.service.spec.ts
+++ b/libs/shared/src/lib/service/notification.service.spec.ts
@@ -1,0 +1,63 @@
+/// <reference types="vitest/globals" />
+import { TestBed } from '@angular/core/testing';
+import { ToastrService } from 'ngx-toastr';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NotificationService } from './notification.service';
+
+describe('NotificationService', () => {
+  const toastrMock = {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    TestBed.configureTestingModule({
+      providers: [
+        NotificationService,
+        { provide: ToastrService, useValue: toastrMock },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    void TestBed.resetTestingModule();
+  });
+
+  it('shows error toasts', () => {
+    const service = TestBed.inject(NotificationService);
+    service.error('保存失敗', 'デバイスへの保存に失敗しました');
+    expect(toastrMock.error).toHaveBeenCalledWith(
+      'デバイスへの保存に失敗しました',
+      '保存失敗',
+    );
+  });
+
+  it('dedupes consecutive identical notifications within the window', () => {
+    const service = TestBed.inject(NotificationService);
+    service.error('読込失敗', 'same');
+    service.error('読込失敗', 'same');
+    expect(toastrMock.error).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows the same notification after the dedupe window', () => {
+    const service = TestBed.inject(NotificationService);
+    service.error('読込失敗', 'same');
+    vi.advanceTimersByTime(2600);
+    service.error('読込失敗', 'same');
+    expect(toastrMock.error).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not dedupe different severities or messages', () => {
+    const service = TestBed.inject(NotificationService);
+    service.error('読込失敗', 'a');
+    service.warning('読込失敗', 'a');
+    service.error('読込失敗', 'b');
+    expect(toastrMock.error).toHaveBeenCalledTimes(2);
+    expect(toastrMock.warning).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/shared/src/lib/service/notification.service.ts
+++ b/libs/shared/src/lib/service/notification.service.ts
@@ -11,12 +11,21 @@ import { ToastrService } from 'ngx-toastr';
 export class NotificationService {
   private toastr = inject(ToastrService);
 
+  /** Suppress identical consecutive toasts within this window (#812). */
+  private static readonly DEDUPE_WINDOW_MS = 2500;
+
+  private lastKey: string | null = null;
+  private lastAt = 0;
+
   /**
    * 成功メッセージを表示
    * @param title タイトル
    * @param message メッセージ
    */
   success(title: string, message: string): void {
+    if (this.shouldSkip(title, message, 'success')) {
+      return;
+    }
     this.toastr.success(message, title);
   }
 
@@ -26,6 +35,9 @@ export class NotificationService {
    * @param message メッセージ
    */
   error(title: string, message: string): void {
+    if (this.shouldSkip(title, message, 'error')) {
+      return;
+    }
     this.toastr.error(message, title);
   }
 
@@ -35,6 +47,9 @@ export class NotificationService {
    * @param message メッセージ
    */
   info(title: string, message: string): void {
+    if (this.shouldSkip(title, message, 'info')) {
+      return;
+    }
     this.toastr.info(message, title);
   }
 
@@ -44,6 +59,24 @@ export class NotificationService {
    * @param message メッセージ
    */
   warning(title: string, message: string): void {
+    if (this.shouldSkip(title, message, 'warning')) {
+      return;
+    }
     this.toastr.warning(message, title);
+  }
+
+  private shouldSkip(
+    title: string,
+    message: string,
+    severity: 'success' | 'error' | 'info' | 'warning',
+  ): boolean {
+    const key = `${severity}|${title}|${message}`;
+    const now = Date.now();
+    if (this.lastKey === key && now - this.lastAt < NotificationService.DEDUPE_WINDOW_MS) {
+      return true;
+    }
+    this.lastKey = key;
+    this.lastAt = now;
+    return false;
   }
 }

--- a/libs/web-serial/src/lib/service/serial-notification.service.spec.ts
+++ b/libs/web-serial/src/lib/service/serial-notification.service.spec.ts
@@ -20,10 +20,55 @@ describe('SerialNotificationService', () => {
     service.notifyManualDisconnect();
 
     expect(info).toHaveBeenCalledWith(
-      'Web Serial 接続を切断しました',
+      'CHIRIMEN Lite との接続が切断されました。未保存の変更は Editor または Draft に保持されています。',
       '切断',
-      { timeOut: 4000 },
+      { timeOut: 5000 },
     );
+  });
+
+  it('notifyUnexpectedDisconnect shows warning toast', () => {
+    const warning = vi.fn();
+    const service = Object.create(
+      SerialNotificationService.prototype,
+    ) as SerialNotificationService;
+    (
+      service as unknown as { toastr: { warning: typeof warning } }
+    ).toastr = { warning };
+    (
+      service as unknown as {
+        expectedDisconnect: SerialExpectedDisconnectService;
+      }
+    ).expectedDisconnect = new SerialExpectedDisconnectService();
+
+    service.notifyUnexpectedDisconnect();
+
+    expect(warning).toHaveBeenCalledWith(
+      'CHIRIMEN Lite との接続が切断されました。未保存の変更は Editor または Draft に保持されています。',
+      '切断',
+      { timeOut: 6000 },
+    );
+  });
+
+  it('notifyUnexpectedDisconnect is suppressed during expected disconnect', () => {
+    const warning = vi.fn();
+    const expectedDisconnect = new SerialExpectedDisconnectService();
+    expectedDisconnect.beginExpectedDisconnect('reboot');
+
+    const service = Object.create(
+      SerialNotificationService.prototype,
+    ) as SerialNotificationService;
+    (
+      service as unknown as { toastr: { warning: typeof warning } }
+    ).toastr = { warning };
+    (
+      service as unknown as {
+        expectedDisconnect: SerialExpectedDisconnectService;
+      }
+    ).expectedDisconnect = expectedDisconnect;
+
+    service.notifyUnexpectedDisconnect();
+
+    expect(warning).not.toHaveBeenCalled();
   });
 
   it('notifyAutoLoginFailed shows error toast with message', () => {

--- a/libs/web-serial/src/lib/service/serial-notification.service.ts
+++ b/libs/web-serial/src/lib/service/serial-notification.service.ts
@@ -53,12 +53,16 @@ export class SerialNotificationService {
   }
 
   /**
-   * ヘッダーの Web Serial DisConnect で接続前状態へ戻すときの通知（#753）。
+   * ヘッダーの Web Serial DisConnect で接続前状態へ戻すときの通知（#753 / #812）。
    */
   notifyManualDisconnect(): void {
-    this.toastr.info('Web Serial 接続を切断しました', '切断', {
-      timeOut: 4000,
-    });
+    this.toastr.info(
+      'CHIRIMEN Lite との接続が切断されました。未保存の変更は Editor または Draft に保持されています。',
+      '切断',
+      {
+        timeOut: 5000,
+      },
+    );
   }
 
   /**
@@ -83,6 +87,22 @@ export class SerialNotificationService {
       'ログインエラー',
       {
         timeOut: 8000,
+      },
+    );
+  }
+
+  /**
+   * 予期しない切断時の通知（#812）。未保存内容が Draft に残ることを明示する。
+   */
+  notifyUnexpectedDisconnect(): void {
+    if (this.expectedDisconnect.isExpectedDisconnect()) {
+      return;
+    }
+    this.toastr.warning(
+      'CHIRIMEN Lite との接続が切断されました。未保存の変更は Editor または Draft に保持されています。',
+      '切断',
+      {
+        timeOut: 6000,
       },
     );
   }


### PR DESCRIPTION
## Summary

- ファイルツリーで未接続・接続中・読込中・空ディレクトリ・取得失敗を区別して表示し、取得失敗時に再試行できるようにしました
- Editor で接続 VM を参照し、未接続バナー・読込/保存エラーの技術詳細開閉・再試行・Format 含むリモート操作ガードを追加しました
- 切断トーストで Draft 保持を明示し、同一通知の連続表示を抑制しました

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #812
- Parent: #804

## What changed?

- `FileTreeFeatureComponent` に接続/読込/空/エラーの Empty State と再試行 UI を追加
- `EditorPageComponent` を `SerialConnectionViewModelFacade` 参照に切り替え、エラー詳細・再試行・操作無効化を強化
- `SerialNotificationService` の切断メッセージを更新し、予期しない切断時も Draft 保持を通知
- `NotificationService` に短時間の同一通知 dedupe を追加
- 関連 unit test を追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. 未接続時にファイルツリーへ「CHIRIMEN Lite に接続されていません」相当の表示が出ることを確認する（接続レイアウト内の防御表示）
2. 接続後、空フォルダでは「このフォルダーにはファイルがありません。」、一覧取得失敗時は「再試行」で再取得できることを確認する
3. Editor で読込/保存失敗時に利用者向けメッセージと「技術的詳細」の開閉、読込失敗の再試行を確認する
4. 切断時に未保存 Draft が保持され、切断トーストにその旨が表示されることを確認する
5. `pnpm nx test libs-file-manager libs-editor libs-shared libs-web-serial libs-console-shell` が通ることを確認する

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)