### PR TITLE
feat(terminal): send ctrl+c as etx interrupt over serial

### DIFF
--- a/libs/terminal/src/lib/component/terminal-input.spec.ts
+++ b/libs/terminal/src/lib/component/terminal-input.spec.ts
@@ -214,4 +214,64 @@ describe('attachTerminalInput', () => {
     expect(onSend).toHaveBeenCalledWith('\x7f');
     expect(terminal.write).not.toHaveBeenCalled();
   });
+
+  it('sends ETX and clears buffer on Ctrl+C', () => {
+    let keyHandler: ((e: TerminalKeyEvent) => void) | undefined;
+    const onSend = vi.fn();
+    const onCommand = vi.fn();
+
+    const terminal = {
+      onKey: (cb: (e: TerminalKeyEvent) => void) => {
+        keyHandler = cb;
+      },
+      write: vi.fn(),
+      writeln: vi.fn(),
+    } as unknown as Parameters<typeof attachTerminalInput>[0];
+
+    attachTerminalInput(terminal, onCommand, () => true, onSend);
+
+    keyHandler?.({
+      domEvent: createDomEvent({ code: 'KeyN', key: 'n' }),
+    });
+    const ctrlC = createDomEvent({
+      code: 'KeyC',
+      key: 'c',
+      ctrlKey: true,
+    });
+    keyHandler?.({ domEvent: ctrlC });
+    keyHandler?.({
+      domEvent: createDomEvent({ code: 'Enter', key: 'Enter' }),
+    });
+
+    expect(onSend).toHaveBeenCalledWith('n');
+    expect(onSend).toHaveBeenCalledWith('\x03');
+    expect(ctrlC.preventDefault).toHaveBeenCalled();
+    expect(onCommand).not.toHaveBeenCalled();
+    expect(terminal.write).not.toHaveBeenCalled();
+  });
+
+  it('does not send Ctrl+C when input is disabled', () => {
+    let keyHandler: ((e: TerminalKeyEvent) => void) | undefined;
+    const onSend = vi.fn();
+
+    const terminal = {
+      onKey: (cb: (e: TerminalKeyEvent) => void) => {
+        keyHandler = cb;
+      },
+      write: vi.fn(),
+      writeln: vi.fn(),
+    } as unknown as Parameters<typeof attachTerminalInput>[0];
+
+    attachTerminalInput(terminal, undefined, () => false, onSend);
+
+    keyHandler?.({
+      domEvent: createDomEvent({
+        code: 'KeyC',
+        key: 'c',
+        ctrlKey: true,
+      }),
+    });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
 });

--- a/libs/terminal/src/lib/component/terminal-input.ts
+++ b/libs/terminal/src/lib/component/terminal-input.ts
@@ -7,11 +7,14 @@ type SendHandler = (data: string) => void;
 const CSI_ARROW_UP = '\x1b[A';
 const CSI_ARROW_DOWN = '\x1b[B';
 const DEL_BACKSPACE = '\x7f';
+/** ETX — remote shell SIGINT (Ctrl+C). */
+const ETX_INTERRUPT = '\x03';
 
 /**
  * Attaches key input handling to an xterm Terminal instance.
  * Sends keystrokes via {@link onSend} for remote shell interaction (no local echo).
  * Left/Right arrows are ignored per interactive console UX.
+ * Ctrl+C sends ETX so foreground processes (e.g. node) can be interrupted.
  */
 export function attachTerminalInput(
   terminal: Terminal,
@@ -78,6 +81,19 @@ export function attachTerminalInput(
         inputBuffer = inputBuffer.slice(0, -1);
       }
       send(DEL_BACKSPACE);
+      return;
+    }
+
+    const isCtrlC =
+      ev.ctrlKey &&
+      !ev.altKey &&
+      !ev.metaKey &&
+      (ev.key === 'c' || ev.key === 'C' || ev.code === 'KeyC');
+
+    if (isCtrlC) {
+      ev.preventDefault?.();
+      inputBuffer = '';
+      send(ETX_INTERRUPT);
       return;
     }
 


### PR DESCRIPTION
## Summary

ターミナルで `node` などを実行中に Ctrl+C で割り込めるようにしました。これまで修飾キー付き入力はすべて破棄されていたため、SIGINT 相当の ETX (`\x03`) がデバイスへ送られていませんでした。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #834

## What changed?

- `attachTerminalInput` で Ctrl+C を検知し、Web Serial 経由で `\x03` を送信するよう変更
- 割り込み時にローカル入力バッファをクリア
- Ctrl+C の回帰テストを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. デバイスに接続し、ターミナルで `node` スクリプト（例: `node hoge.js`）をフォアグラウンド実行する
2. Ctrl+C を押す
3. プロセスが停止し、シェルプロンプトに戻ることを確認する
4. （任意）`pnpm nx test libs-terminal` / `pnpm nx lint libs-terminal` が通ることを確認する

## Environment (if relevant)

- Browser: Chromium 系（Web Serial 対応）
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)