### PR TITLE
feat(file-manager): enable drag and drop move in file tree

### DIFF
--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.html
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.html
@@ -103,7 +103,19 @@
         </p>
 
         @if (currentPath() !== '.' && !remoteOpsDisabled) {
-          <button type="button" class="text-xs underline" (click)="goParent()">
+          <button
+            type="button"
+            class="text-xs underline rounded px-1"
+            [class.bg-blue-100]="parentDropActive"
+            [class.outline]="parentDropActive"
+            [class.outline-2]="parentDropActive"
+            [class.outline-dashed]="parentDropActive"
+            [class.outline-blue-600]="parentDropActive"
+            (click)="goParent()"
+            (dragover)="onParentDragOver($event)"
+            (dragleave)="onParentDragLeave()"
+            (drop)="onParentDrop($event)"
+          >
             ← parent
           </button>
         }
@@ -126,6 +138,7 @@
             (directorySelected)="onDirectorySelected($event)"
             (fileSelected)="onFileSelected($event)"
             (nodeContextMenu)="onNodeContextMenu($event)"
+            (nodeDropped)="onNodeDropped($event)"
           />
         }
       </div>

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
@@ -464,6 +464,85 @@ describe('FileTreeFeatureComponent', () => {
     });
   });
 
+  it('moves a node when dropped onto a directory', async () => {
+    const fixture = await compileAndCreate();
+    await connectReady(fixture);
+    const renamedSpy = vi.spyOn(fixture.componentInstance.fileRenamed, 'emit');
+
+    fixture.componentInstance.onNodeDropped({
+      source: treeNodes[1],
+      targetDirectory: treeNodes[0],
+    });
+
+    await vi.waitFor(() => {
+      expect(moveMock).toHaveBeenCalledWith('./main.ts', './docs/main.ts');
+    });
+    expect(renamedSpy).toHaveBeenCalledWith({
+      from: './main.ts',
+      to: './docs/main.ts',
+    });
+  });
+
+  it('does not move when the drop destination already exists', async () => {
+    existsMock.mockResolvedValue(true);
+    const fixture = await compileAndCreate();
+    await connectReady(fixture);
+
+    fixture.componentInstance.onNodeDropped({
+      source: treeNodes[1],
+      targetDirectory: treeNodes[0],
+    });
+
+    await vi.waitFor(() => {
+      expect(fixture.componentInstance.errorMessage).toBe(
+        '「main.ts」は既に存在します',
+      );
+    });
+    expect(moveMock).not.toHaveBeenCalled();
+  });
+
+  it('moves a node to the parent directory on parent drop', async () => {
+    const nestedNodes: FileTreeNode[] = [
+      { name: 'readme.md', path: './docs/readme.md', isDirectory: false },
+    ];
+    const fixture = await compileAndCreate();
+    await connectReady(fixture);
+
+    listTreeMock.mockResolvedValue(nestedNodes);
+    fixture.componentRef.setInput('currentPath', './docs');
+    await vi.waitFor(() => {
+      expect(listTreeMock).toHaveBeenCalledWith('./docs');
+    });
+    fixture.detectChanges();
+
+    const dataTransfer = {
+      getData: (type: string) =>
+        type === 'text/plain' ||
+        type === 'application/x-chirimen-file-tree-path'
+          ? './docs/readme.md'
+          : '',
+      dropEffect: 'none',
+    } as DataTransfer;
+    const dropEvent = new Event('drop', {
+      bubbles: true,
+      cancelable: true,
+    }) as DragEvent;
+    Object.defineProperty(dropEvent, 'dataTransfer', {
+      value: dataTransfer,
+    });
+
+    const renamedSpy = vi.spyOn(fixture.componentInstance.fileRenamed, 'emit');
+    fixture.componentInstance.onParentDrop(dropEvent);
+
+    await vi.waitFor(() => {
+      expect(moveMock).toHaveBeenCalledWith('./docs/readme.md', './readme.md');
+    });
+    expect(renamedSpy).toHaveBeenCalledWith({
+      from: './docs/readme.md',
+      to: './readme.md',
+    });
+  });
+
   it('emits fileDeleted after deleting a node', async () => {
     dialogOpen.mockReturnValue({ closed: of(true) });
     const fixture = await compileAndCreate();

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
@@ -13,7 +13,12 @@ import { ConfirmDialogComponent, DialogService } from '@libs-dialogs';
 import { ButtonComponent } from '@libs-shared';
 import { SerialConnectionViewModelFacade } from '@libs-web-serial';
 import { firstValueFrom } from 'rxjs';
-import { joinPath, parentPathOf } from '../../functions';
+import {
+  buildMoveDestination,
+  canMoveNode,
+  joinPath,
+  parentPathOf,
+} from '../../functions';
 import type { FileContextMenuAction } from '../../models/file-context-menu.types';
 import type { FileRenamedEvent } from '../../models/file-lifecycle.types';
 import type { FileNameDialogData } from '../../models/file-name-dialog.types';
@@ -28,6 +33,7 @@ import { FileNameDialogComponent } from '../file-name-dialog/file-name-dialog.co
 import {
   FileTreeComponent,
   FileTreeContextMenuEvent,
+  FileTreeNodeDropEvent,
 } from '../file-tree/file-tree.component';
 
 @Component({
@@ -77,6 +83,7 @@ export class FileTreeFeatureComponent {
   listFetchFailed = false;
   contextTarget: FileTreeNode | null = null;
   operationBusy = false;
+  parentDropActive = false;
 
   private loadedForLogin = false;
   private lastVmKey = '';
@@ -236,6 +243,46 @@ export class FileTreeFeatureComponent {
     this.fileSelected.emit(node.path);
   }
 
+  onNodeDropped(event: FileTreeNodeDropEvent): void {
+    if (this.remoteOpsDisabled) {
+      return;
+    }
+    void this.withBusy(() =>
+      this.moveNodeToDirectory(event.source, event.targetDirectory.path),
+    );
+  }
+
+  onParentDragOver(event: DragEvent): void {
+    if (this.remoteOpsDisabled || this.currentPath() === '.') {
+      return;
+    }
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'move';
+    }
+    this.parentDropActive = true;
+  }
+
+  onParentDragLeave(): void {
+    this.parentDropActive = false;
+  }
+
+  onParentDrop(event: DragEvent): void {
+    event.preventDefault();
+    this.parentDropActive = false;
+    if (this.remoteOpsDisabled || this.currentPath() === '.') {
+      return;
+    }
+    const source = this.resolveDroppedNode(event);
+    if (!source) {
+      return;
+    }
+    const targetDirectoryPath = parentPathOf(this.currentPath());
+    void this.withBusy(() =>
+      this.moveNodeToDirectory(source, targetDirectoryPath),
+    );
+  }
+
   onNodeContextMenu({ node, event }: FileTreeContextMenuEvent): void {
     event.preventDefault();
     event.stopPropagation();
@@ -373,6 +420,35 @@ export class FileTreeFeatureComponent {
     await this.file.move(target.path, destination);
     await this.reload();
     this.fileRenamed.emit({ from: target.path, to: destination });
+  }
+
+  private async moveNodeToDirectory(
+    source: FileTreeNode,
+    targetDirectoryPath: string,
+  ): Promise<void> {
+    if (!canMoveNode(source, targetDirectoryPath)) {
+      return;
+    }
+    const destination = buildMoveDestination(source, targetDirectoryPath);
+    if (destination === source.path) {
+      return;
+    }
+    if (await this.file.exists(destination)) {
+      throw new Error(`「${source.name}」は既に存在します`);
+    }
+    await this.file.move(source.path, destination);
+    await this.reload();
+    this.fileRenamed.emit({ from: source.path, to: destination });
+  }
+
+  private resolveDroppedNode(event: DragEvent): FileTreeNode | null {
+    const path =
+      event.dataTransfer?.getData('application/x-chirimen-file-tree-path') ||
+      event.dataTransfer?.getData('text/plain');
+    if (!path) {
+      return null;
+    }
+    return this.nodes.find((node) => node.path === path) ?? null;
   }
 
   private async deleteNode(target: FileTreeNode): Promise<void> {

--- a/libs/file-manager/src/lib/component/file-tree/file-tree.component.css
+++ b/libs/file-manager/src/lib/component/file-tree/file-tree.component.css
@@ -2,3 +2,9 @@
   outline: 2px solid #2563eb;
   outline-offset: 2px;
 }
+
+.file-tree__node--drop-target {
+  background-color: #dbeafe;
+  outline: 2px dashed #2563eb;
+  outline-offset: -2px;
+}

--- a/libs/file-manager/src/lib/component/file-tree/file-tree.component.html
+++ b/libs/file-manager/src/lib/component/file-tree/file-tree.component.html
@@ -8,10 +8,17 @@
           class="file-tree__node inline-flex w-full items-center gap-1 text-left px-2 py-1 rounded hover:bg-gray-100"
           [class.bg-blue-50]="isSelected(node)"
           [class.font-medium]="isSelected(node)"
+          [class.file-tree__node--drop-target]="isDropTarget(node)"
           [attr.aria-current]="isSelected(node) ? 'true' : null"
+          [attr.draggable]="true"
           (click)="onSelect(node)"
           (keydown)="onNodeKeydown($event, i)"
           (contextmenu)="onContextMenu($event, node)"
+          (dragstart)="onDragStart($event, node)"
+          (dragend)="onDragEnd()"
+          (dragover)="onDragOver($event, node)"
+          (dragleave)="onDragLeave(node)"
+          (drop)="onDrop($event, node)"
         >
           @if (node.isDirectory) {
             <mat-icon aria-hidden="true" class="shrink-0 text-amber-500">folder</mat-icon>

--- a/libs/file-manager/src/lib/component/file-tree/file-tree.component.spec.ts
+++ b/libs/file-manager/src/lib/component/file-tree/file-tree.component.spec.ts
@@ -4,6 +4,23 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FileTreeNode } from '../../models';
 import { FileTreeComponent } from './file-tree.component';
 
+function createDragEvent(
+  type: string,
+  dataTransfer?: Pick<
+    DataTransfer,
+    'getData' | 'setData' | 'effectAllowed' | 'dropEffect'
+  >,
+): DragEvent {
+  const event = new Event(type, {
+    bubbles: true,
+    cancelable: true,
+  }) as DragEvent;
+  if (dataTransfer) {
+    Object.defineProperty(event, 'dataTransfer', { value: dataTransfer });
+  }
+  return event;
+}
+
 describe('FileTreeComponent', () => {
   let fixture: ComponentFixture<FileTreeComponent>;
   const nodes: FileTreeNode[] = [
@@ -95,5 +112,51 @@ describe('FileTreeComponent', () => {
     buttons[1]?.click();
 
     expect(spy).toHaveBeenCalledWith(nodes[1]);
+  });
+
+  it('emits nodeDropped when a node is dropped onto a directory', () => {
+    const spy = vi.spyOn(fixture.componentInstance.nodeDropped, 'emit');
+    const component = fixture.componentInstance;
+
+    component.onDragStart(createDragEvent('dragstart'), nodes[1]);
+    const dropEvent = createDragEvent('drop');
+    component.onDrop(dropEvent, nodes[0]);
+
+    expect(spy).toHaveBeenCalledWith({
+      source: nodes[1],
+      targetDirectory: nodes[0],
+    });
+    expect(dropEvent.defaultPrevented).toBe(true);
+  });
+
+  it('does not emit nodeDropped when dropped onto a file', () => {
+    const spy = vi.spyOn(fixture.componentInstance.nodeDropped, 'emit');
+    const component = fixture.componentInstance;
+
+    component.onDragStart(createDragEvent('dragstart'), nodes[0]);
+    component.onDrop(createDragEvent('drop'), nodes[1]);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('does not emit nodeDropped when a directory is dropped onto itself', () => {
+    const spy = vi.spyOn(fixture.componentInstance.nodeDropped, 'emit');
+    const component = fixture.componentInstance;
+
+    component.onDragStart(createDragEvent('dragstart'), nodes[0]);
+    component.onDrop(createDragEvent('drop'), nodes[0]);
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('suppresses the click that follows a drag', () => {
+    const spy = vi.spyOn(fixture.componentInstance.directorySelected, 'emit');
+    const component = fixture.componentInstance;
+
+    component.onDragStart(createDragEvent('dragstart'), nodes[0]);
+    component.onDragEnd();
+    component.onSelect(nodes[0]);
+
+    expect(spy).not.toHaveBeenCalled();
   });
 });

--- a/libs/file-manager/src/lib/component/file-tree/file-tree.component.ts
+++ b/libs/file-manager/src/lib/component/file-tree/file-tree.component.ts
@@ -1,11 +1,19 @@
 import { Component, ElementRef, input, output, viewChildren } from '@angular/core';
 import { MatIcon } from '@angular/material/icon';
+import { canMoveNode } from '../../functions';
 import { FileTreeNode } from '../../models';
 
 export interface FileTreeContextMenuEvent {
   node: FileTreeNode;
   event: MouseEvent;
 }
+
+export interface FileTreeNodeDropEvent {
+  source: FileTreeNode;
+  targetDirectory: FileTreeNode;
+}
+
+const DRAG_MIME = 'application/x-chirimen-file-tree-path';
 
 @Component({
   selector: 'lib-file-tree',
@@ -20,16 +28,29 @@ export class FileTreeComponent {
   readonly directorySelected = output<FileTreeNode>();
   readonly fileSelected = output<FileTreeNode>();
   readonly nodeContextMenu = output<FileTreeContextMenuEvent>();
+  readonly nodeDropped = output<FileTreeNodeDropEvent>();
 
   private readonly nodeButtons =
     viewChildren<ElementRef<HTMLButtonElement>>('nodeButton');
+
+  private dragSource: FileTreeNode | null = null;
+  private suppressClick = false;
+  dropTargetPath: string | null = null;
 
   isSelected(node: FileTreeNode): boolean {
     const selected = this.selectedPath();
     return selected !== null && selected === node.path;
   }
 
+  isDropTarget(node: FileTreeNode): boolean {
+    return this.dropTargetPath === node.path;
+  }
+
   onSelect(node: FileTreeNode): void {
+    if (this.suppressClick) {
+      this.suppressClick = false;
+      return;
+    }
     if (node.isDirectory) {
       this.directorySelected.emit(node);
       return;
@@ -40,6 +61,54 @@ export class FileTreeComponent {
   onContextMenu(event: MouseEvent, node: FileTreeNode): void {
     event.preventDefault();
     this.nodeContextMenu.emit({ node, event });
+  }
+
+  onDragStart(event: DragEvent, node: FileTreeNode): void {
+    this.dragSource = node;
+    this.suppressClick = false;
+    const transfer = event.dataTransfer;
+    if (transfer) {
+      transfer.effectAllowed = 'move';
+      transfer.setData(DRAG_MIME, node.path);
+      transfer.setData('text/plain', node.path);
+    }
+  }
+
+  onDragEnd(): void {
+    if (this.dragSource) {
+      this.suppressClick = true;
+    }
+    this.dragSource = null;
+    this.dropTargetPath = null;
+  }
+
+  onDragOver(event: DragEvent, node: FileTreeNode): void {
+    if (!node.isDirectory || !this.canAcceptDrop(node)) {
+      return;
+    }
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'move';
+    }
+    this.dropTargetPath = node.path;
+  }
+
+  onDragLeave(node: FileTreeNode): void {
+    if (this.dropTargetPath === node.path) {
+      this.dropTargetPath = null;
+    }
+  }
+
+  onDrop(event: DragEvent, node: FileTreeNode): void {
+    event.preventDefault();
+    this.dropTargetPath = null;
+    const source = this.resolveDragSource(event);
+    if (!source || !node.isDirectory || !canMoveNode(source, node.path)) {
+      return;
+    }
+    this.nodeDropped.emit({ source, targetDirectory: node });
+    this.dragSource = null;
+    this.suppressClick = true;
   }
 
   onNodeKeydown(event: KeyboardEvent, index: number): void {
@@ -71,5 +140,26 @@ export class FileTreeComponent {
       return;
     }
     buttons[nextIndex]?.nativeElement.focus();
+  }
+
+  private canAcceptDrop(target: FileTreeNode): boolean {
+    const source = this.dragSource;
+    if (!source) {
+      return true;
+    }
+    return canMoveNode(source, target.path);
+  }
+
+  private resolveDragSource(event: DragEvent): FileTreeNode | null {
+    if (this.dragSource) {
+      return this.dragSource;
+    }
+    const path =
+      event.dataTransfer?.getData(DRAG_MIME) ||
+      event.dataTransfer?.getData('text/plain');
+    if (!path) {
+      return null;
+    }
+    return this.nodes().find((node) => node.path === path) ?? null;
   }
 }

--- a/libs/file-manager/src/lib/functions/file-tree.util.spec.ts
+++ b/libs/file-manager/src/lib/functions/file-tree.util.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { parentPathOf, parseLsLine, parseLsOutput } from './file-tree.util';
+import {
+  buildMoveDestination,
+  canMoveNode,
+  parentPathOf,
+  parseLsLine,
+  parseLsOutput,
+} from './file-tree.util';
 
 describe('file-tree util', () => {
   it('parses a file entry', () => {
@@ -43,5 +49,19 @@ describe('file-tree util', () => {
     expect(parentPathOf('./docs')).toBe('.');
     expect(parentPathOf('./docs/readme.md')).toBe('./docs');
     expect(parentPathOf('.')).toBe('.');
+  });
+
+  it('builds move destinations under the target directory', () => {
+    expect(buildMoveDestination({ name: 'main.ts' }, './docs')).toBe(
+      './docs/main.ts',
+    );
+    expect(buildMoveDestination({ name: 'main.ts' }, '.')).toBe('./main.ts');
+  });
+
+  it('rejects moving a node onto itself', () => {
+    expect(canMoveNode({ path: './docs' }, './docs')).toBe(false);
+    expect(canMoveNode({ path: './docs/' }, './docs')).toBe(false);
+    expect(canMoveNode({ path: './main.ts' }, './docs')).toBe(true);
+    expect(canMoveNode({ path: './docs' }, '.')).toBe(true);
   });
 });

--- a/libs/file-manager/src/lib/functions/file-tree.util.ts
+++ b/libs/file-manager/src/lib/functions/file-tree.util.ts
@@ -33,6 +33,30 @@ export function parentPathOf(path: string): string {
   return joinPath('.', segments.join('/'));
 }
 
+/** Destination path when moving `source` into `targetDirectoryPath`. */
+export function buildMoveDestination(
+  source: Pick<FileTreeNode, 'name'>,
+  targetDirectoryPath: string,
+): string {
+  return joinPath(targetDirectoryPath, source.name);
+}
+
+/**
+ * Whether `source` can be moved into `targetDirectoryPath`.
+ * Rejects self-drop and dropping a node onto its own path.
+ */
+export function canMoveNode(
+  source: Pick<FileTreeNode, 'path'>,
+  targetDirectoryPath: string,
+): boolean {
+  const target = normalizeDirectoryPath(targetDirectoryPath);
+  const sourcePath = normalizeDirectoryPath(source.path);
+  if (!target || sourcePath === target) {
+    return false;
+  }
+  return true;
+}
+
 export function parseLsLine(
   line: string,
   basePath: string,


### PR DESCRIPTION
## Summary

ファイルツリー（フラット一覧）内でファイル／ディレクトリをドラッグ＆ドロップし、兄弟ディレクトリまたは親ディレクトリへ移動できるようにしました。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #776

## What changed?

- `buildMoveDestination` / `canMoveNode` ヘルパーを追加し、移動先パスの組み立てと自己ドロップ拒否を共通化
- `FileTreeComponent` に HTML5 DnD（ドラッグ元／ディレクトリへのドロップ／ドロップ先ハイライト／ドラッグ後クリック抑制）を追加
- `FileTreeFeatureComponent` で `FileService.move` による移動と `fileRenamed` ライフサイクル連携、`← parent` へのドロップを実装
- util / tree / feature の単体テストを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. アプリを起動し CHIRIMEN Lite に接続する
2. ファイル一覧でファイルまたはディレクトリをドラッグし、別のディレクトリ行にドロップする
3. 対象がディレクトリ内へ移動し、一覧が再読み込みされることを確認する
4. サブディレクトリ表示中にノードを `← parent` へドロップし、親へ移動することを確認する
5. 同名が既に存在する場合、エラーメッセージが表示され移動されないことを確認する
6. `pnpm nx test libs-file-manager` / `pnpm nx lint libs-file-manager` が通ることを確認する

## Environment (if relevant)

- Browser: Chromium 系（Web Serial 対応）
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)