### PR TITLE
feat(editor): improve editor accessibility and keyboard interaction

### DIFF
--- a/libs/console-shell/src/lib/component/console-shell/console-shell.component.html
+++ b/libs/console-shell/src/lib/component/console-shell/console-shell.component.html
@@ -45,6 +45,7 @@
             [paneWidthPx]="leftPaneWidthPx()"
             (toggleLeftSidebar)="onToggleLeftSidebar()"
             (paneResizeStart)="onLeftPaneResizeStart($event)"
+            (paneResizeBy)="onLeftPaneResizeBy($event)"
           />
         </div>
 
@@ -68,6 +69,7 @@
             [diagramWidthPx]="rightDiagramWidthPx()"
             (toggleRightSidebar)="onToggleRightSidebar()"
             (paneResizeStart)="onRightPaneResizeStart($event)"
+            (paneResizeBy)="onRightPaneResizeBy($event)"
           />
         </div>
       </div>

--- a/libs/console-shell/src/lib/component/console-shell/console-shell.component.ts
+++ b/libs/console-shell/src/lib/component/console-shell/console-shell.component.ts
@@ -321,6 +321,18 @@ export class ConsoleShellComponent implements OnInit, OnDestroy {
     this.startPaneResize(event, 'right');
   }
 
+  onLeftPaneResizeBy(delta: number): void {
+    this.shellStore.setLeftPaneWidth(
+      this.shellStore.leftPaneWidthPx() + delta,
+    );
+  }
+
+  onRightPaneResizeBy(delta: number): void {
+    this.shellStore.setRightDiagramWidth(
+      this.shellStore.rightDiagramWidthPx() + delta,
+    );
+  }
+
   private startPaneResize(
     event: PointerEvent,
     side: 'left' | 'right',

--- a/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.css
+++ b/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.css
@@ -1,0 +1,5 @@
+.shell-rail-button:focus-visible,
+.shell-pane-separator:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}

--- a/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.html
+++ b/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.html
@@ -23,8 +23,9 @@
           aria-orientation="vertical"
           aria-label="Resize left panel"
           tabindex="0"
-          class="absolute top-0 right-0 bottom-0 z-50 w-1.5 cursor-col-resize touch-none bg-transparent hover:bg-blue-500/40"
+          class="shell-pane-separator absolute top-0 right-0 bottom-0 z-50 w-1.5 cursor-col-resize touch-none bg-transparent hover:bg-blue-500/40"
           (pointerdown)="onResizePointerDown($event)"
+          (keydown)="onResizeKeydown($event)"
         ></div>
       </div>
     } @else {
@@ -52,24 +53,26 @@
     <button
       mat-icon-button
       type="button"
-      [matTooltip]="panelToggleLabel()"
-      [attr.aria-label]="panelToggleLabel()"
+      class="shell-rail-button"
+      [matTooltip]="contentLabel"
+      [attr.aria-label]="contentLabel"
       [attr.aria-expanded]="leftNavOpen()"
       aria-controls="console-shell-left-pane"
       (click)="toggleLeftSidebar.emit()"
     >
-      <mat-icon>folder</mat-icon>
+      <mat-icon aria-hidden="true">folder</mat-icon>
     </button>
     <button
       mat-icon-button
       type="button"
+      class="shell-rail-button"
       [matTooltip]="panelToggleLabel()"
       [attr.aria-label]="panelToggleLabel()"
       [attr.aria-expanded]="leftNavOpen()"
       aria-controls="console-shell-left-pane"
       (click)="toggleLeftSidebar.emit()"
     >
-      <mat-icon>
+      <mat-icon aria-hidden="true">
         @if (leftNavOpen()) {
           left_panel_close
         } @else {
@@ -83,8 +86,9 @@
         aria-orientation="vertical"
         aria-label="Resize left panel"
         tabindex="0"
-        class="absolute top-0 right-0 bottom-0 z-50 w-1.5 cursor-col-resize touch-none bg-transparent hover:bg-blue-500/40"
+        class="shell-pane-separator absolute top-0 right-0 bottom-0 z-50 w-1.5 cursor-col-resize touch-none bg-transparent hover:bg-blue-500/40"
         (pointerdown)="onResizePointerDown($event)"
+        (keydown)="onResizeKeydown($event)"
       ></div>
     }
   </div>

--- a/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.spec.ts
+++ b/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.spec.ts
@@ -165,12 +165,20 @@ describe('LeftSidebarComponent', () => {
   });
 
   it('should set tooltip on panel toggle based on open state', () => {
+    const contentButton = fixture.debugElement.query(
+      By.css('button[aria-label="ファイルツリー"]'),
+    );
+    expect(contentButton).not.toBeNull();
+    expect(contentButton.injector.get(MatTooltip).message).toBe(
+      'ファイルツリー',
+    );
+
     const openButton = fixture.debugElement.query(
-      By.css('button[aria-label="ファイツリー閉じる"]'),
+      By.css('button[aria-label="ファイルツリーを閉じる"]'),
     );
     expect(openButton).not.toBeNull();
     expect(openButton.injector.get(MatTooltip).message).toBe(
-      'ファイツリー閉じる',
+      'ファイルツリーを閉じる',
     );
     expect(openButton.attributes['aria-expanded']).toBe('true');
 
@@ -178,12 +186,30 @@ describe('LeftSidebarComponent', () => {
     fixture.detectChanges();
 
     const closedButton = fixture.debugElement.query(
-      By.css('button[aria-label="ファイツリー開く"]'),
+      By.css('button[aria-label="ファイルツリーを開く"]'),
     );
     expect(closedButton).not.toBeNull();
     expect(closedButton.injector.get(MatTooltip).message).toBe(
-      'ファイツリー開く',
+      'ファイルツリーを開く',
     );
     expect(closedButton.attributes['aria-expanded']).toBe('false');
+  });
+
+  it('emits paneResizeBy on separator arrow keys', () => {
+    const emitSpy = vi.spyOn(component.paneResizeBy, 'emit');
+    const separator = fixture.nativeElement.querySelector(
+      '[role="separator"]',
+    ) as HTMLElement;
+    expect(separator).not.toBeNull();
+
+    separator.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+    );
+    separator.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
+    );
+
+    expect(emitSpy).toHaveBeenCalledWith(16);
+    expect(emitSpy).toHaveBeenCalledWith(-16);
   });
 });

--- a/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.ts
+++ b/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.ts
@@ -95,15 +95,14 @@ export class LeftSidebarComponent {
   }
 
   onResizeKeydown(event: KeyboardEvent): void {
-    let delta = 0;
     if (event.key === 'ArrowRight') {
-      delta = LEFT_PANE_RESIZE_STEP_PX;
-    } else if (event.key === 'ArrowLeft') {
-      delta = -LEFT_PANE_RESIZE_STEP_PX;
-    } else {
+      event.preventDefault();
+      this.paneResizeBy.emit(LEFT_PANE_RESIZE_STEP_PX);
       return;
     }
-    event.preventDefault();
-    this.paneResizeBy.emit(delta);
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      this.paneResizeBy.emit(-LEFT_PANE_RESIZE_STEP_PX);
+    }
   }
 }

--- a/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.ts
+++ b/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.ts
@@ -13,10 +13,14 @@ import {
   RAIL_WIDTH_PX,
 } from '@libs-shared';
 
+/** Keyboard resize step for the left panel separator (px). */
+export const LEFT_PANE_RESIZE_STEP_PX = 16;
+
 @Component({
   selector: 'lib-left-sidebar',
   imports: [FileTreeFeatureComponent, MatIconButton, MatIcon, MatTooltip],
   templateUrl: './left-sidebar.component.html',
+  styleUrl: './left-sidebar.component.css',
   host: {
     class: 'flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden',
   },
@@ -27,6 +31,7 @@ export class LeftSidebarComponent {
   paneWidthPx = input<number>(LEFT_PANE_WIDTH.default);
   toggleLeftSidebar = output<void>();
   paneResizeStart = output<PointerEvent>();
+  paneResizeBy = output<number>();
 
   readonly isOverlay = computed(() => this.layoutMode() === 'overlay');
   readonly isDockedOpen = computed(
@@ -42,8 +47,10 @@ export class LeftSidebarComponent {
     () => `min(${this.paneWidthPx()}px, 85vw)`,
   );
 
+  readonly contentLabel = 'ファイルツリー';
+
   readonly panelToggleLabel = computed(() =>
-    this.leftNavOpen() ? 'ファイツリー閉じる' : 'ファイツリー開く',
+    this.leftNavOpen() ? 'ファイルツリーを閉じる' : 'ファイルツリーを開く',
   );
 
   readonly shellStore = inject(ConsoleShellStore);
@@ -85,5 +92,18 @@ export class LeftSidebarComponent {
 
   onResizePointerDown(event: PointerEvent): void {
     this.paneResizeStart.emit(event);
+  }
+
+  onResizeKeydown(event: KeyboardEvent): void {
+    let delta = 0;
+    if (event.key === 'ArrowRight') {
+      delta = LEFT_PANE_RESIZE_STEP_PX;
+    } else if (event.key === 'ArrowLeft') {
+      delta = -LEFT_PANE_RESIZE_STEP_PX;
+    } else {
+      return;
+    }
+    event.preventDefault();
+    this.paneResizeBy.emit(delta);
   }
 }

--- a/libs/console-shell/src/lib/component/right-sidebar/right-sidebar.component.css
+++ b/libs/console-shell/src/lib/component/right-sidebar/right-sidebar.component.css
@@ -1,0 +1,5 @@
+.shell-rail-button:focus-visible,
+.shell-pane-separator:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}

--- a/libs/console-shell/src/lib/component/right-sidebar/right-sidebar.component.html
+++ b/libs/console-shell/src/lib/component/right-sidebar/right-sidebar.component.html
@@ -7,24 +7,26 @@
     <button
       mat-icon-button
       type="button"
-      [matTooltip]="panelToggleLabel()"
-      [attr.aria-label]="panelToggleLabel()"
+      class="shell-rail-button"
+      [matTooltip]="contentLabel"
+      [attr.aria-label]="contentLabel"
       [attr.aria-expanded]="rightNavOpen()"
       aria-controls="console-shell-right-pane"
       (click)="toggleRightSidebar.emit()"
     >
-      <mat-icon>fiber_pin</mat-icon>
+      <mat-icon aria-hidden="true">fiber_pin</mat-icon>
     </button>
     <button
       mat-icon-button
       type="button"
+      class="shell-rail-button"
       [matTooltip]="panelToggleLabel()"
       [attr.aria-label]="panelToggleLabel()"
       [attr.aria-expanded]="rightNavOpen()"
       aria-controls="console-shell-right-pane"
       (click)="toggleRightSidebar.emit()"
     >
-      <mat-icon>
+      <mat-icon aria-hidden="true">
         @if (rightNavOpen()) {
           right_panel_close
         } @else {
@@ -38,8 +40,9 @@
         aria-orientation="vertical"
         aria-label="Resize right panel"
         tabindex="0"
-        class="absolute top-0 left-0 bottom-0 z-50 w-1.5 cursor-col-resize touch-none bg-transparent hover:bg-blue-500/40"
+        class="shell-pane-separator absolute top-0 left-0 bottom-0 z-50 w-1.5 cursor-col-resize touch-none bg-transparent hover:bg-blue-500/40"
         (pointerdown)="onResizePointerDown($event)"
+        (keydown)="onResizeKeydown($event)"
       ></div>
     }
   </div>
@@ -55,8 +58,9 @@
           aria-orientation="vertical"
           aria-label="Resize right panel"
           tabindex="0"
-          class="absolute top-0 left-0 bottom-0 z-50 w-1.5 cursor-col-resize touch-none bg-transparent hover:bg-blue-500/40"
+          class="shell-pane-separator absolute top-0 left-0 bottom-0 z-50 w-1.5 cursor-col-resize touch-none bg-transparent hover:bg-blue-500/40"
           (pointerdown)="onResizePointerDown($event)"
+          (keydown)="onResizeKeydown($event)"
         ></div>
         <choh-pin-assign />
       </div>

--- a/libs/console-shell/src/lib/component/right-sidebar/right-sidebar.component.spec.ts
+++ b/libs/console-shell/src/lib/component/right-sidebar/right-sidebar.component.spec.ts
@@ -52,21 +52,45 @@ describe('RightSidebarComponent', () => {
   });
 
   it('should set tooltip on panel toggle based on open state', () => {
+    const contentButton = fixture.debugElement.query(
+      By.css('button[aria-label="ピン配置"]'),
+    );
+    expect(contentButton).not.toBeNull();
+    expect(contentButton.injector.get(MatTooltip).message).toBe('ピン配置');
+
     const openButton = fixture.debugElement.query(
-      By.css('button[aria-label="ピン配置閉じる"]'),
+      By.css('button[aria-label="ピン配置を閉じる"]'),
     );
     expect(openButton).not.toBeNull();
-    expect(openButton.injector.get(MatTooltip).message).toBe('ピン配置閉じる');
+    expect(openButton.injector.get(MatTooltip).message).toBe('ピン配置を閉じる');
     expect(openButton.attributes['aria-expanded']).toBe('true');
 
     fixture.componentRef.setInput('rightNavOpen', false);
     fixture.detectChanges();
 
     const closedButton = fixture.debugElement.query(
-      By.css('button[aria-label="ピン配置開く"]'),
+      By.css('button[aria-label="ピン配置を開く"]'),
     );
     expect(closedButton).not.toBeNull();
-    expect(closedButton.injector.get(MatTooltip).message).toBe('ピン配置開く');
+    expect(closedButton.injector.get(MatTooltip).message).toBe('ピン配置を開く');
     expect(closedButton.attributes['aria-expanded']).toBe('false');
+  });
+
+  it('emits paneResizeBy on separator arrow keys', () => {
+    const emitSpy = vi.spyOn(component.paneResizeBy, 'emit');
+    const separator = fixture.nativeElement.querySelector(
+      '[role="separator"]',
+    ) as HTMLElement;
+    expect(separator).not.toBeNull();
+
+    separator.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
+    );
+    separator.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+    );
+
+    expect(emitSpy).toHaveBeenCalledWith(16);
+    expect(emitSpy).toHaveBeenCalledWith(-16);
   });
 });

--- a/libs/console-shell/src/lib/component/right-sidebar/right-sidebar.component.ts
+++ b/libs/console-shell/src/lib/component/right-sidebar/right-sidebar.component.ts
@@ -8,10 +8,14 @@ import {
   RIGHT_DIAGRAM_WIDTH,
 } from '@libs-shared';
 
+/** Keyboard resize step for the right panel separator (px). */
+export const RIGHT_PANE_RESIZE_STEP_PX = 16;
+
 @Component({
   selector: 'lib-right-sidebar',
   imports: [MatIconButton, MatIcon, MatTooltip, PinAssignComponent],
   templateUrl: './right-sidebar.component.html',
+  styleUrl: './right-sidebar.component.css',
   host: {
     class: 'flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden',
   },
@@ -22,6 +26,7 @@ export class RightSidebarComponent {
   diagramWidthPx = input<number>(RIGHT_DIAGRAM_WIDTH.default);
   toggleRightSidebar = output<void>();
   paneResizeStart = output<PointerEvent>();
+  paneResizeBy = output<number>();
 
   readonly isOverlay = computed(() => this.layoutMode() === 'overlay');
   readonly isDockedOpen = computed(
@@ -32,11 +37,27 @@ export class RightSidebarComponent {
     () => `min(${this.diagramWidthPx()}px, 85vw)`,
   );
 
+  readonly contentLabel = 'ピン配置';
+
   readonly panelToggleLabel = computed(() =>
-    this.rightNavOpen() ? 'ピン配置閉じる' : 'ピン配置開く',
+    this.rightNavOpen() ? 'ピン配置を閉じる' : 'ピン配置を開く',
   );
 
   onResizePointerDown(event: PointerEvent): void {
     this.paneResizeStart.emit(event);
+  }
+
+  onResizeKeydown(event: KeyboardEvent): void {
+    // Separator is on the left edge: ArrowLeft grows the pane, ArrowRight shrinks.
+    let delta = 0;
+    if (event.key === 'ArrowLeft') {
+      delta = RIGHT_PANE_RESIZE_STEP_PX;
+    } else if (event.key === 'ArrowRight') {
+      delta = -RIGHT_PANE_RESIZE_STEP_PX;
+    } else {
+      return;
+    }
+    event.preventDefault();
+    this.paneResizeBy.emit(delta);
   }
 }

--- a/libs/console-shell/src/lib/component/right-sidebar/right-sidebar.component.ts
+++ b/libs/console-shell/src/lib/component/right-sidebar/right-sidebar.component.ts
@@ -49,15 +49,14 @@ export class RightSidebarComponent {
 
   onResizeKeydown(event: KeyboardEvent): void {
     // Separator is on the left edge: ArrowLeft grows the pane, ArrowRight shrinks.
-    let delta = 0;
     if (event.key === 'ArrowLeft') {
-      delta = RIGHT_PANE_RESIZE_STEP_PX;
-    } else if (event.key === 'ArrowRight') {
-      delta = -RIGHT_PANE_RESIZE_STEP_PX;
-    } else {
+      event.preventDefault();
+      this.paneResizeBy.emit(RIGHT_PANE_RESIZE_STEP_PX);
       return;
     }
-    event.preventDefault();
-    this.paneResizeBy.emit(delta);
+    if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      this.paneResizeBy.emit(-RIGHT_PANE_RESIZE_STEP_PX);
+    }
   }
 }

--- a/libs/editor/src/lib/component/editor-draft-resolve-dialog/editor-draft-resolve-dialog.component.html
+++ b/libs/editor/src/lib/component/editor-draft-resolve-dialog/editor-draft-resolve-dialog.component.html
@@ -1,6 +1,12 @@
-<div class="dialog-content">
-  <h2>Local draft found</h2>
-  <p>
+<div
+  class="dialog-content"
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="draft-resolve-title"
+  aria-describedby="draft-resolve-desc"
+>
+  <h2 id="draft-resolve-title">Local draft found</h2>
+  <p id="draft-resolve-desc">
     A local draft exists for {{ path }}. Restore the draft, discard it, or reload the
     file from the device?
   </p>

--- a/libs/editor/src/lib/component/editor-draft-resolve-dialog/editor-draft-resolve-dialog.component.ts
+++ b/libs/editor/src/lib/component/editor-draft-resolve-dialog/editor-draft-resolve-dialog.component.ts
@@ -52,6 +52,10 @@ export interface EditorDraftResolveDialogData {
       .dialog-actions button:hover {
         background: rgba(0, 0, 0, 0.04);
       }
+      .dialog-actions button:focus-visible {
+        outline: 2px solid #2563eb;
+        outline-offset: 2px;
+      }
     `,
   ],
 })

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.spec.ts
@@ -722,4 +722,86 @@ describe('EditorPageComponent', () => {
     );
     expect(component.loadError()?.message).toContain('UTF-8');
   });
+
+  it('should save on Ctrl/Cmd+S shortcut', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
+    component.onCodeChange('edited');
+    component.onContentEdited();
+    const saveSpy = vi.spyOn(component, 'saveCurrentFile').mockResolvedValue();
+
+    await component.onKeydown(
+      new KeyboardEvent('keydown', { key: 's', ctrlKey: true }),
+    );
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+
+    saveSpy.mockClear();
+    await component.onKeydown(
+      new KeyboardEvent('keydown', { key: 's', metaKey: true }),
+    );
+    expect(saveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should format on Shift+Alt+F shortcut', async () => {
+    await loadPath('/home/pi/main.js', 'const x=1');
+    const formatSpy = vi
+      .spyOn(component, 'formatCurrentFile')
+      .mockResolvedValue();
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'f',
+      shiftKey: true,
+      altKey: true,
+    });
+    const preventSpy = vi.spyOn(event, 'preventDefault');
+
+    await component.onKeydown(event);
+
+    expect(preventSpy).toHaveBeenCalled();
+    expect(formatSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('should open draft resolve dialog with autoFocus and Escape enabled', async () => {
+    const closed = mockDialogResult(undefined);
+    draftServiceMock.list.mockReturnValueOnce([
+      {
+        path: '/home/pi/draft.js',
+        content: 'restored draft',
+        updatedAt: Date.now(),
+      },
+    ]);
+
+    const initPromise = component.ngOnInit();
+    closed.next(undefined);
+    closed.complete();
+    await initPromise;
+
+    expect(dialogServiceMock.open).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        autoFocus: true,
+        data: { path: '/home/pi/draft.js' },
+      }),
+    );
+    const config = dialogServiceMock.open.mock.calls[0]?.[1] as {
+      disableClose?: boolean;
+    };
+    expect(config.disableClose).toBeUndefined();
+  });
+
+  it('should open confirm dialogs with autoFocus', async () => {
+    await loadPath('/home/pi/main.js', 'loaded content');
+    component.onCodeChange('dirty');
+    component.onContentEdited();
+
+    const closed = mockDialogResult(false);
+    const deactivatePromise = component.canDeactivate();
+    closed.next(false);
+    closed.complete();
+    await deactivatePromise;
+
+    expect(dialogServiceMock.open).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ autoFocus: true }),
+    );
+  });
 });

--- a/libs/editor/src/lib/component/editor-page/editor-page.component.ts
+++ b/libs/editor/src/lib/component/editor-page/editor-page.component.ts
@@ -359,6 +359,7 @@ export class EditorPageComponent implements OnInit {
     const sizeLabel = FileUtils.formatFileSize(byteSize);
     const ref = this.dialog.open(ConfirmDialogComponent, {
       width: '420px',
+      autoFocus: true,
       data: {
         title: '大きなファイル',
         message: `このファイルは ${sizeLabel} あります。読み込みに時間がかかる可能性があります。開きますか？`,
@@ -383,6 +384,7 @@ export class EditorPageComponent implements OnInit {
       width: '400px',
       data,
       disableClose: true,
+      autoFocus: true,
     });
 
     const abortGeneration = ++this.transferAbortGeneration;
@@ -433,6 +435,7 @@ export class EditorPageComponent implements OnInit {
       width: '400px',
       data,
       disableClose: true,
+      autoFocus: true,
     });
 
     const abortGeneration = ++this.transferAbortGeneration;
@@ -530,7 +533,7 @@ export class EditorPageComponent implements OnInit {
     const ref = this.dialog.open(EditorDraftResolveDialogComponent, {
       width: '420px',
       data: { path },
-      disableClose: true,
+      autoFocus: true,
     });
     const result = await firstValueFrom(ref.closed);
     return result === 'restore' || result === 'discard' || result === 'reload'
@@ -548,6 +551,7 @@ export class EditorPageComponent implements OnInit {
     this.promptInFlight = (async () => {
       const ref = this.dialog.open(ConfirmDialogComponent, {
         width: '400px',
+        autoFocus: true,
         data: {
           title: 'Unsaved changes',
           message,
@@ -577,6 +581,7 @@ export class EditorPageComponent implements OnInit {
     const parent = this.shellStore.fileManagerCurrentPath();
     const ref = this.dialog.open(FileNameDialogComponent, {
       width: '360px',
+      autoFocus: true,
       data: {
         title: '新規ファイル',
         confirmLabel: '作成',

--- a/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.spec.ts
+++ b/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.spec.ts
@@ -47,18 +47,27 @@ describe('MonacoEditorComponent', () => {
   });
 
   it('should call layout when the container resizes', () => {
+    vi.stubGlobal('monaco', {
+      KeyMod: { CtrlCmd: 2048, Shift: 1024, Alt: 512 },
+      KeyCode: { KeyS: 49, KeyF: 36 },
+      editor: { setModelLanguage: vi.fn() },
+    });
+
     const layout = vi.fn();
+    const addCommand = vi.fn();
     const editorInstance = {
       layout,
       updateOptions: vi.fn(),
       getModel: () => null,
       onDidChangeModelContent: vi.fn(),
+      addCommand,
     } as unknown as editor.IStandaloneCodeEditor;
 
     component.onEditorInit(editorInstance);
 
     expect(observeSpy).toHaveBeenCalled();
     expect(layout).toHaveBeenCalled();
+    expect(addCommand).toHaveBeenCalledTimes(2);
 
     layout.mockClear();
     resizeCallback?.(
@@ -75,6 +84,7 @@ describe('MonacoEditorComponent', () => {
       updateOptions: vi.fn(),
       getModel: () => null,
       onDidChangeModelContent: vi.fn(),
+      addCommand: vi.fn(),
     } as unknown as editor.IStandaloneCodeEditor;
 
     component.onEditorInit(editorInstance);

--- a/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.ts
+++ b/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.ts
@@ -22,6 +22,15 @@ export type MonacoEditorOptions = {
 };
 
 declare const monaco: {
+  KeyMod: {
+    CtrlCmd: number;
+    Shift: number;
+    Alt: number;
+  };
+  KeyCode: {
+    KeyS: number;
+    KeyF: number;
+  };
   editor: {
     setModelLanguage: (
       model: editor.ITextModel,
@@ -75,6 +84,7 @@ export class MonacoEditorComponent {
   onEditorInit(editorInstance: editor.IStandaloneCodeEditor): void {
     this.editorInstance = editorInstance;
     this.applyEditorOptions(editorInstance, this.editorOptions());
+    this.bindPageOwnedShortcuts(editorInstance);
     this.editorInitialized.emit(editorInstance);
     this.observeContainerResize(editorInstance);
     editorInstance.onDidChangeModelContent((event) => {
@@ -83,6 +93,28 @@ export class MonacoEditorComponent {
       }
       this.contentEdited.emit();
     });
+  }
+
+  /**
+   * Steal Ctrl/Cmd+S and Shift+Alt/Option+F from Monaco so EditorPage's
+   * window:keydown handler remains the single owner (avoids double format /
+   * browser save dialog conflicts).
+   */
+  private bindPageOwnedShortcuts(
+    editorInstance: editor.IStandaloneCodeEditor,
+  ): void {
+    if (typeof monaco === 'undefined') {
+      return;
+    }
+    const noop = (): void => undefined;
+    editorInstance.addCommand(
+      monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS,
+      noop,
+    );
+    editorInstance.addCommand(
+      monaco.KeyMod.Shift | monaco.KeyMod.Alt | monaco.KeyCode.KeyF,
+      noop,
+    );
   }
 
   private observeContainerResize(

--- a/libs/editor/src/lib/service/monaco-editor.service.ts
+++ b/libs/editor/src/lib/service/monaco-editor.service.ts
@@ -1,5 +1,11 @@
-import { Injectable } from '@angular/core';
-
+/**
+ * Legacy Monaco helper — not used by the active ngx-monaco-editor path
+ * (`MonacoEditorComponent` + `EditorPageComponent`).
+ *
+ * Save / Format shortcuts are owned by `EditorPageComponent` (`window:keydown`)
+ * and blocked inside Monaco via `addCommand` no-ops so they do not double-fire.
+ * Do not reintroduce CtrlCmd+S here without removing the page-level handler.
+ */
 @Injectable({
   providedIn: 'root',
 })
@@ -26,7 +32,7 @@ export class MonacoEditorService {
     monaco: any,
     container: HTMLElement,
     jsSrc: string,
-    onSave: (value: string) => void,
+    _onSave: (value: string) => void,
   ) {
     this.editor = monaco.editor.create(container, {
       value: jsSrc,
@@ -38,9 +44,7 @@ export class MonacoEditorService {
       readOnly: false,
       theme: 'vs-dark',
     });
-    this.editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KEY_S, () => {
-      this.saveSource(onSave);
-    });
+    // Intentionally no CtrlCmd+S binding — see class JSDoc.
     this.editor.onDidChangeModelContent(() => {
       this.editedFlag = true;
       // UI上のファイル名色変更などは呼び出し元で対応

--- a/libs/editor/src/lib/service/monaco-editor.service.ts
+++ b/libs/editor/src/lib/service/monaco-editor.service.ts
@@ -1,3 +1,5 @@
+import { Injectable } from '@angular/core';
+
 /**
  * Legacy Monaco helper — not used by the active ngx-monaco-editor path
  * (`MonacoEditorComponent` + `EditorPageComponent`).

--- a/libs/editor/src/lib/service/monaco-editor.service.ts
+++ b/libs/editor/src/lib/service/monaco-editor.service.ts
@@ -47,6 +47,7 @@ export class MonacoEditorService {
       theme: 'vs-dark',
     });
     // Intentionally no CtrlCmd+S binding — see class JSDoc.
+    void _onSave;
     this.editor.onDidChangeModelContent(() => {
       this.editedFlag = true;
       // UI上のファイル名色変更などは呼び出し元で対応

--- a/libs/file-manager/src/lib/component/file-tree/file-tree.component.css
+++ b/libs/file-manager/src/lib/component/file-tree/file-tree.component.css
@@ -1,0 +1,4 @@
+.file-tree__node:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}

--- a/libs/file-manager/src/lib/component/file-tree/file-tree.component.html
+++ b/libs/file-manager/src/lib/component/file-tree/file-tree.component.html
@@ -1,14 +1,16 @@
 <div class="file-tree text-sm">
-  <ul class="space-y-1">
-    @for (node of nodes(); track node.path) {
+  <ul class="space-y-1" role="list">
+    @for (node of nodes(); track node.path; let i = $index) {
       <li>
         <button
+          #nodeButton
           type="button"
-          class="inline-flex w-full items-center gap-1 text-left px-2 py-1 rounded hover:bg-gray-100"
+          class="file-tree__node inline-flex w-full items-center gap-1 text-left px-2 py-1 rounded hover:bg-gray-100"
           [class.bg-blue-50]="isSelected(node)"
           [class.font-medium]="isSelected(node)"
           [attr.aria-current]="isSelected(node) ? 'true' : null"
           (click)="onSelect(node)"
+          (keydown)="onNodeKeydown($event, i)"
           (contextmenu)="onContextMenu($event, node)"
         >
           @if (node.isDirectory) {

--- a/libs/file-manager/src/lib/component/file-tree/file-tree.component.spec.ts
+++ b/libs/file-manager/src/lib/component/file-tree/file-tree.component.spec.ts
@@ -53,4 +53,47 @@ describe('FileTreeComponent', () => {
     expect(fileButton?.classList.contains('bg-blue-50')).toBe(true);
     expect(buttons[0]?.getAttribute('aria-current')).toBeNull();
   });
+
+  it('moves focus with ArrowDown and ArrowUp', () => {
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('button');
+    buttons[0]?.focus();
+    expect(document.activeElement).toBe(buttons[0]);
+
+    buttons[0]?.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+    );
+    expect(document.activeElement).toBe(buttons[1]);
+
+    buttons[1]?.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }),
+    );
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it('moves focus to first and last with Home and End', () => {
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('button');
+    buttons[0]?.focus();
+
+    buttons[0]?.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'End', bubbles: true }),
+    );
+    expect(document.activeElement).toBe(buttons[1]);
+
+    buttons[1]?.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Home', bubbles: true }),
+    );
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it('emits fileSelected when Enter activates a file button', () => {
+    const spy = vi.spyOn(fixture.componentInstance.fileSelected, 'emit');
+    const buttons: NodeListOf<HTMLButtonElement> =
+      fixture.nativeElement.querySelectorAll('button');
+
+    buttons[1]?.click();
+
+    expect(spy).toHaveBeenCalledWith(nodes[1]);
+  });
 });

--- a/libs/file-manager/src/lib/component/file-tree/file-tree.component.ts
+++ b/libs/file-manager/src/lib/component/file-tree/file-tree.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, output } from '@angular/core';
+import { Component, ElementRef, input, output, viewChildren } from '@angular/core';
 import { MatIcon } from '@angular/material/icon';
 import { FileTreeNode } from '../../models';
 
@@ -11,6 +11,7 @@ export interface FileTreeContextMenuEvent {
   selector: 'lib-file-tree',
   imports: [MatIcon],
   templateUrl: './file-tree.component.html',
+  styleUrl: './file-tree.component.css',
 })
 export class FileTreeComponent {
   readonly nodes = input<FileTreeNode[]>([]);
@@ -19,6 +20,9 @@ export class FileTreeComponent {
   readonly directorySelected = output<FileTreeNode>();
   readonly fileSelected = output<FileTreeNode>();
   readonly nodeContextMenu = output<FileTreeContextMenuEvent>();
+
+  private readonly nodeButtons =
+    viewChildren<ElementRef<HTMLButtonElement>>('nodeButton');
 
   isSelected(node: FileTreeNode): boolean {
     const selected = this.selectedPath();
@@ -36,5 +40,36 @@ export class FileTreeComponent {
   onContextMenu(event: MouseEvent, node: FileTreeNode): void {
     event.preventDefault();
     this.nodeContextMenu.emit({ node, event });
+  }
+
+  onNodeKeydown(event: KeyboardEvent, index: number): void {
+    const buttons = this.nodeButtons();
+    if (buttons.length === 0) {
+      return;
+    }
+
+    let nextIndex: number | null = null;
+    switch (event.key) {
+      case 'ArrowDown':
+        nextIndex = Math.min(index + 1, buttons.length - 1);
+        break;
+      case 'ArrowUp':
+        nextIndex = Math.max(index - 1, 0);
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = buttons.length - 1;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    if (nextIndex === index) {
+      return;
+    }
+    buttons[nextIndex]?.nativeElement.focus();
   }
 }

--- a/libs/file-manager/src/lib/component/file-tree/file-tree.component.ts
+++ b/libs/file-manager/src/lib/component/file-tree/file-tree.component.ts
@@ -48,7 +48,7 @@ export class FileTreeComponent {
       return;
     }
 
-    let nextIndex: number | null = null;
+    let nextIndex: number;
     switch (event.key) {
       case 'ArrowDown':
         nextIndex = Math.min(index + 1, buttons.length - 1);


### PR DESCRIPTION
## Summary

- ファイルツリーで Arrow / Home / End によるキーボード移動と focus-visible を追加
- 左右パネルのレールボタンラベルを区別し、separator の矢印キーリサイズと focus-visible を追加
- Editor Dialog の autoFocus / Escape（Draft resolve）と Monaco の Save/Format ショートカット競合を整理

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Closes #814
- Refs #804

## What changed?

- `file-manager`: ファイルツリーの矢印キー移動と `:focus-visible`
- `console-shell`: パネル開閉ラベルの差別化、リサイズ separator のキーボード操作、フォーカスリング
- `editor`: Dialog の `autoFocus`、Draft resolve の Escape 許可、Monaco 側で Ctrl/Cmd+S と Shift+Alt+F を no-op 化しページハンドラと二重実行しないようにした
- Unit テストでショートカット・Dialog 設定・ツリーキーボード操作をカバー

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `pnpm nx test libs-file-manager` / `pnpm nx test libs-console-shell` / `pnpm nx test libs-editor`
2. `/editor` でマウスなしにファイルツリーを Arrow で移動し Enter で開く
3. Ctrl/Cmd+S と Shift+Alt+F で Save / Format が動くことを確認
4. 左右パネルのトグルをキーボードで開閉し、separator にフォーカスして矢印で幅変更できることを確認
5. Draft resolve / Confirm Dialog で初期フォーカスが Dialog 内にあり、Escape で閉じられる（Progress は Cancel ボタン経由）ことを確認

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)