### PR TITLE
feat(editor): handle large files utf8 bom and eol

### DIFF
--- a/libs/dialogs/src/lib/dialogs/progress-dialog/progress-dialog.component.html
+++ b/libs/dialogs/src/lib/dialogs/progress-dialog/progress-dialog.component.html
@@ -1,9 +1,14 @@
 <div class="dialog-content">
-  @if (message()) {
-    <p>{{ message() }}</p>
+  @if (viewMessage) {
+    <p>{{ viewMessage }}</p>
   }
-  <p>Progress: {{ progress() }}%</p>
-  <div class="progress-bar">
-    <div class="progress-fill" [style.width.%]="progress()"></div>
+  <p class="progress-label">Progress: {{ viewProgress() }}%</p>
+  <div class="progress-bar" role="progressbar" [attr.aria-valuenow]="viewProgress()" aria-valuemin="0" aria-valuemax="100">
+    <div class="progress-fill" [style.width.%]="viewProgress()"></div>
   </div>
+  @if (!viewHideCancel) {
+    <div class="dialog-actions">
+      <button type="button" (click)="cancel()">{{ viewCancelLabel }}</button>
+    </div>
+  }
 </div>

--- a/libs/dialogs/src/lib/dialogs/progress-dialog/progress-dialog.component.spec.ts
+++ b/libs/dialogs/src/lib/dialogs/progress-dialog/progress-dialog.component.spec.ts
@@ -1,0 +1,54 @@
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ProgressDialogComponent,
+  ProgressDialogData,
+} from './progress-dialog.component';
+
+describe('ProgressDialogComponent', () => {
+  let fixture: ComponentFixture<ProgressDialogComponent>;
+  let close: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    close = vi.fn();
+    const progress = signal(12);
+    const data: ProgressDialogData = {
+      message: 'Saving…',
+      progress,
+      cancelLabel: 'Stop',
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [ProgressDialogComponent],
+      providers: [
+        { provide: DIALOG_DATA, useValue: data },
+        { provide: DialogRef, useValue: { close } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProgressDialogComponent);
+    fixture.detectChanges();
+  });
+
+  it('shows message and live progress from dialog data', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('Saving…');
+    expect(el.textContent).toContain('Progress: 12%');
+
+    const data = TestBed.inject(DIALOG_DATA) as ProgressDialogData;
+    (data.progress as ReturnType<typeof signal<number>>).set(55);
+    fixture.detectChanges();
+    expect(el.textContent).toContain('Progress: 55%');
+  });
+
+  it('closes with cancelled when cancel is clicked', () => {
+    const button = (fixture.nativeElement as HTMLElement).querySelector(
+      'button',
+    );
+    expect(button?.textContent?.trim()).toBe('Stop');
+    button?.dispatchEvent(new MouseEvent('click'));
+    expect(close).toHaveBeenCalledWith('cancelled');
+  });
+});

--- a/libs/dialogs/src/lib/dialogs/progress-dialog/progress-dialog.component.ts
+++ b/libs/dialogs/src/lib/dialogs/progress-dialog/progress-dialog.component.ts
@@ -1,4 +1,25 @@
-import { Component, input } from '@angular/core';
+import { DialogRef, DIALOG_DATA } from '@angular/cdk/dialog';
+import {
+  Component,
+  computed,
+  inject,
+  input,
+  OnInit,
+  Signal,
+  signal,
+  WritableSignal,
+} from '@angular/core';
+
+export interface ProgressDialogData {
+  message?: string;
+  /** Caller updates this signal to refresh the progress bar (0–100). */
+  progress?: WritableSignal<number> | Signal<number>;
+  cancelLabel?: string;
+  /** When true, hide the cancel button. */
+  hideCancel?: boolean;
+}
+
+export type ProgressDialogResult = 'cancelled' | undefined;
 
 @Component({
   selector: 'lib-progress-dialog',
@@ -6,8 +27,23 @@ import { Component, input } from '@angular/core';
   styles: [
     `
       .dialog-content {
-        padding: 1rem;
-        min-width: 200px;
+        min-width: 280px;
+        max-width: 100%;
+        padding: 1.25rem 1.5rem;
+        background: #fff;
+        color: rgba(0, 0, 0, 0.87);
+        border-radius: 8px;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+      }
+      .dialog-content p {
+        margin: 0;
+        white-space: pre-wrap;
+        word-break: break-word;
+        line-height: 1.5;
+      }
+      .progress-label {
+        margin-top: 0.75rem;
+        font-variant-numeric: tabular-nums;
       }
       .progress-bar {
         height: 8px;
@@ -21,10 +57,76 @@ import { Component, input } from '@angular/core';
         background: #1976d2;
         transition: width 0.2s ease;
       }
+      .dialog-actions {
+        display: flex;
+        gap: 0.5rem;
+        margin-top: 1.25rem;
+        justify-content: flex-end;
+      }
+      .dialog-actions button {
+        padding: 0.4rem 0.85rem;
+        border: 1px solid rgba(0, 0, 0, 0.24);
+        border-radius: 4px;
+        background: #fff;
+        color: inherit;
+        cursor: pointer;
+        font: inherit;
+      }
+      .dialog-actions button:hover {
+        background: rgba(0, 0, 0, 0.04);
+      }
     `,
   ],
 })
-export class ProgressDialogComponent {
-  readonly message = input('');
+export class ProgressDialogComponent implements OnInit {
+  private dialogRef = inject(DialogRef<ProgressDialogResult>, {
+    optional: true,
+  });
+  private data = inject<ProgressDialogData | null>(DIALOG_DATA, {
+    optional: true,
+  });
+
+  readonly message = input('Transferring...');
   readonly progress = input(0);
+  readonly cancelLabel = input('Cancel');
+  readonly hideCancel = input(false);
+
+  viewMessage = 'Transferring...';
+  viewCancelLabel = 'Cancel';
+  viewHideCancel = false;
+  private progressSource: Signal<number> = signal(0);
+
+  readonly viewProgress = computed(() => {
+    const value = this.progressSource();
+    if (!Number.isFinite(value)) {
+      return 0;
+    }
+    return Math.max(0, Math.min(100, Math.round(value)));
+  });
+
+  ngOnInit(): void {
+    this.viewMessage = this.message();
+    this.viewCancelLabel = this.cancelLabel();
+    this.viewHideCancel = this.hideCancel();
+    this.progressSource = signal(this.progress());
+
+    if (this.data) {
+      if (this.data.message != null) {
+        this.viewMessage = this.data.message;
+      }
+      if (this.data.cancelLabel != null) {
+        this.viewCancelLabel = this.data.cancelLabel;
+      }
+      if (this.data.hideCancel === true) {
+        this.viewHideCancel = true;
+      }
+      if (this.data.progress) {
+        this.progressSource = this.data.progress;
+      }
+    }
+  }
+
+  cancel(): void {
+    this.dialogRef?.close('cancelled');
+  }
 }

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -638,7 +638,7 @@ describe('EditorPageComponent', () => {
   });
 
   it('should refuse files larger than the max size', async () => {
-    const { EDITOR_FILE_MAX_BYTES } = await import('@libs-shared');
+    const { EDITOR_FILE_MAX_BYTES } = await import('@libs-web-serial');
     editorServiceMock.getByteSize.mockResolvedValue(EDITOR_FILE_MAX_BYTES + 1);
     editorServiceMock.loadTextFile.mockClear();
 
@@ -652,7 +652,7 @@ describe('EditorPageComponent', () => {
   });
 
   it('should confirm before opening warn-sized files', async () => {
-    const { EDITOR_FILE_WARN_BYTES } = await import('@libs-shared');
+    const { EDITOR_FILE_WARN_BYTES } = await import('@libs-web-serial');
     const confirmClosed = new Subject<unknown>();
     dialogServiceMock.open
       .mockReturnValueOnce({ closed: confirmClosed.asObservable() })
@@ -683,7 +683,7 @@ describe('EditorPageComponent', () => {
   });
 
   it('should abort warn-sized open when the user cancels', async () => {
-    const { EDITOR_FILE_WARN_BYTES } = await import('@libs-shared');
+    const { EDITOR_FILE_WARN_BYTES } = await import('@libs-web-serial');
     const confirmClosed = new Subject<unknown>();
     dialogServiceMock.open.mockReturnValueOnce({
       closed: confirmClosed.asObservable(),

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -5,7 +5,12 @@ import { DialogService } from '@libs-dialogs';
 import { FileService } from '@libs-file-manager';
 import { ConsoleShellStore, NotificationService } from '@libs-shared';
 import type { SerialConnectionViewModel } from '@libs-web-serial';
-import { SerialConnectionViewModelFacade } from '@libs-web-serial';
+import {
+  EDITOR_FILE_MAX_BYTES,
+  EDITOR_FILE_WARN_BYTES,
+  NonUtf8TextError,
+  SerialConnectionViewModelFacade,
+} from '@libs-web-serial';
 import { provideMonacoEditor } from 'ngx-monaco-editor-v2';
 import { Subject } from 'rxjs';
 import { EditorDraftService, EditorService } from '../../service';
@@ -100,7 +105,8 @@ describe('EditorPageComponent', () => {
     await fixture.whenStable();
   }
 
-  function mockDialogResult(_result: unknown): Subject<unknown> {
+  function mockDialogResult(..._unused: unknown[]): Subject<unknown> {
+    void _unused;
     const closed = new Subject<unknown>();
     dialogServiceMock.open.mockReturnValueOnce({
       closed: closed.asObservable(),
@@ -638,7 +644,6 @@ describe('EditorPageComponent', () => {
   });
 
   it('should refuse files larger than the max size', async () => {
-    const { EDITOR_FILE_MAX_BYTES } = await import('@libs-web-serial');
     editorServiceMock.getByteSize.mockResolvedValue(EDITOR_FILE_MAX_BYTES + 1);
     editorServiceMock.loadTextFile.mockClear();
 
@@ -652,7 +657,6 @@ describe('EditorPageComponent', () => {
   });
 
   it('should confirm before opening warn-sized files', async () => {
-    const { EDITOR_FILE_WARN_BYTES } = await import('@libs-web-serial');
     const confirmClosed = new Subject<unknown>();
     dialogServiceMock.open
       .mockReturnValueOnce({ closed: confirmClosed.asObservable() })
@@ -683,7 +687,6 @@ describe('EditorPageComponent', () => {
   });
 
   it('should abort warn-sized open when the user cancels', async () => {
-    const { EDITOR_FILE_WARN_BYTES } = await import('@libs-web-serial');
     const confirmClosed = new Subject<unknown>();
     dialogServiceMock.open.mockReturnValueOnce({
       closed: confirmClosed.asObservable(),
@@ -705,7 +708,6 @@ describe('EditorPageComponent', () => {
   });
 
   it('should refuse non UTF-8 files', async () => {
-    const { NonUtf8TextError } = await import('@libs-web-serial');
     editorServiceMock.getByteSize.mockResolvedValue(3);
     editorServiceMock.loadTextFile.mockRejectedValue(new NonUtf8TextError());
 

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -25,8 +25,20 @@ describe('EditorPageComponent', () => {
     errorMessage: null,
   });
   const editorServiceMock = {
-    loadTextFile: vi.fn().mockResolvedValue('loaded content'),
+    loadTextFile: vi.fn().mockResolvedValue({
+      content: 'loaded content',
+      meta: {
+        encoding: 'utf-8',
+        bom: false,
+        lineEnding: 'lf',
+        trailingNewline: true,
+      },
+      size: 14,
+    }),
     saveTextFile: vi.fn().mockResolvedValue(undefined),
+    getByteSize: vi.fn().mockResolvedValue(14),
+    cancelTransfer: vi.fn(),
+    applyLineEnding: vi.fn(),
     initializeEditor: vi.fn(),
     formatDocument: vi.fn().mockResolvedValue(true),
     getValue: vi.fn().mockReturnValue(null),
@@ -64,8 +76,25 @@ describe('EditorPageComponent', () => {
     warning: vi.fn(),
   };
 
+  function loadedFile(
+    content: string,
+    overrides?: Partial<{ size: number; lineEnding: 'lf' | 'crlf' }>,
+  ) {
+    return {
+      content,
+      meta: {
+        encoding: 'utf-8' as const,
+        bom: false,
+        lineEnding: overrides?.lineEnding ?? ('lf' as const),
+        trailingNewline: content.endsWith('\n'),
+      },
+      size: overrides?.size ?? content.length,
+    };
+  }
+
   async function loadPath(path: string, content = 'loaded content'): Promise<void> {
-    editorServiceMock.loadTextFile.mockResolvedValue(content);
+    editorServiceMock.loadTextFile.mockResolvedValue(loadedFile(content));
+    editorServiceMock.getByteSize.mockResolvedValue(content.length);
     selectedFilePathSignal.set(path);
     fixture.detectChanges();
     await fixture.whenStable();
@@ -94,7 +123,17 @@ describe('EditorPageComponent', () => {
     draftServiceMock.read.mockReturnValue(null);
     draftServiceMock.list.mockReturnValue([]);
     draftServiceMock.has.mockReturnValue(false);
-    editorServiceMock.loadTextFile.mockResolvedValue('loaded content');
+    editorServiceMock.loadTextFile.mockResolvedValue({
+      content: 'loaded content',
+      meta: {
+        encoding: 'utf-8',
+        bom: false,
+        lineEnding: 'lf',
+        trailingNewline: true,
+      },
+      size: 14,
+    });
+    editorServiceMock.getByteSize.mockResolvedValue(14);
     fileServiceMock.exists.mockResolvedValue(false);
     fileServiceMock.touch.mockResolvedValue(undefined);
 
@@ -154,12 +193,14 @@ describe('EditorPageComponent', () => {
     await loadPath('/home/pi/ok.js', 'previous');
     const previousCode = component.code();
 
+    editorServiceMock.getByteSize.mockResolvedValue(8);
     editorServiceMock.loadTextFile.mockRejectedValue(
       new Error('Target file is not a text file'),
     );
     selectedFilePathSignal.set('/home/pi/binary.bin');
     fixture.detectChanges();
     await fixture.whenStable();
+    await Promise.resolve();
 
     expect(component.code()).toBe(previousCode);
     expect(component.currentFileName()).toBe('ok.js');
@@ -191,6 +232,12 @@ describe('EditorPageComponent', () => {
     expect(editorServiceMock.saveTextFile).toHaveBeenCalledWith(
       '/home/pi/main.js',
       'updated',
+      {
+        encoding: 'utf-8',
+        bom: false,
+        lineEnding: 'lf',
+        trailingNewline: false,
+      },
     );
     expect(component.isDirty()).toBe(false);
     expect(component.saveStatus()).toBe('savedToDevice');
@@ -303,7 +350,7 @@ describe('EditorPageComponent', () => {
         updatedAt: Date.now(),
       },
     ]);
-    editorServiceMock.loadTextFile.mockResolvedValue('device content');
+    editorServiceMock.loadTextFile.mockResolvedValue(loadedFile('device content'));
 
     const initPromise = component.ngOnInit();
     closed.next('restore');
@@ -326,7 +373,7 @@ describe('EditorPageComponent', () => {
         updatedAt: Date.now(),
       },
     ]);
-    editorServiceMock.loadTextFile.mockResolvedValue('device content');
+    editorServiceMock.loadTextFile.mockResolvedValue(loadedFile('device content'));
 
     const initPromise = component.ngOnInit();
     closed.next('reload');
@@ -568,7 +615,8 @@ describe('EditorPageComponent', () => {
     });
 
     editorServiceMock.loadTextFile.mockClear();
-    editorServiceMock.loadTextFile.mockResolvedValue('recovered');
+    editorServiceMock.loadTextFile.mockResolvedValue(loadedFile('recovered'));
+    editorServiceMock.getByteSize.mockResolvedValue(9);
 
     await component.retryLoadCurrentFile();
 
@@ -587,5 +635,89 @@ describe('EditorPageComponent', () => {
     await component.formatCurrentFile();
 
     expect(editorServiceMock.formatDocument).not.toHaveBeenCalled();
+  });
+
+  it('should refuse files larger than the max size', async () => {
+    const { EDITOR_FILE_MAX_BYTES } = await import('@libs-shared');
+    editorServiceMock.getByteSize.mockResolvedValue(EDITOR_FILE_MAX_BYTES + 1);
+    editorServiceMock.loadTextFile.mockClear();
+
+    selectedFilePathSignal.set('/home/pi/huge.js');
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(editorServiceMock.loadTextFile).not.toHaveBeenCalled();
+    expect(notifyMock.error).toHaveBeenCalled();
+    expect(component.loadError()?.path).toBe('/home/pi/huge.js');
+  });
+
+  it('should confirm before opening warn-sized files', async () => {
+    const { EDITOR_FILE_WARN_BYTES } = await import('@libs-shared');
+    const confirmClosed = new Subject<unknown>();
+    dialogServiceMock.open
+      .mockReturnValueOnce({ closed: confirmClosed.asObservable() })
+      .mockReturnValueOnce({
+        closed: new Subject<unknown>().asObservable(),
+        close: vi.fn(),
+      });
+
+    editorServiceMock.getByteSize.mockResolvedValue(EDITOR_FILE_WARN_BYTES);
+    editorServiceMock.loadTextFile.mockResolvedValue(
+      loadedFile('big', { size: EDITOR_FILE_WARN_BYTES }),
+    );
+
+    const fetchPromise = (
+      component as unknown as {
+        fetchDeviceFile: (path: string) => Promise<void>;
+      }
+    ).fetchDeviceFile('/home/pi/big.js');
+    await Promise.resolve();
+    confirmClosed.next(true);
+    confirmClosed.complete();
+    await fetchPromise;
+
+    expect(dialogServiceMock.open).toHaveBeenCalled();
+    expect(editorServiceMock.loadTextFile).toHaveBeenCalledWith('/home/pi/big.js');
+    expect(component.code()).toBe('big');
+    expect(component.saveStatus()).toBe('savedToDevice');
+  });
+
+  it('should abort warn-sized open when the user cancels', async () => {
+    const { EDITOR_FILE_WARN_BYTES } = await import('@libs-shared');
+    const confirmClosed = new Subject<unknown>();
+    dialogServiceMock.open.mockReturnValueOnce({
+      closed: confirmClosed.asObservable(),
+    });
+    editorServiceMock.getByteSize.mockResolvedValue(EDITOR_FILE_WARN_BYTES);
+    editorServiceMock.loadTextFile.mockClear();
+
+    const fetchPromise = (
+      component as unknown as {
+        fetchDeviceFile: (path: string) => Promise<void>;
+      }
+    ).fetchDeviceFile('/home/pi/big.js');
+    await Promise.resolve();
+    confirmClosed.next(false);
+    confirmClosed.complete();
+    await fetchPromise;
+
+    expect(editorServiceMock.loadTextFile).not.toHaveBeenCalled();
+  });
+
+  it('should refuse non UTF-8 files', async () => {
+    const { NonUtf8TextError } = await import('@libs-web-serial');
+    editorServiceMock.getByteSize.mockResolvedValue(3);
+    editorServiceMock.loadTextFile.mockRejectedValue(new NonUtf8TextError());
+
+    selectedFilePathSignal.set('/home/pi/bad.js');
+    fixture.detectChanges();
+    await fixture.whenStable();
+    await Promise.resolve();
+
+    expect(notifyMock.error).toHaveBeenCalledWith(
+      '読込失敗',
+      'UTF-8 ではないためファイルを開けません。',
+    );
+    expect(component.loadError()?.message).toContain('UTF-8');
   });
 });

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.ts
@@ -8,14 +8,30 @@ import {
   signal,
 } from '@angular/core';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
-import { ConfirmDialogComponent, DialogService } from '@libs-dialogs';
+import {
+  ConfirmDialogComponent,
+  DialogService,
+  ProgressDialogComponent,
+  type ProgressDialogData,
+} from '@libs-dialogs';
 import {
   FileNameDialogComponent,
   FileService,
   joinPath,
 } from '@libs-file-manager';
-import { ConsoleShellStore, NotificationService } from '@libs-shared';
-import { SerialConnectionViewModelFacade } from '@libs-web-serial';
+import {
+  ConsoleShellStore,
+  DEFAULT_NEW_TEXT_FILE_META,
+  EDITOR_FILE_MAX_BYTES,
+  EDITOR_FILE_WARN_BYTES,
+  NotificationService,
+  type TextFileMeta,
+} from '@libs-shared';
+import {
+  FileUtils,
+  isNonUtf8TextError,
+  SerialConnectionViewModelFacade,
+} from '@libs-web-serial';
 import type { editor } from 'monaco-editor';
 import { firstValueFrom } from 'rxjs';
 import { resolveEditorLanguage } from '../../functions';
@@ -102,10 +118,12 @@ export class EditorPageComponent implements OnInit {
   private readonly activeFilePath = signal<string | null>(null);
   private baselineContent = '';
   private baselineReady = false;
+  private textFileMeta: TextFileMeta = { ...DEFAULT_NEW_TEXT_FILE_META };
   private initialized = false;
   private loadGeneration = 0;
   private ignoreNextSelection = false;
   private promptInFlight: Promise<boolean> | null = null;
+  private transferAbortGeneration = 0;
 
   constructor() {
     effect(() => {
@@ -199,6 +217,7 @@ export class EditorPageComponent implements OnInit {
     this.code.set('');
     this.baselineContent = '';
     this.baselineReady = false;
+    this.textFileMeta = { ...DEFAULT_NEW_TEXT_FILE_META };
     this.saveStatus.set(null);
     this.loadError.set(null);
     this.saveError.set(null);
@@ -258,13 +277,63 @@ export class EditorPageComponent implements OnInit {
     this.isReadOnly.set(false);
 
     try {
-      const loaded = await this.editorService.loadTextFile(path);
+      const byteSize = await this.editorService.getByteSize(path);
       if (generation !== this.loadGeneration) {
         return;
       }
-      this.applyDeviceContent(path, loaded);
+
+      if (byteSize > EDITOR_FILE_MAX_BYTES) {
+        this.notify.error(
+          '読込失敗',
+          `ファイルが大きすぎます（上限 ${FileUtils.formatFileSize(EDITOR_FILE_MAX_BYTES)}）。`,
+        );
+        this.loadError.set({
+          path,
+          message: `ファイルが大きすぎるため開けません: ${path}`,
+          detail: `size=${byteSize} max=${EDITOR_FILE_MAX_BYTES}`,
+        });
+        this.restoreStatusAfterFailedLoad(previousStatus);
+        return;
+      }
+
+      if (byteSize >= EDITOR_FILE_WARN_BYTES) {
+        const proceed = await this.confirmLargeFileOpen(byteSize);
+        if (generation !== this.loadGeneration) {
+          return;
+        }
+        if (!proceed) {
+          this.restoreStatusAfterFailedLoad(previousStatus);
+          if (!this.activeFilePath()) {
+            this.revertSelection();
+          }
+          return;
+        }
+      }
+
+      const showProgress = byteSize >= EDITOR_FILE_WARN_BYTES;
+      const loaded = showProgress
+        ? await this.loadTextFileWithProgress(path, generation)
+        : await this.editorService.loadTextFile(path);
+
+      if (generation !== this.loadGeneration || loaded === null) {
+        return;
+      }
+      this.applyDeviceContent(path, loaded.content, loaded.meta);
     } catch (error: unknown) {
       if (generation !== this.loadGeneration) {
+        return;
+      }
+      if (isNonUtf8TextError(error)) {
+        this.notify.error(
+          '読込失敗',
+          'UTF-8 ではないためファイルを開けません。',
+        );
+        this.loadError.set({
+          path,
+          message: `UTF-8 ではないため開けません: ${path}`,
+          detail: error instanceof Error ? error.message : 'NON_UTF8_TEXT',
+        });
+        this.restoreStatusAfterFailedLoad(previousStatus);
         return;
       }
       const detail =
@@ -275,11 +344,121 @@ export class EditorPageComponent implements OnInit {
         detail,
       });
       this.notify.error('読込失敗', `ファイルの読み込みに失敗しました: ${path}`);
-      if (this.activeFilePath()) {
-        this.saveStatus.set(previousStatus ?? 'savedToDevice');
-      } else {
-        this.saveStatus.set(null);
+      this.restoreStatusAfterFailedLoad(previousStatus);
+    }
+  }
+
+  private restoreStatusAfterFailedLoad(
+    previousStatus: EditorSaveStatus | null,
+  ): void {
+    if (this.activeFilePath()) {
+      this.saveStatus.set(previousStatus ?? 'savedToDevice');
+    } else {
+      this.saveStatus.set(null);
+    }
+  }
+
+  private async confirmLargeFileOpen(byteSize: number): Promise<boolean> {
+    const sizeLabel = FileUtils.formatFileSize(byteSize);
+    const ref = this.dialog.open(ConfirmDialogComponent, {
+      width: '420px',
+      data: {
+        title: '大きなファイル',
+        message: `このファイルは ${sizeLabel} あります。読み込みに時間がかかる可能性があります。開きますか？`,
+        confirmLabel: '開く',
+        cancelLabel: 'キャンセル',
+      },
+    });
+    return (await firstValueFrom(ref.closed)) === true;
+  }
+
+  private async loadTextFileWithProgress(
+    path: string,
+    generation: number,
+  ): Promise<{ content: string; meta: TextFileMeta; size: number } | null> {
+    const progress = signal(0);
+    const data: ProgressDialogData = {
+      message: `読み込み中…\n${path}`,
+      progress,
+      cancelLabel: 'キャンセル',
+    };
+    const ref = this.dialog.open(ProgressDialogComponent, {
+      width: '400px',
+      data,
+      disableClose: true,
+    });
+
+    const abortGeneration = ++this.transferAbortGeneration;
+    const cancelSub = ref.closed.subscribe((result) => {
+      if (
+        result === 'cancelled' &&
+        abortGeneration === this.transferAbortGeneration &&
+        generation === this.loadGeneration
+      ) {
+        this.editorService.cancelTransfer();
       }
+    });
+
+    progress.set(10);
+    try {
+      progress.set(40);
+      const loaded = await this.editorService.loadTextFile(path);
+      progress.set(100);
+      ref.close();
+      return loaded;
+    } catch (error: unknown) {
+      ref.close();
+      const cancelled =
+        error instanceof Error && isUserCancelledTransfer(error.message);
+      if (cancelled) {
+        this.notify.warning('読込キャンセル', 'ファイルの読み込みを中止しました');
+        this.restoreStatusAfterFailedLoad(null);
+        return null;
+      }
+      throw error;
+    } finally {
+      cancelSub.unsubscribe();
+    }
+  }
+
+  private async saveTextFileWithProgress(
+    path: string,
+    content: string,
+    meta: TextFileMeta,
+  ): Promise<void> {
+    const progress = signal(0);
+    const data: ProgressDialogData = {
+      message: `保存中…\n${path}`,
+      progress,
+      cancelLabel: 'キャンセル',
+    };
+    const ref = this.dialog.open(ProgressDialogComponent, {
+      width: '400px',
+      data,
+      disableClose: true,
+    });
+
+    const abortGeneration = ++this.transferAbortGeneration;
+    const cancelSub = ref.closed.subscribe((result) => {
+      if (
+        result === 'cancelled' &&
+        abortGeneration === this.transferAbortGeneration
+      ) {
+        this.editorService.cancelTransfer();
+      }
+    });
+
+    try {
+      await this.editorService.saveTextFile(path, content, meta, {
+        onProgress: (percent) => progress.set(percent),
+      });
+      progress.set(100);
+      ref.close();
+    } catch (error: unknown) {
+      ref.close();
+      throw error;
+    } finally {
+      cancelSub.unsubscribe();
     }
   }
 
@@ -291,15 +470,21 @@ export class EditorPageComponent implements OnInit {
     await this.fetchDeviceFile(path);
   }
 
-  private applyDeviceContent(path: string, content: string): void {
+  private applyDeviceContent(
+    path: string,
+    content: string,
+    meta: TextFileMeta,
+  ): void {
     this.activeFilePath.set(path);
     this.code.set(content);
     this.baselineContent = content;
     this.baselineReady = true;
+    this.textFileMeta = { ...meta };
     this.saveStatus.set('savedToDevice');
     this.saveError.set(null);
     this.lastDeviceSavedAt.set(null);
     this.isReadOnly.set(false);
+    this.editorService.applyLineEnding(meta.lineEnding);
   }
 
   private async resolveDraft(draft: EditorDraft): Promise<void> {
@@ -330,11 +515,15 @@ export class EditorPageComponent implements OnInit {
     this.isReadOnly.set(false);
 
     try {
-      this.baselineContent = await this.editorService.loadTextFile(draft.path);
+      const loaded = await this.editorService.loadTextFile(draft.path);
+      this.baselineContent = loaded.content;
       this.baselineReady = true;
+      this.textFileMeta = { ...loaded.meta };
+      this.editorService.applyLineEnding(loaded.meta.lineEnding);
     } catch {
       this.baselineContent = '';
       this.baselineReady = false;
+      this.textFileMeta = { ...DEFAULT_NEW_TEXT_FILE_META };
     }
   }
 
@@ -431,9 +620,24 @@ export class EditorPageComponent implements OnInit {
 
     this.saveStatus.set('saving');
     this.saveError.set(null);
+
+    const meta = this.textFileMeta;
+    const content = this.code();
+    const estimatedBytes = new TextEncoder().encode(
+      // rough size for progress UI decision; exact payload may differ slightly
+      content,
+    ).byteLength;
+    const showProgress =
+      estimatedBytes > FileUtils.TEXT_CHUNK_THRESHOLD_BYTES ||
+      estimatedBytes >= EDITOR_FILE_WARN_BYTES;
+
     try {
-      await this.editorService.saveTextFile(path, this.code());
-      this.baselineContent = this.code();
+      if (showProgress) {
+        await this.saveTextFileWithProgress(path, content, meta);
+      } else {
+        await this.editorService.saveTextFile(path, content, meta);
+      }
+      this.baselineContent = content;
       this.baselineReady = true;
       this.lastDeviceSavedAt.set(Date.now());
       this.isReadOnly.set(false);
@@ -445,6 +649,11 @@ export class EditorPageComponent implements OnInit {
         error instanceof Error
           ? error.message
           : 'Save failed: unexpected error while writing to the device';
+      if (isUserCancelledTransfer(detail)) {
+        this.saveStatus.set('draftSavedLocally');
+        this.notify.warning('保存キャンセル', '保存を中止しました。Draft は保持されています。');
+        return;
+      }
       this.saveError.set({
         message: 'デバイスへの保存に失敗しました。内容は Editor / Draft に保持されています。',
         detail,
@@ -591,5 +800,15 @@ function isWritePermissionDenied(message: string): boolean {
   return (
     lower.includes('write permission was denied') ||
     lower.includes('permission denied')
+  );
+}
+
+/** User clicked Cancel on the progress dialog (not serial disconnect). */
+function isUserCancelledTransfer(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('all commands cancelled') ||
+    lower === 'cancelled' ||
+    lower.includes('transfer cancelled')
   );
 }

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.ts
@@ -19,18 +19,15 @@ import {
   FileService,
   joinPath,
 } from '@libs-file-manager';
+import { ConsoleShellStore, NotificationService } from '@libs-shared';
 import {
-  ConsoleShellStore,
   DEFAULT_NEW_TEXT_FILE_META,
   EDITOR_FILE_MAX_BYTES,
   EDITOR_FILE_WARN_BYTES,
-  NotificationService,
-  type TextFileMeta,
-} from '@libs-shared';
-import {
   FileUtils,
   isNonUtf8TextError,
   SerialConnectionViewModelFacade,
+  type TextFileMeta,
 } from '@libs-web-serial';
 import type { editor } from 'monaco-editor';
 import { firstValueFrom } from 'rxjs';

--- a/libs/editor/src/lib/service/editor.service.spec.ts
+++ b/libs/editor/src/lib/service/editor.service.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { DEFAULT_NEW_TEXT_FILE_META } from '@libs-shared';
 import { FileContentService, SerialFacadeService } from '@libs-web-serial';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EditorService } from './editor.service';
@@ -17,11 +18,11 @@ describe('EditorService.saveTextFile', () => {
         EditorService,
         {
           provide: FileContentService,
-          useValue: { writeTextFile, readFile: vi.fn() },
+          useValue: { writeTextFile, readFile: vi.fn(), getByteSize: vi.fn() },
         },
         {
           provide: SerialFacadeService,
-          useValue: { isConnected },
+          useValue: { isConnected, cancelAllCommands: vi.fn() },
         },
       ],
     });
@@ -29,16 +30,19 @@ describe('EditorService.saveTextFile', () => {
     service = TestBed.inject(EditorService);
   });
 
-  it('delegates to FileContentService when connected', async () => {
-    await service.saveTextFile('/home/pi/a.js', 'x = 1');
-    expect(writeTextFile).toHaveBeenCalledWith('/home/pi/a.js', 'x = 1');
+  it('serializes meta then delegates to FileContentService when connected', async () => {
+    await service.saveTextFile('/home/pi/a.js', 'x = 1', {
+      ...DEFAULT_NEW_TEXT_FILE_META,
+      trailingNewline: true,
+    });
+    expect(writeTextFile).toHaveBeenCalledWith('/home/pi/a.js', 'x = 1\n', undefined);
   });
 
   it('fails without writing when disconnected', async () => {
     isConnected.mockReturnValue(false);
 
     await expect(
-      service.saveTextFile('/home/pi/a.js', 'x = 1'),
+      service.saveTextFile('/home/pi/a.js', 'x', DEFAULT_NEW_TEXT_FILE_META),
     ).rejects.toThrow(/connection was lost or cancelled/);
 
     expect(writeTextFile).not.toHaveBeenCalled();
@@ -48,8 +52,54 @@ describe('EditorService.saveTextFile', () => {
     writeTextFile.mockRejectedValueOnce(new Error('Permission denied'));
 
     await expect(
-      service.saveTextFile('/home/pi/a.js', 'x = 1'),
+      service.saveTextFile('/home/pi/a.js', 'x', DEFAULT_NEW_TEXT_FILE_META),
     ).rejects.toThrow(/write permission was denied/);
+  });
+});
+
+describe('EditorService.loadTextFile', () => {
+  let service: EditorService;
+  let readFile: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    readFile = vi.fn().mockResolvedValue({
+      content: 'hello',
+      isText: true,
+      size: 5,
+      encoding: 'utf-8',
+      meta: DEFAULT_NEW_TEXT_FILE_META,
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        EditorService,
+        {
+          provide: FileContentService,
+          useValue: {
+            writeTextFile: vi.fn(),
+            readFile,
+            getByteSize: vi.fn().mockResolvedValue(5),
+          },
+        },
+        {
+          provide: SerialFacadeService,
+          useValue: {
+            isConnected: vi.fn().mockReturnValue(true),
+            cancelAllCommands: vi.fn(),
+          },
+        },
+      ],
+    });
+
+    service = TestBed.inject(EditorService);
+  });
+
+  it('returns content and meta for text files', async () => {
+    await expect(service.loadTextFile('/home/pi/a.js')).resolves.toEqual({
+      content: 'hello',
+      meta: DEFAULT_NEW_TEXT_FILE_META,
+      size: 5,
+    });
   });
 });
 
@@ -62,11 +112,14 @@ describe('EditorService.formatDocument', () => {
         EditorService,
         {
           provide: FileContentService,
-          useValue: { writeTextFile: vi.fn(), readFile: vi.fn() },
+          useValue: { writeTextFile: vi.fn(), readFile: vi.fn(), getByteSize: vi.fn() },
         },
         {
           provide: SerialFacadeService,
-          useValue: { isConnected: vi.fn().mockReturnValue(true) },
+          useValue: {
+            isConnected: vi.fn().mockReturnValue(true),
+            cancelAllCommands: vi.fn(),
+          },
         },
       ],
     });
@@ -87,6 +140,7 @@ describe('EditorService.formatDocument', () => {
         run,
       }),
       getValue: vi.fn().mockReturnValue(''),
+      getModel: vi.fn().mockReturnValue(null),
     } as never);
 
     await expect(service.formatDocument()).resolves.toBe(false);
@@ -102,6 +156,7 @@ describe('EditorService.formatDocument', () => {
         run,
       }),
       getValue: vi.fn().mockReturnValue('formatted'),
+      getModel: vi.fn().mockReturnValue(null),
     } as never);
 
     await expect(service.formatDocument()).resolves.toBe(true);

--- a/libs/editor/src/lib/service/editor.service.spec.ts
+++ b/libs/editor/src/lib/service/editor.service.spec.ts
@@ -1,6 +1,9 @@
 import { TestBed } from '@angular/core/testing';
-import { DEFAULT_NEW_TEXT_FILE_META } from '@libs-shared';
-import { FileContentService, SerialFacadeService } from '@libs-web-serial';
+import {
+  DEFAULT_NEW_TEXT_FILE_META,
+  FileContentService,
+  SerialFacadeService,
+} from '@libs-web-serial';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { EditorService } from './editor.service';
 

--- a/libs/editor/src/lib/service/editor.service.ts
+++ b/libs/editor/src/lib/service/editor.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, inject } from '@angular/core';
-import type { TextFileMeta, TextLineEnding } from '@libs-shared';
 import type { editor } from 'monaco-editor';
 import {
   classifyFileWriteError,
@@ -7,6 +6,8 @@ import {
   type FileTransferOptions,
   SerialFacadeService,
   serializeTextFileForSave,
+  type TextFileMeta,
+  type TextLineEnding,
 } from '@libs-web-serial';
 
 export interface EditorLoadedTextFile {

--- a/libs/editor/src/lib/service/editor.service.ts
+++ b/libs/editor/src/lib/service/editor.service.ts
@@ -1,10 +1,19 @@
 import { Injectable, inject } from '@angular/core';
+import type { TextFileMeta, TextLineEnding } from '@libs-shared';
 import type { editor } from 'monaco-editor';
 import {
   classifyFileWriteError,
   FileContentService,
+  type FileTransferOptions,
   SerialFacadeService,
+  serializeTextFileForSave,
 } from '@libs-web-serial';
+
+export interface EditorLoadedTextFile {
+  content: string;
+  meta: TextFileMeta;
+  size: number;
+}
 
 /**
  * エディターサービス
@@ -38,31 +47,66 @@ export class EditorService {
     });
   }
 
+  /** Remote UTF-8 byte size (`wc -c`) for large-file preflight. */
+  async getByteSize(path: string): Promise<number> {
+    return this.fileContent.getByteSize(path);
+  }
+
   /**
    * デバイス上のテキストファイルを読み込みます。
    */
-  async loadTextFile(path: string): Promise<string> {
+  async loadTextFile(path: string): Promise<EditorLoadedTextFile> {
     const info = await this.fileContent.readFile(path);
-    if (!info.isText || typeof info.content !== 'string') {
+    if (!info.isText || typeof info.content !== 'string' || !info.meta) {
       throw new Error('Target file is not a text file');
     }
-    return info.content;
+    return {
+      content: info.content,
+      meta: info.meta,
+      size: info.size,
+    };
   }
 
   /**
    * デバイス上のテキストファイルを安全に保存します。
    * 未接続時は実ファイルへ書き込まず失敗します。
+   * `editorContent` は Monaco 上の LF 正規化テキスト。`meta` で BOM/EOL を再適用する。
    */
-  async saveTextFile(path: string, content: string): Promise<void> {
+  async saveTextFile(
+    path: string,
+    editorContent: string,
+    meta: TextFileMeta,
+    options?: FileTransferOptions,
+  ): Promise<void> {
     if (!this.serial.isConnected()) {
       throw classifyFileWriteError(new Error('not connected'));
     }
 
+    const payload = serializeTextFileForSave(editorContent, meta);
+
     try {
-      await this.fileContent.writeTextFile(path, content);
+      await this.fileContent.writeTextFile(path, payload, options);
     } catch (error: unknown) {
       throw classifyFileWriteError(error);
     }
+  }
+
+  /** Abort in-flight serial commands used by load/save transfers. */
+  cancelTransfer(): void {
+    this.serial.cancelAllCommands();
+  }
+
+  /** Apply Monaco model EOL to match preserved file meta. */
+  applyLineEnding(lineEnding: TextLineEnding): void {
+    const model = this.editor?.getModel();
+    if (!model || typeof monaco === 'undefined') {
+      return;
+    }
+    const sequence =
+      lineEnding === 'crlf'
+        ? monaco.editor.EndOfLineSequence.CRLF
+        : monaco.editor.EndOfLineSequence.LF;
+    model.setEOL(sequence);
   }
 
   /**
@@ -88,3 +132,12 @@ export class EditorService {
     return this.editor?.getValue() ?? null;
   }
 }
+
+declare const monaco: {
+  editor: {
+    EndOfLineSequence: {
+      LF: number;
+      CRLF: number;
+    };
+  };
+};

--- a/libs/editor/vitest.config.ts
+++ b/libs/editor/vitest.config.ts
@@ -30,6 +30,8 @@ export default defineConfig({
       '@libs-editor': resolve(__dirname, './src/index.ts'),
       '@libs-dialogs': resolve(__dirname, '../dialogs/src/index.ts'),
       '@libs-shared': resolve(__dirname, '../shared/src/index.ts'),
+      '@libs-web-serial': resolve(__dirname, '../web-serial/src/index.ts'),
+      '@libs-file-manager': resolve(__dirname, '../file-manager/src/index.ts'),
     },
   },
 });

--- a/libs/shared/src/lib/models/file.types.ts
+++ b/libs/shared/src/lib/models/file.types.ts
@@ -1,2 +1,35 @@
-// Stub for file-related types. To be implemented in migration phase.
-export {};
+/**
+ * Editor / file transfer text metadata and size limits (Issue #813).
+ */
+
+/** Line ending style preserved across load/save. */
+export type TextLineEnding = 'lf' | 'crlf';
+
+/**
+ * Metadata captured when loading a text file from the device.
+ * Editing uses a normalized LF string; save re-applies these fields.
+ */
+export interface TextFileMeta {
+  /** Always UTF-8 for editable text files. */
+  encoding: 'utf-8';
+  /** Whether the on-disk file had a UTF-8 BOM. */
+  bom: boolean;
+  /** Original line ending style. */
+  lineEnding: TextLineEnding;
+  /** Whether the original file ended with a newline. */
+  trailingNewline: boolean;
+}
+
+/** Default meta for newly created files (LF, no BOM, trailing newline). */
+export const DEFAULT_NEW_TEXT_FILE_META: TextFileMeta = {
+  encoding: 'utf-8',
+  bom: false,
+  lineEnding: 'lf',
+  trailingNewline: true,
+};
+
+/** Warn before opening files at or above this UTF-8 byte size. */
+export const EDITOR_FILE_WARN_BYTES = 256 * 1024;
+
+/** Hard limit: refuse to open files above this UTF-8 byte size. */
+export const EDITOR_FILE_MAX_BYTES = 1024 * 1024;

--- a/libs/shared/src/lib/models/file.types.ts
+++ b/libs/shared/src/lib/models/file.types.ts
@@ -1,35 +1,3 @@
-/**
- * Editor / file transfer text metadata and size limits (Issue #813).
- */
-
-/** Line ending style preserved across load/save. */
-export type TextLineEnding = 'lf' | 'crlf';
-
-/**
- * Metadata captured when loading a text file from the device.
- * Editing uses a normalized LF string; save re-applies these fields.
- */
-export interface TextFileMeta {
-  /** Always UTF-8 for editable text files. */
-  encoding: 'utf-8';
-  /** Whether the on-disk file had a UTF-8 BOM. */
-  bom: boolean;
-  /** Original line ending style. */
-  lineEnding: TextLineEnding;
-  /** Whether the original file ended with a newline. */
-  trailingNewline: boolean;
-}
-
-/** Default meta for newly created files (LF, no BOM, trailing newline). */
-export const DEFAULT_NEW_TEXT_FILE_META: TextFileMeta = {
-  encoding: 'utf-8',
-  bom: false,
-  lineEnding: 'lf',
-  trailingNewline: true,
-};
-
-/** Warn before opening files at or above this UTF-8 byte size. */
-export const EDITOR_FILE_WARN_BYTES = 256 * 1024;
-
-/** Hard limit: refuse to open files above this UTF-8 byte size. */
-export const EDITOR_FILE_MAX_BYTES = 1024 * 1024;
+// Stub for file-related types. Editor text meta lives in @libs-web-serial
+// to avoid shared ↔ web-serial circular dependencies.
+export {};

--- a/libs/web-serial/src/index.ts
+++ b/libs/web-serial/src/index.ts
@@ -5,7 +5,17 @@ export type {
   CommandExecutionConfig,
   CommandResult,
 } from './lib/models';
-export type { FileContentInfo, FileTransferOptions } from './lib/models/file-content.types';
+export type {
+  FileContentInfo,
+  FileTransferOptions,
+  TextFileMeta,
+  TextLineEnding,
+} from './lib/models/file-content.types';
+export {
+  DEFAULT_NEW_TEXT_FILE_META,
+  EDITOR_FILE_MAX_BYTES,
+  EDITOR_FILE_WARN_BYTES,
+} from './lib/models/file-content.types';
 export type { SerialCommandEnqueueOptions } from './lib/service/serial-command/serial-command-pipeline.service';
 export * from './lib/service/file-content.service';
 export * from './lib/functions/file.utils';

--- a/libs/web-serial/src/index.ts
+++ b/libs/web-serial/src/index.ts
@@ -5,7 +5,7 @@ export type {
   CommandExecutionConfig,
   CommandResult,
 } from './lib/models';
-export type { FileContentInfo } from './lib/models/file-content.types';
+export type { FileContentInfo, FileTransferOptions } from './lib/models/file-content.types';
 export type { SerialCommandEnqueueOptions } from './lib/service/serial-command/serial-command-pipeline.service';
 export * from './lib/service/file-content.service';
 export * from './lib/functions/file.utils';

--- a/libs/web-serial/src/lib/functions/file.utils.ts
+++ b/libs/web-serial/src/lib/functions/file.utils.ts
@@ -117,16 +117,31 @@ export class FileUtils {
     return content.split(/\r?\n/).some((line) => line === delimiter);
   }
 
+  /**
+   * Heredoc write. `content` must already end with `\n` so the delimiter line
+   * does not inject an extra blank line (preserves a single trailing newline).
+   */
   static generateHeredocCommand(fileName: string, content: string): string {
     const delimiter = FileUtils.chooseHeredocDelimiter(content);
     const path = FileUtils.escapePath(fileName);
-    return `cat > ${path} << '${delimiter}'\n${content}\n${delimiter}`;
+    const body = content.endsWith('\n') ? content : `${content}\n`;
+    return `cat > ${path} << '${delimiter}'\n${body}${delimiter}`;
   }
 
   static generateAppendCommand(fileName: string, content: string): string {
     const delimiter = FileUtils.chooseHeredocDelimiter(content);
     const path = FileUtils.escapePath(fileName);
-    return `cat >> ${path} << '${delimiter}'\n${content}\n${delimiter}`;
+    const body = content.endsWith('\n') ? content : `${content}\n`;
+    return `cat >> ${path} << '${delimiter}'\n${body}${delimiter}`;
+  }
+
+  /** True when heredoc cannot preserve exact bytes (CRLF, BOM, or no trailing NL). */
+  static requiresExactByteWrite(content: string): boolean {
+    return (
+      content.includes('\r') ||
+      content.startsWith('\uFEFF') ||
+      !content.endsWith('\n')
+    );
   }
 
   static generateBase64SaveCommand(fileName: string): string {

--- a/libs/web-serial/src/lib/functions/index.ts
+++ b/libs/web-serial/src/lib/functions/index.ts
@@ -7,3 +7,4 @@ export * from './serial-error-messages';
 export * from './serial-error-wrap';
 export * from './serial-exec-options';
 export * from './serial-timeout';
+export * from './text-file-codec';

--- a/libs/web-serial/src/lib/functions/text-file-codec.spec.ts
+++ b/libs/web-serial/src/lib/functions/text-file-codec.spec.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_NEW_TEXT_FILE_META } from '@libs-shared';
+import { DEFAULT_NEW_TEXT_FILE_META } from '../models/file-content.types';
 import {
   NonUtf8TextError,
   decodeUtf8Fatal,

--- a/libs/web-serial/src/lib/functions/text-file-codec.spec.ts
+++ b/libs/web-serial/src/lib/functions/text-file-codec.spec.ts
@@ -1,0 +1,108 @@
+import { DEFAULT_NEW_TEXT_FILE_META } from '@libs-shared';
+import {
+  NonUtf8TextError,
+  decodeUtf8Fatal,
+  detectLineEnding,
+  isNonUtf8TextError,
+  normalizeToLf,
+  parseTextFileBytes,
+  serializeTextFileForSave,
+} from './text-file-codec';
+
+function encode(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+describe('text-file-codec', () => {
+  describe('decodeUtf8Fatal', () => {
+    it('decodes japanese emoji and combining characters', () => {
+      const text = '日本語 🍣 e\u0301';
+      expect(decodeUtf8Fatal(encode(text))).toBe(text);
+    });
+
+    it('throws NonUtf8TextError for invalid sequences', () => {
+      expect(() => decodeUtf8Fatal(new Uint8Array([0xff, 0xfe, 0xfd]))).toThrow(
+        NonUtf8TextError,
+      );
+      try {
+        decodeUtf8Fatal(new Uint8Array([0xff]));
+      } catch (error) {
+        expect(isNonUtf8TextError(error)).toBe(true);
+      }
+    });
+  });
+
+  describe('parseTextFileBytes', () => {
+    it('detects LF without BOM and trailing newline', () => {
+      const { editorText, meta } = parseTextFileBytes(encode('a\nb\n'));
+      expect(editorText).toBe('a\nb\n');
+      expect(meta).toEqual({
+        encoding: 'utf-8',
+        bom: false,
+        lineEnding: 'lf',
+        trailingNewline: true,
+      });
+    });
+
+    it('detects CRLF and preserves meta while normalizing editor text to LF', () => {
+      const { editorText, meta } = parseTextFileBytes(encode('a\r\nb\r\n'));
+      expect(editorText).toBe('a\nb\n');
+      expect(meta.lineEnding).toBe('crlf');
+      expect(meta.trailingNewline).toBe(true);
+    });
+
+    it('detects UTF-8 BOM and strips it from editor text', () => {
+      const { editorText, meta } = parseTextFileBytes(encode('\uFEFFhello'));
+      expect(editorText).toBe('hello');
+      expect(meta.bom).toBe(true);
+      expect(meta.trailingNewline).toBe(false);
+    });
+
+    it('detects missing trailing newline', () => {
+      const { meta } = parseTextFileBytes(encode('no-nl'));
+      expect(meta.trailingNewline).toBe(false);
+    });
+  });
+
+  describe('serializeTextFileForSave', () => {
+    it('round-trips CRLF with BOM and trailing newline', () => {
+      const original = '\uFEFFline1\r\nline2\r\n';
+      const { editorText, meta } = parseTextFileBytes(encode(original));
+      expect(serializeTextFileForSave(editorText, meta)).toBe(original);
+    });
+
+    it('round-trips LF without trailing newline', () => {
+      const original = 'a\nb';
+      const { editorText, meta } = parseTextFileBytes(encode(original));
+      expect(serializeTextFileForSave(editorText, meta)).toBe(original);
+    });
+
+    it('uses new-file defaults for LF with trailing newline', () => {
+      expect(
+        serializeTextFileForSave('hello', DEFAULT_NEW_TEXT_FILE_META),
+      ).toBe('hello\n');
+    });
+
+    it('does not convert LF content to CRLF when meta is lf', () => {
+      const saved = serializeTextFileForSave('a\nb\n', {
+        encoding: 'utf-8',
+        bom: false,
+        lineEnding: 'lf',
+        trailingNewline: true,
+      });
+      expect(saved).toBe('a\nb\n');
+      expect(saved.includes('\r')).toBe(false);
+    });
+  });
+
+  describe('detectLineEnding / normalizeToLf', () => {
+    it('defaults to lf when no CRLF is present', () => {
+      expect(detectLineEnding('a\nb')).toBe('lf');
+      expect(detectLineEnding('')).toBe('lf');
+    });
+
+    it('normalizes lone CR to LF', () => {
+      expect(normalizeToLf('a\rb\n')).toBe('a\nb\n');
+    });
+  });
+});

--- a/libs/web-serial/src/lib/functions/text-file-codec.ts
+++ b/libs/web-serial/src/lib/functions/text-file-codec.ts
@@ -1,0 +1,116 @@
+import type { TextFileMeta, TextLineEnding } from '@libs-shared';
+
+const UTF8_BOM = '\uFEFF';
+
+export class NonUtf8TextError extends Error {
+  readonly code = 'NON_UTF8_TEXT' as const;
+
+  constructor(message = 'File is not valid UTF-8') {
+    super(message);
+    this.name = 'NonUtf8TextError';
+  }
+}
+
+export function isNonUtf8TextError(error: unknown): error is NonUtf8TextError {
+  return (
+    error instanceof NonUtf8TextError ||
+    (typeof error === 'object' &&
+      error !== null &&
+      (error as { code?: string }).code === 'NON_UTF8_TEXT')
+  );
+}
+
+/** UTF-8 BOM byte sequence (EF BB BF). */
+const UTF8_BOM_BYTES = new Uint8Array([0xef, 0xbb, 0xbf]);
+
+export function hasUtf8Bom(bytes: Uint8Array): boolean {
+  return (
+    bytes.byteLength >= 3 &&
+    bytes[0] === UTF8_BOM_BYTES[0] &&
+    bytes[1] === UTF8_BOM_BYTES[1] &&
+    bytes[2] === UTF8_BOM_BYTES[2]
+  );
+}
+
+/**
+ * Decode bytes as UTF-8 (fatal). Throws {@link NonUtf8TextError} on invalid sequences.
+ * Note: TextDecoder strips a leading UTF-8 BOM from the returned string.
+ */
+export function decodeUtf8Fatal(bytes: Uint8Array): string {
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    throw new NonUtf8TextError();
+  }
+}
+
+/**
+ * Detect BOM / line ending / trailing newline, strip BOM, and normalize EOLs to LF
+ * for Monaco editing. Original style is retained in {@link TextFileMeta}.
+ */
+export function parseTextFileBytes(bytes: Uint8Array): {
+  editorText: string;
+  meta: TextFileMeta;
+  utf8ByteLength: number;
+} {
+  const bom = hasUtf8Bom(bytes);
+  // TextDecoder removes BOM from the string; detect it from raw bytes first.
+  const withoutBomBytes = bom ? bytes.subarray(3) : bytes;
+  const withoutBom = decodeUtf8Fatal(withoutBomBytes);
+  const lineEnding = detectLineEnding(withoutBom);
+  const trailingNewline = /(?:\r\n|\n|\r)$/.test(withoutBom);
+  const editorText = normalizeToLf(withoutBom);
+
+  return {
+    editorText,
+    meta: {
+      encoding: 'utf-8',
+      bom,
+      lineEnding,
+      trailingNewline,
+    },
+    utf8ByteLength: bytes.byteLength,
+  };
+}
+
+/**
+ * Re-apply BOM / EOL / trailing-newline policy to editor LF text before save.
+ */
+export function serializeTextFileForSave(
+  editorText: string,
+  meta: TextFileMeta,
+): string {
+  let body = normalizeToLf(editorText);
+
+  const endsWithNewline = body.endsWith('\n');
+  if (meta.trailingNewline && !endsWithNewline) {
+    body += '\n';
+  } else if (!meta.trailingNewline && endsWithNewline) {
+    body = body.replace(/\n+$/, '');
+  }
+
+  if (meta.lineEnding === 'crlf') {
+    body = body.replace(/\n/g, '\r\n');
+  }
+
+  if (meta.bom) {
+    body = UTF8_BOM + body;
+  }
+
+  return body;
+}
+
+export function detectLineEnding(text: string): TextLineEnding {
+  if (text.includes('\r\n')) {
+    return 'crlf';
+  }
+  return 'lf';
+}
+
+export function normalizeToLf(text: string): string {
+  return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+export function encodeUtf8(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}

--- a/libs/web-serial/src/lib/functions/text-file-codec.ts
+++ b/libs/web-serial/src/lib/functions/text-file-codec.ts
@@ -1,4 +1,4 @@
-import type { TextFileMeta, TextLineEnding } from '@libs-shared';
+import type { TextFileMeta, TextLineEnding } from '../models/file-content.types';
 
 const UTF8_BOM = '\uFEFF';
 

--- a/libs/web-serial/src/lib/models/file-content.types.ts
+++ b/libs/web-serial/src/lib/models/file-content.types.ts
@@ -1,4 +1,38 @@
-import type { TextFileMeta } from '@libs-shared';
+/**
+ * Editor / file transfer text metadata and size limits (Issue #813).
+ */
+
+/** Line ending style preserved across load/save. */
+export type TextLineEnding = 'lf' | 'crlf';
+
+/**
+ * Metadata captured when loading a text file from the device.
+ * Editing uses a normalized LF string; save re-applies these fields.
+ */
+export interface TextFileMeta {
+  /** Always UTF-8 for editable text files. */
+  encoding: 'utf-8';
+  /** Whether the on-disk file had a UTF-8 BOM. */
+  bom: boolean;
+  /** Original line ending style. */
+  lineEnding: TextLineEnding;
+  /** Whether the original file ended with a newline. */
+  trailingNewline: boolean;
+}
+
+/** Default meta for newly created files (LF, no BOM, trailing newline). */
+export const DEFAULT_NEW_TEXT_FILE_META: TextFileMeta = {
+  encoding: 'utf-8',
+  bom: false,
+  lineEnding: 'lf',
+  trailingNewline: true,
+};
+
+/** Warn before opening files at or above this UTF-8 byte size. */
+export const EDITOR_FILE_WARN_BYTES = 256 * 1024;
+
+/** Hard limit: refuse to open files above this UTF-8 byte size. */
+export const EDITOR_FILE_MAX_BYTES = 1024 * 1024;
 
 /**
  * ファイル内容情報

--- a/libs/web-serial/src/lib/models/file-content.types.ts
+++ b/libs/web-serial/src/lib/models/file-content.types.ts
@@ -1,9 +1,19 @@
+import type { TextFileMeta } from '@libs-shared';
+
 /**
  * ファイル内容情報
  */
 export interface FileContentInfo {
   content: string | ArrayBuffer;
   isText: boolean;
+  /** UTF-8 byte length on disk (or buffer byteLength for binary). */
   size: number;
   encoding?: string;
+  /** Present for successfully decoded text files. */
+  meta?: TextFileMeta;
+}
+
+/** Options for chunked file transfers. */
+export interface FileTransferOptions {
+  onProgress?: (percent: number) => void;
 }

--- a/libs/web-serial/src/lib/service/file-content.service.spec.ts
+++ b/libs/web-serial/src/lib/service/file-content.service.spec.ts
@@ -132,6 +132,7 @@ describe('FileContentService.writeTextFile', () => {
   it('uses chunked binary write for large payloads', async () => {
     const content = 'a'.repeat(FileUtils.TEXT_CHUNK_THRESHOLD_BYTES + 1);
     const expected = FileUtils.utf8ByteLength(content);
+    const onProgress = vi.fn();
 
     exec$.mockImplementation((cmd: string) => {
       if (typeof cmd === 'string' && cmd.includes('base64 -d >')) {
@@ -149,12 +150,118 @@ describe('FileContentService.writeTextFile', () => {
       return of({ stdout: '' });
     });
 
-    await service.writeTextFile('/home/pi/main.js', content);
+    await service.writeTextFile('/home/pi/main.js', content, { onProgress });
 
     const commands = exec$.mock.calls.map((args: unknown[]) => args[0] as string);
     expect(commands.some((c) => c.includes('base64 -d >'))).toBe(true);
     expect(commands.some((c) => c.startsWith('cat >'))).toBe(false);
     expect(commands.some((c) => c.startsWith('mv --'))).toBe(true);
     expect(send$).toHaveBeenCalled();
+    expect(onProgress).toHaveBeenCalled();
+    expect(onProgress).toHaveBeenCalledWith(100);
+  });
+
+  it('uses binary write when content has CRLF to preserve exact bytes', async () => {
+    const content = 'a\r\nb\r\n';
+    const expected = FileUtils.utf8ByteLength(content);
+
+    exec$.mockImplementation((cmd: string) => {
+      if (typeof cmd === 'string' && cmd.includes('base64 -d >')) {
+        return of({ stdout: '' });
+      }
+      if (typeof cmd === 'string' && cmd.startsWith('wc -c')) {
+        return of({
+          stdout: `${expected} /home/pi/.main.js.chirimen-saving.test\n`,
+        });
+      }
+      if (typeof cmd === 'string' && cmd.startsWith('mv --')) {
+        return of({ stdout: '' });
+      }
+      if (typeof cmd === 'string' && cmd.startsWith('base64 --')) {
+        const b64 = FileUtils.arrayBufferToBase64(
+          new TextEncoder().encode(content).buffer,
+        );
+        return of({
+          stdout: `base64 -- /home/pi/main.js\n${b64}\npi@raspberrypi:~$ `,
+        });
+      }
+      return of({ stdout: '' });
+    });
+
+    await service.writeTextFile('/home/pi/main.js', content);
+
+    const commands = exec$.mock.calls.map((args: unknown[]) => args[0] as string);
+    expect(commands.some((c) => c.includes('base64 -d >'))).toBe(true);
+    expect(commands.some((c) => c.startsWith('cat >'))).toBe(false);
+  });
+});
+
+describe('FileContentService.getByteSize / readFile', () => {
+  let service: FileContentService;
+  let exec$: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    exec$ = vi.fn();
+
+    TestBed.configureTestingModule({
+      providers: [
+        FileContentService,
+        {
+          provide: SerialFacadeService,
+          useValue: {
+            exec$,
+            send$: vi.fn().mockReturnValue(of(undefined)),
+            isConnected: vi.fn().mockReturnValue(true),
+          },
+        },
+        {
+          provide: PiZeroPromptDetectorService,
+          useValue: { isCommandCompleted: () => true },
+        },
+      ],
+    });
+
+    service = TestBed.inject(FileContentService);
+  });
+
+  it('returns byte size from wc -c', async () => {
+    exec$.mockReturnValue(of({ stdout: '42 /home/pi/a.js\n' }));
+    await expect(service.getByteSize('/home/pi/a.js')).resolves.toBe(42);
+  });
+
+  it('parses UTF-8 text with CRLF meta for the editor', async () => {
+    const onDisk = '日本語\r\n';
+    const b64 = FileUtils.arrayBufferToBase64(
+      new TextEncoder().encode(onDisk).buffer,
+    );
+    exec$.mockReturnValue(
+      of({
+        stdout: `base64 -- /home/pi/a.js\n${b64}\npi@raspberrypi:~$ `,
+      }),
+    );
+
+    const info = await service.readFile('/home/pi/a.js');
+    expect(info.isText).toBe(true);
+    expect(info.content).toBe('日本語\n');
+    expect(info.meta).toEqual({
+      encoding: 'utf-8',
+      bom: false,
+      lineEnding: 'crlf',
+      trailingNewline: true,
+    });
+    expect(info.size).toBe(FileUtils.utf8ByteLength(onDisk));
+  });
+
+  it('rejects non UTF-8 text files', async () => {
+    const b64 = FileUtils.arrayBufferToBase64(new Uint8Array([0xff, 0xfe]).buffer);
+    exec$.mockReturnValue(
+      of({
+        stdout: `base64 -- /home/pi/a.js\n${b64}\npi@raspberrypi:~$ `,
+      }),
+    );
+
+    await expect(service.readFile('/home/pi/a.js')).rejects.toMatchObject({
+      code: 'NON_UTF8_TEXT',
+    });
   });
 });

--- a/libs/web-serial/src/lib/service/file-content.service.ts
+++ b/libs/web-serial/src/lib/service/file-content.service.ts
@@ -6,7 +6,15 @@ import { createPiZeroShellExecOptions } from '../functions/pi-zero-shell-exec-op
 import { FileUtils } from '../functions/file.utils';
 import { SERIAL_TIMEOUT } from '../functions/serial-timeout';
 import { wrapSerialError } from '../functions/serial-error-wrap';
-import type { FileContentInfo } from '../models/file-content.types';
+import {
+  isNonUtf8TextError,
+  parseTextFileBytes,
+  serializeTextFileForSave,
+} from '../functions/text-file-codec';
+import type {
+  FileContentInfo,
+  FileTransferOptions,
+} from '../models/file-content.types';
 import { PiZeroPromptDetectorService } from './pi-zero-prompt-detector.service';
 import { SerialFacadeService } from './serial-facade.service';
 
@@ -24,6 +32,30 @@ export class FileContentService {
 
   private shellExecOptions(timeout: number = SERIAL_TIMEOUT.DEFAULT) {
     return createPiZeroShellExecOptions(this.promptDetector, { timeout });
+  }
+
+  /**
+   * Remote file size in bytes via `wc -c` (preflight for large-file gates).
+   */
+  async getByteSize(path: string): Promise<number> {
+    try {
+      const stdout = (
+        await firstValueFrom(
+          this.serial.exec$(
+            FileUtils.generateByteSizeCommand(path),
+            this.shellExecOptions(SERIAL_TIMEOUT.DEFAULT),
+          ),
+        )
+      ).stdout;
+
+      const size = FileUtils.parseByteSizeOutput(stdout);
+      if (size === null) {
+        throw new Error(`could not parse byte size for ${path}`);
+      }
+      return size;
+    } catch (error: unknown) {
+      throw wrapSerialError('Failed to get file size', error);
+    }
   }
 
   async readFile(path: string): Promise<FileContentInfo> {
@@ -45,24 +77,36 @@ export class FileContentService {
       }
 
       const buffer = FileUtils.base64ToArrayBuffer(content);
+      const bytes = new Uint8Array(buffer);
       const isText = FileUtils.isTextFile(path);
 
       if (isText) {
-        const textContent = new TextDecoder().decode(new Uint8Array(buffer));
-        return {
-          content: textContent,
-          isText: true,
-          size: textContent.length,
-          encoding: 'utf-8',
-        };
-      } else {
-        return {
-          content: buffer,
-          isText: false,
-          size: buffer.byteLength,
-        };
+        try {
+          const parsed = parseTextFileBytes(bytes);
+          return {
+            content: parsed.editorText,
+            isText: true,
+            size: parsed.utf8ByteLength,
+            encoding: 'utf-8',
+            meta: parsed.meta,
+          };
+        } catch (error: unknown) {
+          if (isNonUtf8TextError(error)) {
+            throw error;
+          }
+          throw error;
+        }
       }
+
+      return {
+        content: buffer,
+        isText: false,
+        size: buffer.byteLength,
+      };
     } catch (error: unknown) {
+      if (isNonUtf8TextError(error)) {
+        throw error;
+      }
       throw wrapSerialError('Failed to read file', error);
     }
   }
@@ -75,8 +119,14 @@ export class FileContentService {
    * 3. `mv` で対象へ置換（置換成功まで元ファイルは非接触）
    * 4. 保存後検証
    * 失敗時は一時ファイルをベストエフォートで削除する。
+   *
+   * `content` はデバイス上のバイト列に対応する文字列（BOM / CRLF 適用済み）を渡す。
    */
-  async writeTextFile(path: string, content: string): Promise<void> {
+  async writeTextFile(
+    path: string,
+    content: string,
+    options?: FileTransferOptions,
+  ): Promise<void> {
     if (!this.serial.isConnected()) {
       throw classifyFileWriteError(new Error('not connected'));
     }
@@ -86,7 +136,7 @@ export class FileContentService {
     let replaced = false;
 
     try {
-      await this.writeTextPayload(tempPath, content, expectedBytes);
+      await this.writeTextPayload(tempPath, content, expectedBytes, options);
       await this.assertRemoteByteSize(tempPath, expectedBytes);
 
       await firstValueFrom(
@@ -98,6 +148,7 @@ export class FileContentService {
       replaced = true;
 
       await this.verifySavedTextFile(path, content, expectedBytes);
+      options?.onProgress?.(100);
     } catch (error: unknown) {
       if (!replaced) {
         await this.cleanupTempFile(tempPath);
@@ -106,7 +157,11 @@ export class FileContentService {
     }
   }
 
-  async writeBinaryFile(path: string, buffer: ArrayBuffer): Promise<void> {
+  async writeBinaryFile(
+    path: string,
+    buffer: ArrayBuffer,
+    options?: FileTransferOptions,
+  ): Promise<void> {
     try {
       const base64 = FileUtils.arrayBufferToBase64(buffer);
 
@@ -121,7 +176,8 @@ export class FileContentService {
       );
 
       const lineLength = 512;
-      for (let i = 0; i <= Math.floor(base64.length / lineLength); i++) {
+      const totalChunks = Math.floor(base64.length / lineLength) + 1;
+      for (let i = 0; i < totalChunks; i++) {
         const line = base64.substring(i * lineLength, (i + 1) * lineLength);
         await firstValueFrom(
           this.serial.exec$(line, {
@@ -130,6 +186,11 @@ export class FileContentService {
           }),
         );
         await this.sleep(1);
+        if (options?.onProgress && totalChunks > 0) {
+          // Leave headroom for mv/verify; editor may set 100 on completion.
+          const percent = Math.min(99, Math.round(((i + 1) / totalChunks) * 99));
+          options.onProgress(percent);
+        }
       }
 
       await firstValueFrom(this.serial.send$('\x04'));
@@ -163,10 +224,15 @@ export class FileContentService {
     path: string,
     content: string,
     expectedBytes: number,
+    options?: FileTransferOptions,
   ): Promise<void> {
-    if (expectedBytes > FileUtils.TEXT_CHUNK_THRESHOLD_BYTES) {
+    const useBinary =
+      expectedBytes > FileUtils.TEXT_CHUNK_THRESHOLD_BYTES ||
+      FileUtils.requiresExactByteWrite(content);
+
+    if (useBinary) {
       const buffer = new TextEncoder().encode(content).buffer;
-      await this.writeBinaryFile(path, buffer);
+      await this.writeBinaryFile(path, buffer, options);
       return;
     }
 
@@ -177,6 +243,7 @@ export class FileContentService {
         this.shellExecOptions(SERIAL_TIMEOUT.FILE_TRANSFER),
       ),
     );
+    options?.onProgress?.(90);
   }
 
   private async assertRemoteByteSize(
@@ -216,10 +283,11 @@ export class FileContentService {
     }
 
     const info = await this.readFile(path);
-    if (!info.isText || typeof info.content !== 'string') {
+    if (!info.isText || typeof info.content !== 'string' || !info.meta) {
       throw new Error('content mismatch: saved file is not text');
     }
-    if (info.content !== content) {
+    const restored = serializeTextFileForSave(info.content, info.meta);
+    if (restored !== content) {
       throw new Error('content mismatch: saved file differs from editor content');
     }
   }

--- a/libs/web-serial/src/lib/service/serial-facade.service.ts
+++ b/libs/web-serial/src/lib/service/serial-facade.service.ts
@@ -84,6 +84,11 @@ export class SerialFacadeService {
     return this.command.readUntilPrompt$(options);
   }
 
+  /** Cancel queued/in-flight shell commands (e.g. mid file transfer). */
+  cancelAllCommands(): void {
+    this.command.cancelAllCommands();
+  }
+
   isRaspberryPiZero(): Promise<boolean> {
     return this.transport.isRaspberryPiZero();
   }

--- a/libs/web-serial/vitest.config.ts
+++ b/libs/web-serial/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@libs-web-serial': resolve(__dirname, './src/index.ts'),
+      '@libs-shared': resolve(__dirname, '../shared/src/index.ts'),
     },
   },
   test: {

--- a/libs/web-serial/vitest.config.ts
+++ b/libs/web-serial/vitest.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
   resolve: {
     alias: {
       '@libs-web-serial': resolve(__dirname, './src/index.ts'),
-      '@libs-shared': resolve(__dirname, '../shared/src/index.ts'),
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- Editor の読込前にファイルサイズを取得し、警告（256 KiB）／上限（1 MiB）でゲートする
- UTF-8（fatal）・BOM・LF/CRLF・末尾改行のメタを保持し、保存時に元形式を復元する
- 大容量転送の進捗ダイアログとキャンセル／切断後の Editor 復旧を追加する

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Closes #813
- Refs #804

## What changed?

- `TextFileMeta` と WARN/MAX 定数を `shared` に追加
- `web-serial` に UTF-8/BOM/EOL codec、`getByteSize`、読込 meta、チャンク転送進捗を追加
- `ProgressDialog` をキャンセル可能にし、進捗シグナル更新に対応
- Editor で大容量警告・非 UTF-8 拒否・meta 保持・転送進捗／キャンセル復旧を実装

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details: `EditorService.loadTextFile` の戻り値を `{ content, meta, size }` に変更。`saveTextFile` に `meta` と任意の progress options を追加。`SerialFacadeService.cancelAllCommands` を公開。
- [ ] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes: Editor 内の呼び出しは更新済み。外部から `EditorService` の load/save を直接使う場合は meta 引数／戻り値に合わせて更新が必要。

## How to test

1. `pnpm nx test libs-shared`（型エクスポート確認が必要なら） / `pnpm nx test libs-web-serial` / `pnpm nx test libs-dialogs` / `pnpm nx test libs-editor`
2. 実機またはモックで日本語・絵文字を含む UTF-8 ファイルを読込・保存し、文字化けしないことを確認
3. LF / CRLF ファイルを保存し、改行コードが維持されることを確認
4. 256 KiB 以上で警告、1 MiB 超で読込拒否されることを確認
5. 大容量保存中にキャンセル／切断しても Editor が操作不能にならないことを確認

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)