### PR TITLE
fix(editor): show source code when opening files in monaco

### DIFF
--- a/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.html
+++ b/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.html
@@ -5,8 +5,6 @@
   <ngx-monaco-editor
     class="block min-h-0 min-w-0 flex-1"
     [options]="baseEditorOptions"
-    [ngModel]="code()"
-    (ngModelChange)="code.set($event)"
     (onInit)="onEditorInit($event)"
   />
 </div>

--- a/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.html
+++ b/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.html
@@ -4,7 +4,7 @@
 >
   <ngx-monaco-editor
     class="block min-h-0 min-w-0 flex-1"
-    [options]="editorOptions()"
+    [options]="baseEditorOptions"
     [ngModel]="code()"
     (ngModelChange)="code.set($event)"
     (onInit)="onEditorInit($event)"

--- a/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.spec.ts
+++ b/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.spec.ts
@@ -46,6 +46,59 @@ describe('MonacoEditorComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  it('should expose a stable baseEditorOptions reference for ngx', () => {
+    const first = component.baseEditorOptions;
+    fixture.componentRef.setInput('editorOptions', {
+      theme: 'vs-dark',
+      language: 'markdown',
+      automaticLayout: true,
+      readOnly: true,
+    });
+    fixture.detectChanges();
+
+    expect(component.baseEditorOptions).toBe(first);
+    expect(component.baseEditorOptions).toEqual({
+      theme: 'vs-dark',
+      automaticLayout: true,
+    });
+    expect(component.baseEditorOptions).not.toHaveProperty('language');
+    expect(component.baseEditorOptions).not.toHaveProperty('readOnly');
+  });
+
+  it('should soft-apply language and readOnly when editorOptions change', () => {
+    const setModelLanguage = vi.fn();
+    vi.stubGlobal('monaco', {
+      KeyMod: { CtrlCmd: 2048, Shift: 1024, Alt: 512 },
+      KeyCode: { KeyS: 49, KeyF: 36 },
+      editor: { setModelLanguage },
+    });
+
+    const updateOptions = vi.fn();
+    const model = {} as editor.ITextModel;
+    const editorInstance = {
+      layout: vi.fn(),
+      updateOptions,
+      getModel: () => model,
+      onDidChangeModelContent: vi.fn(),
+      addCommand: vi.fn(),
+    } as unknown as editor.IStandaloneCodeEditor;
+
+    component.onEditorInit(editorInstance);
+    updateOptions.mockClear();
+    setModelLanguage.mockClear();
+
+    fixture.componentRef.setInput('editorOptions', {
+      theme: 'vs-dark',
+      language: 'javascript',
+      automaticLayout: true,
+      readOnly: true,
+    });
+    fixture.detectChanges();
+
+    expect(updateOptions).toHaveBeenCalledWith({ readOnly: true });
+    expect(setModelLanguage).toHaveBeenCalledWith(model, 'javascript');
+  });
+
   it('should call layout when the container resizes', () => {
     vi.stubGlobal('monaco', {
       KeyMod: { CtrlCmd: 2048, Shift: 1024, Alt: 512 },

--- a/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.spec.ts
+++ b/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.spec.ts
@@ -42,6 +42,29 @@ describe('MonacoEditorComponent', () => {
     vi.unstubAllGlobals();
   });
 
+  function createEditorMock(
+    overrides: Partial<{
+      getValue: ReturnType<typeof vi.fn>;
+      setValue: ReturnType<typeof vi.fn>;
+      layout: ReturnType<typeof vi.fn>;
+      updateOptions: ReturnType<typeof vi.fn>;
+      getModel: ReturnType<typeof vi.fn>;
+      onDidChangeModelContent: ReturnType<typeof vi.fn>;
+      addCommand: ReturnType<typeof vi.fn>;
+    }> = {},
+  ): editor.IStandaloneCodeEditor {
+    return {
+      getValue: overrides.getValue ?? vi.fn().mockReturnValue(''),
+      setValue: overrides.setValue ?? vi.fn(),
+      layout: overrides.layout ?? vi.fn(),
+      updateOptions: overrides.updateOptions ?? vi.fn(),
+      getModel: overrides.getModel ?? vi.fn().mockReturnValue(null),
+      onDidChangeModelContent:
+        overrides.onDidChangeModelContent ?? vi.fn(),
+      addCommand: overrides.addCommand ?? vi.fn(),
+    } as unknown as editor.IStandaloneCodeEditor;
+  }
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
@@ -75,13 +98,10 @@ describe('MonacoEditorComponent', () => {
 
     const updateOptions = vi.fn();
     const model = {} as editor.ITextModel;
-    const editorInstance = {
-      layout: vi.fn(),
+    const editorInstance = createEditorMock({
       updateOptions,
-      getModel: () => model,
-      onDidChangeModelContent: vi.fn(),
-      addCommand: vi.fn(),
-    } as unknown as editor.IStandaloneCodeEditor;
+      getModel: vi.fn().mockReturnValue(model),
+    });
 
     component.onEditorInit(editorInstance);
     updateOptions.mockClear();
@@ -99,6 +119,48 @@ describe('MonacoEditorComponent', () => {
     expect(setModelLanguage).toHaveBeenCalledWith(model, 'javascript');
   });
 
+  it('should push code into monaco via setValue when code model changes', () => {
+    vi.stubGlobal('monaco', {
+      KeyMod: { CtrlCmd: 2048, Shift: 1024, Alt: 512 },
+      KeyCode: { KeyS: 49, KeyF: 36 },
+      editor: { setModelLanguage: vi.fn() },
+    });
+
+    const getValue = vi.fn().mockReturnValue('');
+    const setValue = vi.fn();
+    const editorInstance = createEditorMock({ getValue, setValue });
+
+    component.onEditorInit(editorInstance);
+    setValue.mockClear();
+    getValue.mockReturnValue('');
+
+    fixture.componentRef.setInput('code', "console.log('hello');\n");
+    fixture.detectChanges();
+
+    expect(setValue).toHaveBeenCalledWith("console.log('hello');\n");
+  });
+
+  it('should sync current code on editor init', () => {
+    vi.stubGlobal('monaco', {
+      KeyMod: { CtrlCmd: 2048, Shift: 1024, Alt: 512 },
+      KeyCode: { KeyS: 49, KeyF: 36 },
+      editor: { setModelLanguage: vi.fn() },
+    });
+
+    fixture.componentRef.setInput('code', 'preloaded');
+    fixture.detectChanges();
+
+    const setValue = vi.fn();
+    const editorInstance = createEditorMock({
+      getValue: vi.fn().mockReturnValue(''),
+      setValue,
+    });
+
+    component.onEditorInit(editorInstance);
+
+    expect(setValue).toHaveBeenCalledWith('preloaded');
+  });
+
   it('should call layout when the container resizes', () => {
     vi.stubGlobal('monaco', {
       KeyMod: { CtrlCmd: 2048, Shift: 1024, Alt: 512 },
@@ -108,13 +170,7 @@ describe('MonacoEditorComponent', () => {
 
     const layout = vi.fn();
     const addCommand = vi.fn();
-    const editorInstance = {
-      layout,
-      updateOptions: vi.fn(),
-      getModel: () => null,
-      onDidChangeModelContent: vi.fn(),
-      addCommand,
-    } as unknown as editor.IStandaloneCodeEditor;
+    const editorInstance = createEditorMock({ layout, addCommand });
 
     component.onEditorInit(editorInstance);
 
@@ -131,14 +187,7 @@ describe('MonacoEditorComponent', () => {
   });
 
   it('should disconnect ResizeObserver on destroy', () => {
-    const layout = vi.fn();
-    const editorInstance = {
-      layout,
-      updateOptions: vi.fn(),
-      getModel: () => null,
-      onDidChangeModelContent: vi.fn(),
-      addCommand: vi.fn(),
-    } as unknown as editor.IStandaloneCodeEditor;
+    const editorInstance = createEditorMock();
 
     component.onEditorInit(editorInstance);
     fixture.destroy();

--- a/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.ts
+++ b/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.ts
@@ -65,6 +65,16 @@ export class MonacoEditorComponent {
     readOnly: false,
   });
 
+  /**
+   * Stable options for ngx-monaco-editor-v2. That library reinits (dispose +
+   * recreate) whenever the `[options]` input identity changes; language and
+   * readOnly are applied in-place via {@link applyEditorOptions} instead.
+   */
+  readonly baseEditorOptions: MonacoEditorOptions = {
+    theme: 'vs-dark',
+    automaticLayout: true,
+  };
+
   private editorInstance: editor.IStandaloneCodeEditor | null = null;
   private resizeObserver?: ResizeObserver;
 

--- a/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.ts
+++ b/libs/editor/src/lib/component/monaco-editor/monaco-editor.component.ts
@@ -10,7 +10,6 @@ import {
   untracked,
   viewChild,
 } from '@angular/core';
-import { FormsModule } from '@angular/forms';
 import { MonacoEditorModule } from 'ngx-monaco-editor-v2';
 import type { editor } from 'monaco-editor';
 
@@ -41,11 +40,29 @@ declare const monaco: {
 
 @Component({
   selector: 'choh-monaco-editor',
-  imports: [FormsModule, MonacoEditorModule],
+  imports: [MonacoEditorModule],
   templateUrl: './monaco-editor.component.html',
   host: {
     class: 'block h-full min-h-0 min-w-0',
   },
+  styles: `
+    :host {
+      display: block;
+      height: 100%;
+      min-height: 0;
+      min-width: 0;
+    }
+
+    /* ngx-monaco-editor-v2 hardcodes :host { height: 200px }; override so the
+       editor fills the flex panel instead of looking empty/clipped. */
+    ngx-monaco-editor {
+      display: block;
+      height: 100% !important;
+      min-height: 0;
+      min-width: 0;
+      flex: 1 1 0%;
+    }
+  `,
 })
 export class MonacoEditorComponent {
   private readonly destroyRef = inject(DestroyRef);
@@ -77,8 +94,22 @@ export class MonacoEditorComponent {
 
   private editorInstance: editor.IStandaloneCodeEditor | null = null;
   private resizeObserver?: ResizeObserver;
+  /** Skip echoing setValue-driven model changes back into the code model. */
+  private applyingExternalValue = false;
 
   constructor() {
+    // Push parent/model code into Monaco directly. ngx-monaco-editor-v2's
+    // ngModel writeValue uses setTimeout and races with dispose/reinit,
+    // which can leave the buffer empty after a successful file load.
+    effect(() => {
+      const value = this.code();
+      const instance = untracked(() => this.editorInstance);
+      if (!instance) {
+        return;
+      }
+      this.syncValueToEditor(instance, value);
+    });
+
     effect(() => {
       const options = this.editorOptions();
       const instance = untracked(() => this.editorInstance);
@@ -94,12 +125,17 @@ export class MonacoEditorComponent {
   onEditorInit(editorInstance: editor.IStandaloneCodeEditor): void {
     this.editorInstance = editorInstance;
     this.applyEditorOptions(editorInstance, this.editorOptions());
+    this.syncValueToEditor(editorInstance, this.code());
     this.bindPageOwnedShortcuts(editorInstance);
     this.editorInitialized.emit(editorInstance);
     this.observeContainerResize(editorInstance);
     editorInstance.onDidChangeModelContent((event) => {
-      if (event.isFlush) {
+      if (event.isFlush || this.applyingExternalValue) {
         return;
+      }
+      const next = editorInstance.getValue();
+      if (next !== this.code()) {
+        this.code.set(next);
       }
       this.contentEdited.emit();
     });
@@ -150,6 +186,26 @@ export class MonacoEditorComponent {
   private teardownResizeObserver(): void {
     this.resizeObserver?.disconnect();
     this.resizeObserver = undefined;
+  }
+
+  private syncValueToEditor(
+    instance: editor.IStandaloneCodeEditor,
+    value: string,
+  ): void {
+    if (instance.getValue() === value) {
+      return;
+    }
+    this.applyingExternalValue = true;
+    try {
+      instance.setValue(value);
+    } finally {
+      this.applyingExternalValue = false;
+    }
+    try {
+      instance.layout();
+    } catch {
+      // Dimensions may be zero before layout stabilizes
+    }
   }
 
   private applyEditorOptions(


### PR DESCRIPTION
## Summary

ファイル選択時に `ngx-monaco-editor-v2` へ渡す `[options]` が変わるたびに Monaco が dispose / recreate され、ソースが表示されず `Canceled: Canceled` が出る不具合を修正しました。ngx には安定した base options のみを渡し、`language` / `readOnly` は既存の `applyEditorOptions`（`setModelLanguage` / `updateOptions`）でソフト適用するようにしています。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #832

## What changed?

- `MonacoEditorComponent` に安定参照の `baseEditorOptions` を追加し、ngx の `[options]` にバインド
- `language` / `readOnly` の変更は dispose を伴わないソフト適用のみに限定
- 安定 options とソフト適用のユニットテストを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. `http://localhost:4200/` にアクセスし、シリアルポートを選択・許可してオートログインを待つ
2. `/example` で任意の Example をダウンロードする
3. ファイルツリーでダウンロードした Example の JS ファイルをクリックする
4. エディタにソースコードが表示され、コンソールに `Canceled: Canceled` が出ないことを確認する
5. `pnpm nx test libs-editor` / `pnpm nx lint libs-editor` が通ることを確認する

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)