### PR TITLE
feat(console-shell): allow dropping file tree items onto breadcrumbs

### DIFF
--- a/libs/console-shell/src/lib/component/breadcrumb/breadcrumb.component.html
+++ b/libs/console-shell/src/lib/component/breadcrumb/breadcrumb.component.html
@@ -12,19 +12,50 @@
             <span aria-hidden="true" class="select-none text-gray-400">/</span>
           }
           @if ($last) {
-            <span aria-current="page" class="font-medium text-gray-800">
+            <span
+              aria-current="page"
+              class="rounded px-0.5 font-medium text-gray-800"
+              [class.bg-blue-100]="isDropTarget(segment)"
+              [class.outline]="isDropTarget(segment)"
+              [class.outline-2]="isDropTarget(segment)"
+              [class.outline-dashed]="isDropTarget(segment)"
+              [class.outline-blue-600]="isDropTarget(segment)"
+              (dragover)="onSegmentDragOver($event, segment)"
+              (dragleave)="onSegmentDragLeave(segment)"
+              (drop)="onSegmentDrop($event, segment)"
+            >
               {{ segment.label }}
             </span>
           } @else if (segment.clickable && segment.path) {
             <button
               type="button"
-              class="cursor-pointer border-0 bg-transparent p-0 text-inherit underline-offset-2 hover:underline"
+              class="cursor-pointer rounded border-0 bg-transparent px-0.5 py-0 text-inherit underline-offset-2 hover:underline"
+              [class.bg-blue-100]="isDropTarget(segment)"
+              [class.outline]="isDropTarget(segment)"
+              [class.outline-2]="isDropTarget(segment)"
+              [class.outline-dashed]="isDropTarget(segment)"
+              [class.outline-blue-600]="isDropTarget(segment)"
               (click)="onSegmentActivate(segment)"
+              (dragover)="onSegmentDragOver($event, segment)"
+              (dragleave)="onSegmentDragLeave(segment)"
+              (drop)="onSegmentDrop($event, segment)"
             >
               {{ segment.label }}
             </button>
           } @else {
-            <span>{{ segment.label }}</span>
+            <span
+              class="rounded px-0.5"
+              [class.bg-blue-100]="isDropTarget(segment)"
+              [class.outline]="isDropTarget(segment)"
+              [class.outline-2]="isDropTarget(segment)"
+              [class.outline-dashed]="isDropTarget(segment)"
+              [class.outline-blue-600]="isDropTarget(segment)"
+              (dragover)="onSegmentDragOver($event, segment)"
+              (dragleave)="onSegmentDragLeave(segment)"
+              (drop)="onSegmentDrop($event, segment)"
+            >
+              {{ segment.label }}
+            </span>
           }
         </li>
       }

--- a/libs/console-shell/src/lib/component/breadcrumb/breadcrumb.component.spec.ts
+++ b/libs/console-shell/src/lib/component/breadcrumb/breadcrumb.component.spec.ts
@@ -1,5 +1,6 @@
 /// <reference types="vitest/globals" />
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FILE_TREE_DRAG_MIME } from '@libs-file-manager';
 import { BreadcrumbComponent } from './breadcrumb.component';
 
 describe('BreadcrumbComponent', () => {
@@ -74,5 +75,59 @@ describe('BreadcrumbComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.querySelector('button')).toBeNull();
+  });
+
+  it('emits segmentDrop when a path segment receives a file-tree drop', () => {
+    const emitSpy = vi.spyOn(component.segmentDrop, 'emit');
+    fixture.componentRef.setInput('segments', [
+      { label: 'Console' },
+      { label: 'home', path: './home', clickable: true },
+      { label: 'pi', path: './home/pi', clickable: false },
+    ]);
+    fixture.detectChanges();
+
+    const dataTransfer = {
+      getData: (type: string) =>
+        type === FILE_TREE_DRAG_MIME || type === 'text/plain'
+          ? './home/pi/main.ts'
+          : '',
+      dropEffect: 'none',
+    } as DataTransfer;
+    const dropEvent = new Event('drop', {
+      bubbles: true,
+      cancelable: true,
+    }) as DragEvent;
+    Object.defineProperty(dropEvent, 'dataTransfer', {
+      value: dataTransfer,
+    });
+
+    component.onSegmentDrop(dropEvent, {
+      label: 'home',
+      path: './home',
+      clickable: true,
+    });
+
+    expect(emitSpy).toHaveBeenCalledWith({
+      sourcePath: './home/pi/main.ts',
+      targetDirectoryPath: './home',
+    });
+  });
+
+  it('does not emit segmentDrop when the segment has no path', () => {
+    const emitSpy = vi.spyOn(component.segmentDrop, 'emit');
+    const dropEvent = new Event('drop', {
+      bubbles: true,
+      cancelable: true,
+    }) as DragEvent;
+    Object.defineProperty(dropEvent, 'dataTransfer', {
+      value: {
+        getData: () => './main.ts',
+        dropEffect: 'none',
+      } as DataTransfer,
+    });
+
+    component.onSegmentDrop(dropEvent, { label: 'Console' });
+
+    expect(emitSpy).not.toHaveBeenCalled();
   });
 });

--- a/libs/console-shell/src/lib/component/breadcrumb/breadcrumb.component.ts
+++ b/libs/console-shell/src/lib/component/breadcrumb/breadcrumb.component.ts
@@ -1,5 +1,11 @@
 import { Component, input, output } from '@angular/core';
+import { FILE_TREE_DRAG_MIME } from '@libs-file-manager';
 import type { BreadcrumbSegment } from '../../functions';
+
+export interface BreadcrumbSegmentDropEvent {
+  sourcePath: string;
+  targetDirectoryPath: string;
+}
 
 @Component({
   selector: 'lib-breadcrumb',
@@ -8,10 +14,57 @@ import type { BreadcrumbSegment } from '../../functions';
 export class BreadcrumbComponent {
   segments = input<BreadcrumbSegment[]>([]);
   segmentNavigate = output<string>();
+  segmentDrop = output<BreadcrumbSegmentDropEvent>();
+
+  dropTargetPath: string | null = null;
 
   onSegmentActivate(segment: BreadcrumbSegment): void {
     if (segment.clickable && segment.path) {
       this.segmentNavigate.emit(segment.path);
     }
+  }
+
+  isDropTarget(segment: BreadcrumbSegment): boolean {
+    return !!segment.path && this.dropTargetPath === segment.path;
+  }
+
+  onSegmentDragOver(event: DragEvent, segment: BreadcrumbSegment): void {
+    if (!segment.path) {
+      return;
+    }
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'move';
+    }
+    this.dropTargetPath = segment.path;
+  }
+
+  onSegmentDragLeave(segment: BreadcrumbSegment): void {
+    if (segment.path && this.dropTargetPath === segment.path) {
+      this.dropTargetPath = null;
+    }
+  }
+
+  onSegmentDrop(event: DragEvent, segment: BreadcrumbSegment): void {
+    event.preventDefault();
+    this.dropTargetPath = null;
+    if (!segment.path) {
+      return;
+    }
+    const sourcePath = this.resolveDroppedPath(event);
+    if (!sourcePath) {
+      return;
+    }
+    this.segmentDrop.emit({
+      sourcePath,
+      targetDirectoryPath: segment.path,
+    });
+  }
+
+  private resolveDroppedPath(event: DragEvent): string | null {
+    const path =
+      event.dataTransfer?.getData(FILE_TREE_DRAG_MIME) ||
+      event.dataTransfer?.getData('text/plain');
+    return path || null;
   }
 }

--- a/libs/console-shell/src/lib/component/console-shell/console-shell.component.html
+++ b/libs/console-shell/src/lib/component/console-shell/console-shell.component.html
@@ -20,6 +20,7 @@
       <lib-breadcrumb
         [segments]="breadcrumbSegments()"
         (segmentNavigate)="onBreadcrumbNavigate($event)"
+        (segmentDrop)="onBreadcrumbSegmentDrop($event)"
       />
     }
   </div>

--- a/libs/console-shell/src/lib/component/console-shell/console-shell.component.ts
+++ b/libs/console-shell/src/lib/component/console-shell/console-shell.component.ts
@@ -8,6 +8,7 @@ import {
   signal,
   Type,
   untracked,
+  viewChild,
 } from '@angular/core';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import {
@@ -22,7 +23,10 @@ import {
   ActionToolBarComponent,
   ToolbarAction,
 } from '../action-tool-bar/action-tool-bar.component';
-import { BreadcrumbComponent } from '../breadcrumb/breadcrumb.component';
+import {
+  BreadcrumbComponent,
+  type BreadcrumbSegmentDropEvent,
+} from '../breadcrumb/breadcrumb.component';
 import { HeaderToolbarComponent } from '../header-toolbar/header-toolbar.component';
 import { LeftSidebarComponent } from '../left-sidebar/left-sidebar.component';
 import { RightSidebarComponent } from '../right-sidebar/right-sidebar.component';
@@ -69,6 +73,7 @@ export class ConsoleShellComponent implements OnInit, OnDestroy {
   private breakpointObserver = inject(BreakpointObserver);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
+  private readonly leftSidebar = viewChild(LeftSidebarComponent);
 
   /** Web Serial の接続可否（単一ビューモデル {@link SerialConnectionViewModelFacade#vm} を参照）。 */
   readonly connected = computed(() => this.connectionVm.vm().isConnected);
@@ -380,6 +385,14 @@ export class ConsoleShellComponent implements OnInit, OnDestroy {
   onBreadcrumbNavigate(path: string): void {
     this.shellStore.setFileManagerCurrentPath(path);
     this.shellStore.setSelectedFilePath(null);
+  }
+
+  /** Move a file-tree node dropped onto a breadcrumb directory (issue #777). */
+  onBreadcrumbSegmentDrop(event: BreadcrumbSegmentDropEvent): void {
+    void this.leftSidebar()?.movePathToDirectory(
+      event.sourcePath,
+      event.targetDirectoryPath,
+    );
   }
 
   onToolbarAction(action: ToolbarAction): void {

--- a/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.spec.ts
+++ b/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.spec.ts
@@ -64,7 +64,10 @@ describe('LeftSidebarComponent', () => {
         },
         {
           provide: FileService,
-          useValue: { listTree: vi.fn().mockResolvedValue([]) },
+          useValue: {
+            listTree: vi.fn().mockResolvedValue([]),
+            moveIntoDirectory: vi.fn().mockResolvedValue(null),
+          },
         },
         {
           provide: EDITOR_DRAFT_LIFECYCLE,
@@ -193,6 +196,29 @@ describe('LeftSidebarComponent', () => {
       'ファイルツリーを開く',
     );
     expect(closedButton.attributes['aria-expanded']).toBe('false');
+  });
+
+  it('moves via FileService when the file tree is closed', async () => {
+    const moveIntoDirectory = TestBed.inject(FileService)
+      .moveIntoDirectory as ReturnType<typeof vi.fn>;
+    moveIntoDirectory.mockResolvedValue({
+      from: './main.ts',
+      to: './docs/main.ts',
+    });
+    const store = TestBed.inject(ConsoleShellStore);
+    store.setSelectedFilePath('./main.ts');
+
+    fixture.componentRef.setInput('leftNavOpen', false);
+    fixture.detectChanges();
+
+    await component.movePathToDirectory('./main.ts', './docs');
+
+    expect(moveIntoDirectory).toHaveBeenCalledWith('./main.ts', './docs');
+    expect(draftLifecycle.rename).toHaveBeenCalledWith(
+      './main.ts',
+      './docs/main.ts',
+    );
+    expect(store.selectedFilePath()).toBe('./docs/main.ts');
   });
 
   it('emits paneResizeBy on separator arrow keys', () => {

--- a/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.ts
+++ b/libs/console-shell/src/lib/component/left-sidebar/left-sidebar.component.ts
@@ -1,10 +1,17 @@
-import { Component, computed, inject, input, output } from '@angular/core';
+import {
+  Component,
+  computed,
+  inject,
+  input,
+  output,
+  viewChild,
+} from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatIconButton } from '@angular/material/button';
 import { MatIcon } from '@angular/material/icon';
 import { MatTooltip } from '@angular/material/tooltip';
 import type { FileRenamedEvent } from '@libs-file-manager';
-import { FileTreeFeatureComponent } from '@libs-file-manager';
+import { FileService, FileTreeFeatureComponent } from '@libs-file-manager';
 import {
   ConsoleShellLayoutMode,
   ConsoleShellStore,
@@ -32,6 +39,9 @@ export class LeftSidebarComponent {
   toggleLeftSidebar = output<void>();
   paneResizeStart = output<PointerEvent>();
   paneResizeBy = output<number>();
+
+  private readonly fileTree = viewChild(FileTreeFeatureComponent);
+  private readonly fileService = inject(FileService);
 
   readonly isOverlay = computed(() => this.layoutMode() === 'overlay');
   readonly isDockedOpen = computed(
@@ -87,6 +97,36 @@ export class LeftSidebarComponent {
     this.draftLifecycle?.clear(path);
     if (this.shellStore.selectedFilePath() === path) {
       this.shellStore.setSelectedFilePath(null);
+    }
+  }
+
+  /**
+   * Moves a dragged file-tree node into a breadcrumb directory (issue #777).
+   * Prefers FileTreeFeature so busy/error UI stays consistent; falls back to
+   * FileService when the tree is not mounted (sidebar closed).
+   */
+  async movePathToDirectory(
+    sourcePath: string,
+    targetDirectoryPath: string,
+  ): Promise<void> {
+    const tree = this.fileTree();
+    if (tree) {
+      tree.moveDroppedPath(sourcePath, targetDirectoryPath);
+      return;
+    }
+    try {
+      const result = await this.fileService.moveIntoDirectory(
+        sourcePath,
+        targetDirectoryPath,
+      );
+      if (!result) {
+        return;
+      }
+      this.onFileRenamed(result);
+    } catch (error: unknown) {
+      console.error(
+        error instanceof Error ? error.message : String(error),
+      );
     }
   }
 

--- a/libs/console-shell/src/lib/functions/breadcrumb-segments.spec.ts
+++ b/libs/console-shell/src/lib/functions/breadcrumb-segments.spec.ts
@@ -46,6 +46,17 @@ describe('buildFilePathBreadcrumbSegments', () => {
       ],
     );
   });
+
+  it('attaches path to the last segment when includeLastPath is true', () => {
+    const segments = buildFilePathBreadcrumbSegments('./home/pi/docs', {
+      includeLastPath: true,
+    });
+    expect(segments).toEqual([
+      { label: 'home', path: './home', clickable: true },
+      { label: 'pi', path: './home/pi', clickable: true },
+      { label: 'docs', path: './home/pi/docs', clickable: false },
+    ]);
+  });
 });
 
 describe('buildConsoleShellBreadcrumbSegments', () => {
@@ -137,6 +148,7 @@ describe('buildConsoleShellBreadcrumbSegments', () => {
       'docs',
       'readme.md',
     ]);
+    expect(segments[3]).toEqual({ label: 'readme.md', clickable: false });
   });
 
   it('appends directory path when browsing without a selected file', () => {
@@ -152,6 +164,11 @@ describe('buildConsoleShellBreadcrumbSegments', () => {
       'home',
       'pi',
     ]);
+    expect(segments[3]).toEqual({
+      label: 'pi',
+      path: './home/pi',
+      clickable: false,
+    });
   });
 
   it('does not append path segments at file manager root', () => {

--- a/libs/console-shell/src/lib/functions/breadcrumb-segments.ts
+++ b/libs/console-shell/src/lib/functions/breadcrumb-segments.ts
@@ -25,10 +25,14 @@ const DIALOG_LABELS: Record<
 /**
  * Splits a File Manager path into breadcrumb segments with cumulative paths.
  * Intermediate directories are clickable; the last segment is not.
+ * When `includeLastPath` is true (directory browsing), the last segment also
+ * receives a `path` so it can act as a drop target without being clickable.
  */
 export function buildFilePathBreadcrumbSegments(
   rawPath: string,
+  options?: { includeLastPath?: boolean },
 ): BreadcrumbSegment[] {
+  const includeLastPath = options?.includeLastPath ?? false;
   const isAbsolute = rawPath.startsWith('/');
   let rest = rawPath;
   if (rest.startsWith('./')) {
@@ -51,7 +55,11 @@ export function buildFilePathBreadcrumbSegments(
     const path = isAbsolute ? `/${joined}` : `./${joined}`;
 
     if (isLast) {
-      segments.push({ label: part, clickable: false });
+      segments.push(
+        includeLastPath
+          ? { label: part, path, clickable: false }
+          : { label: part, clickable: false },
+      );
     } else {
       segments.push({ label: part, path, clickable: true });
     }
@@ -106,7 +114,13 @@ export function buildConsoleShellBreadcrumbSegments(
   }
 
   if (pathSource) {
-    segments.push(...buildFilePathBreadcrumbSegments(pathSource));
+    segments.push(
+      ...buildFilePathBreadcrumbSegments(pathSource, {
+        // Directory browsing: last segment is a drop target (issue #777).
+        // Selected file: last segment is a file name without path.
+        includeLastPath: !state.selectedFilePath,
+      }),
+    );
   }
 
   return segments;

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
@@ -17,6 +17,8 @@ describe('FileTreeFeatureComponent', () => {
   const touchMock = vi.fn<() => Promise<void>>();
   const mkdirMock = vi.fn<() => Promise<void>>();
   const moveMock = vi.fn<() => Promise<void>>();
+  const moveIntoDirectoryMock =
+    vi.fn<() => Promise<{ from: string; to: string } | null>>();
   const removeMock = vi.fn<() => Promise<void>>();
   const existsMock = vi.fn<() => Promise<boolean>>();
   const hasUnsavedDraftMock = vi.fn<(path: string) => boolean>();
@@ -53,6 +55,7 @@ describe('FileTreeFeatureComponent', () => {
             touch: touchMock,
             mkdir: mkdirMock,
             move: moveMock,
+            moveIntoDirectory: moveIntoDirectoryMock,
             remove: removeMock,
             exists: existsMock,
           },
@@ -97,6 +100,24 @@ describe('FileTreeFeatureComponent', () => {
     mkdirMock.mockResolvedValue(undefined);
     moveMock.mockReset();
     moveMock.mockResolvedValue(undefined);
+    moveIntoDirectoryMock.mockReset();
+    moveIntoDirectoryMock.mockImplementation(
+      async (sourcePath: string, targetDirectoryPath: string) => {
+        const name = sourcePath.split('/').filter(Boolean).pop() ?? sourcePath;
+        const destination =
+          targetDirectoryPath === '.'
+            ? `./${name}`
+            : `${targetDirectoryPath}/${name}`;
+        if (destination === sourcePath || sourcePath === targetDirectoryPath) {
+          return null;
+        }
+        if (await existsMock(destination)) {
+          throw new Error(`「${name}」は既に存在します`);
+        }
+        await moveMock(sourcePath, destination);
+        return { from: sourcePath, to: destination };
+      },
+    );
     removeMock.mockReset();
     removeMock.mockResolvedValue(undefined);
     existsMock.mockReset();

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.spec.ts
@@ -504,6 +504,22 @@ describe('FileTreeFeatureComponent', () => {
     });
   });
 
+  it('moves a path via moveDroppedPath for external drop targets', async () => {
+    const fixture = await compileAndCreate();
+    await connectReady(fixture);
+    const renamedSpy = vi.spyOn(fixture.componentInstance.fileRenamed, 'emit');
+
+    fixture.componentInstance.moveDroppedPath('./main.ts', './docs');
+
+    await vi.waitFor(() => {
+      expect(moveMock).toHaveBeenCalledWith('./main.ts', './docs/main.ts');
+    });
+    expect(renamedSpy).toHaveBeenCalledWith({
+      from: './main.ts',
+      to: './docs/main.ts',
+    });
+  });
+
   it('does not move when the drop destination already exists', async () => {
     existsMock.mockResolvedValue(true);
     const fixture = await compileAndCreate();

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
@@ -248,6 +248,22 @@ export class FileTreeFeatureComponent {
     );
   }
 
+  /**
+   * Moves a node identified by path into a directory (e.g. breadcrumb drop).
+   * Uses the same busy/error handling as in-tree drops.
+   */
+  moveDroppedPath(sourcePath: string, targetDirectoryPath: string): void {
+    if (this.remoteOpsDisabled) {
+      return;
+    }
+    const source =
+      this.nodes.find((node) => node.path === sourcePath) ??
+      fileTreeNodeFromPath(sourcePath);
+    void this.withBusy(() =>
+      this.moveNodeToDirectory(source, targetDirectoryPath),
+    );
+  }
+
   onParentDragOver(event: DragEvent): void {
     if (this.remoteOpsDisabled || this.currentPath() === '.') {
       return;

--- a/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
+++ b/libs/file-manager/src/lib/component/file-tree-feature/file-tree-feature.component.ts
@@ -13,12 +13,7 @@ import { ConfirmDialogComponent, DialogService } from '@libs-dialogs';
 import { ButtonComponent } from '@libs-shared';
 import { SerialConnectionViewModelFacade } from '@libs-web-serial';
 import { firstValueFrom } from 'rxjs';
-import {
-  buildMoveDestination,
-  canMoveNode,
-  joinPath,
-  parentPathOf,
-} from '../../functions';
+import { fileTreeNodeFromPath, joinPath, parentPathOf } from '../../functions';
 import type { FileContextMenuAction } from '../../models/file-context-menu.types';
 import type { FileRenamedEvent } from '../../models/file-lifecycle.types';
 import type { FileNameDialogData } from '../../models/file-name-dialog.types';
@@ -31,6 +26,7 @@ import { FileService } from '../../service';
 import { FileContextMenuComponent } from '../file-context-menu/file-context-menu.component';
 import { FileNameDialogComponent } from '../file-name-dialog/file-name-dialog.component';
 import {
+  FILE_TREE_DRAG_MIME,
   FileTreeComponent,
   FileTreeContextMenuEvent,
   FileTreeNodeDropEvent,
@@ -426,29 +422,28 @@ export class FileTreeFeatureComponent {
     source: FileTreeNode,
     targetDirectoryPath: string,
   ): Promise<void> {
-    if (!canMoveNode(source, targetDirectoryPath)) {
+    const result = await this.file.moveIntoDirectory(
+      source.path,
+      targetDirectoryPath,
+    );
+    if (!result) {
       return;
     }
-    const destination = buildMoveDestination(source, targetDirectoryPath);
-    if (destination === source.path) {
-      return;
-    }
-    if (await this.file.exists(destination)) {
-      throw new Error(`「${source.name}」は既に存在します`);
-    }
-    await this.file.move(source.path, destination);
     await this.reload();
-    this.fileRenamed.emit({ from: source.path, to: destination });
+    this.fileRenamed.emit(result);
   }
 
   private resolveDroppedNode(event: DragEvent): FileTreeNode | null {
     const path =
-      event.dataTransfer?.getData('application/x-chirimen-file-tree-path') ||
+      event.dataTransfer?.getData(FILE_TREE_DRAG_MIME) ||
       event.dataTransfer?.getData('text/plain');
     if (!path) {
       return null;
     }
-    return this.nodes.find((node) => node.path === path) ?? null;
+    return (
+      this.nodes.find((node) => node.path === path) ??
+      fileTreeNodeFromPath(path)
+    );
   }
 
   private async deleteNode(target: FileTreeNode): Promise<void> {

--- a/libs/file-manager/src/lib/component/file-tree/file-tree.component.ts
+++ b/libs/file-manager/src/lib/component/file-tree/file-tree.component.ts
@@ -13,7 +13,8 @@ export interface FileTreeNodeDropEvent {
   targetDirectory: FileTreeNode;
 }
 
-const DRAG_MIME = 'application/x-chirimen-file-tree-path';
+/** MIME type used when dragging a node from the file tree. */
+export const FILE_TREE_DRAG_MIME = 'application/x-chirimen-file-tree-path';
 
 @Component({
   selector: 'lib-file-tree',
@@ -69,7 +70,7 @@ export class FileTreeComponent {
     const transfer = event.dataTransfer;
     if (transfer) {
       transfer.effectAllowed = 'move';
-      transfer.setData(DRAG_MIME, node.path);
+      transfer.setData(FILE_TREE_DRAG_MIME, node.path);
       transfer.setData('text/plain', node.path);
     }
   }
@@ -155,7 +156,7 @@ export class FileTreeComponent {
       return this.dragSource;
     }
     const path =
-      event.dataTransfer?.getData(DRAG_MIME) ||
+      event.dataTransfer?.getData(FILE_TREE_DRAG_MIME) ||
       event.dataTransfer?.getData('text/plain');
     if (!path) {
       return null;

--- a/libs/file-manager/src/lib/functions/file-tree.util.spec.ts
+++ b/libs/file-manager/src/lib/functions/file-tree.util.spec.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  basenameOfPath,
   buildMoveDestination,
   canMoveNode,
+  fileTreeNodeFromPath,
   parentPathOf,
   parseLsLine,
   parseLsOutput,
@@ -56,6 +58,21 @@ describe('file-tree util', () => {
       './docs/main.ts',
     );
     expect(buildMoveDestination({ name: 'main.ts' }, '.')).toBe('./main.ts');
+  });
+
+  it('resolves basename of paths', () => {
+    expect(basenameOfPath('./docs/readme.md')).toBe('readme.md');
+    expect(basenameOfPath('./docs')).toBe('docs');
+    expect(basenameOfPath('.')).toBe('');
+    expect(basenameOfPath('/app/src/main.js')).toBe('main.js');
+  });
+
+  it('builds a synthetic tree node from a path', () => {
+    expect(fileTreeNodeFromPath('./docs/main.ts')).toEqual({
+      name: 'main.ts',
+      path: './docs/main.ts',
+      isDirectory: false,
+    });
   });
 
   it('rejects moving a node onto itself', () => {

--- a/libs/file-manager/src/lib/functions/file-tree.util.ts
+++ b/libs/file-manager/src/lib/functions/file-tree.util.ts
@@ -33,12 +33,31 @@ export function parentPathOf(path: string): string {
   return joinPath('.', segments.join('/'));
 }
 
+/** Basename of a file or directory path (last non-empty segment). */
+export function basenameOfPath(path: string): string {
+  const normalized = path.startsWith('./') ? path.slice(2) : path;
+  if (!normalized || normalized === '.') {
+    return '';
+  }
+  const segments = normalized.split('/').filter(Boolean);
+  return segments[segments.length - 1] ?? '';
+}
+
 /** Destination path when moving `source` into `targetDirectoryPath`. */
 export function buildMoveDestination(
   source: Pick<FileTreeNode, 'name'>,
   targetDirectoryPath: string,
 ): string {
   return joinPath(targetDirectoryPath, source.name);
+}
+
+/** Minimal node used when only a drag path is available (e.g. breadcrumb drop). */
+export function fileTreeNodeFromPath(path: string): FileTreeNode {
+  return {
+    name: basenameOfPath(path) || path,
+    path,
+    isDirectory: false,
+  };
 }
 
 /**

--- a/libs/file-manager/src/lib/service/file.service.spec.ts
+++ b/libs/file-manager/src/lib/service/file.service.spec.ts
@@ -226,6 +226,55 @@ describe('FileService', () => {
     });
   });
 
+  describe('moveIntoDirectory', () => {
+    it('moves into the target directory when destination is free', async () => {
+      exec.mockImplementation(async (command: string) => {
+        if (String(command).includes('test -e')) {
+          return { stdout: '__MISSING__\n' };
+        }
+        return { stdout: '' };
+      });
+
+      await expect(
+        svc.moveIntoDirectory('./main.ts', './docs'),
+      ).resolves.toEqual({
+        from: './main.ts',
+        to: './docs/main.ts',
+      });
+      expect(exec).toHaveBeenCalledWith(
+        `mv -- ${FileUtils.escapePath('./main.ts')} ${FileUtils.escapePath('./docs/main.ts')}`,
+        expect.objectContaining({ timeout: SERIAL_TIMEOUT.DEFAULT }),
+      );
+    });
+
+    it('returns null when dropping onto the same directory path', async () => {
+      await expect(
+        svc.moveIntoDirectory('./docs', './docs'),
+      ).resolves.toBeNull();
+      expect(exec).not.toHaveBeenCalled();
+    });
+
+    it('returns null when destination equals source path', async () => {
+      await expect(
+        svc.moveIntoDirectory('./main.ts', '.'),
+      ).resolves.toBeNull();
+      expect(exec).not.toHaveBeenCalled();
+    });
+
+    it('throws when the destination already exists', async () => {
+      exec.mockImplementation(async (command: string) => {
+        if (String(command).includes('test -e')) {
+          return { stdout: '__EXISTS__\n' };
+        }
+        return { stdout: '' };
+      });
+
+      await expect(
+        svc.moveIntoDirectory('./main.ts', './docs'),
+      ).rejects.toThrow('「main.ts」は既に存在します');
+    });
+  });
+
   describe('writeBinary', () => {
     it('delegates to FileContentService.writeBinaryFile', async () => {
       const buffer = new ArrayBuffer(8);

--- a/libs/file-manager/src/lib/service/file.service.ts
+++ b/libs/file-manager/src/lib/service/file.service.ts
@@ -7,9 +7,19 @@ import {
   SERIAL_TIMEOUT,
   SerialFacadeService,
 } from '@libs-web-serial';
-import { parseLsOutput } from '../functions';
+import {
+  basenameOfPath,
+  buildMoveDestination,
+  canMoveNode,
+  parseLsOutput,
+} from '../functions';
 import { FileTreeNode } from '../models';
 import { firstValueFrom } from 'rxjs';
+
+export interface FileMoveResult {
+  from: string;
+  to: string;
+}
 
 @Injectable({ providedIn: 'root' })
 export class FileService {
@@ -123,6 +133,32 @@ export class FileService {
         this.shellExecOptions(),
       ),
     );
+  }
+
+  /**
+   * Moves a file or directory into `targetDirectoryPath`.
+   * Returns the move result, or `null` when the operation is a no-op / rejected.
+   */
+  async moveIntoDirectory(
+    sourcePath: string,
+    targetDirectoryPath: string,
+  ): Promise<FileMoveResult | null> {
+    if (!canMoveNode({ path: sourcePath }, targetDirectoryPath)) {
+      return null;
+    }
+    const name = basenameOfPath(sourcePath);
+    if (!name) {
+      return null;
+    }
+    const destination = buildMoveDestination({ name }, targetDirectoryPath);
+    if (destination === sourcePath) {
+      return null;
+    }
+    if (await this.exists(destination)) {
+      throw new Error(`「${name}」は既に存在します`);
+    }
+    await this.move(sourcePath, destination);
+    return { from: sourcePath, to: destination };
   }
 
   /**


### PR DESCRIPTION
## Summary

ファイルツリーからパン屑へのドラッグ＆ドロップで、ファイル／フォルダを移動できるようにしました（Issue #777）。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Closes #777

## What changed?

- `FileService.moveIntoDirectory` を追加し、ツリー内 D&D と同じ移動ロジックをパス指定で再利用可能にした
- パン屑の `path` 付きセグメントをドロップターゲット化し、`segmentDrop` でシェルへ通知する
- ディレクトリ閲覧時は最終セグメントにも `path` を付与（クリック不可のままドロップ可）。選択中ファイル名には `path` を付けない
- `LeftSidebar` はマウント中の `FileTreeFeature.moveDroppedPath` を優先し、サイドバー閉時は `FileService` にフォールバックする

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details: `@libs-file-manager` に `FILE_TREE_DRAG_MIME` / `FileService.moveIntoDirectory` / `basenameOfPath` / `fileTreeNodeFromPath` / `FileTreeFeatureComponent.moveDroppedPath` を追加
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. デバイスに接続し、ファイルツリーでサブディレクトリへ移動する
2. ファイルまたはフォルダをドラッグし、パン屑の祖先ディレクトリ（またはホーム相当のパネル名）へドロップする
3. 対象ディレクトリへ移動され、ツリーが一覧を再読込することを確認する
4. 既存名がある先へドロップすると、ツリー上に既存どおりエラーが表示されることを確認する
5. パン屑クリックによるディレクトリ遷移（#727）が従来どおり動作することを確認する

## Environment (if relevant)

- Browser: Chrome（Web Serial 対応）
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)