### PR TITLE
ci(workspace): disable ci workflow on main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary

main へのマージ（push）時に CI ワークフローが起動しないよう、`.github/workflows/ci.yml` のトリガーを `pull_request` のみに変更しました。デプロイは既存の `firebase-hosting-merge.yml` が担当します。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #837

## What changed?

- `.github/workflows/ci.yml` から `push: branches: [main]` トリガーを削除
- CI は `pull_request`（main 向け）のときのみ実行されるように変更

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
 - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. この PR に対して CI ワークフローが起動することを確認する
2. マージ後、main への push では CI が起動しないことを確認する
3. マージ後、Deploy console to Firebase Hosting ワークフローのみが起動することを確認する

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant


Made with [Cursor](https://cursor.com)