### PR TITLE
feat(console-shell): add recommended environment dialog to header menu

### DIFF
--- a/libs/console-shell/src/lib/component/header-toolbar/header-toolbar.component.html
+++ b/libs/console-shell/src/lib/component/header-toolbar/header-toolbar.component.html
@@ -16,6 +16,14 @@
       <mat-menu #menu="matMenu">
         <button
           mat-menu-item
+          matTooltip="推奨環境を表示"
+          (click)="openRecommendedEnvironment()"
+        >
+          <mat-icon>info</mat-icon>
+          <span>推奨環境</span>
+        </button>
+        <button
+          mat-menu-item
           matTooltip="Web Serial の切断"
           (click)="eventDisConnect.emit()"
         >

--- a/libs/console-shell/src/lib/component/header-toolbar/header-toolbar.component.spec.ts
+++ b/libs/console-shell/src/lib/component/header-toolbar/header-toolbar.component.spec.ts
@@ -3,16 +3,27 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatTooltip } from '@angular/material/tooltip';
 import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
+import {
+  DialogService,
+  RecommendedEnvironmentDialogComponent,
+} from '@libs-dialogs';
+import { vi } from 'vitest';
 import { HeaderToolbarComponent } from './header-toolbar.component';
 
 describe('HeaderToolbarComponent', () => {
   let component: HeaderToolbarComponent;
   let fixture: ComponentFixture<HeaderToolbarComponent>;
+  let openDialog: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
+    openDialog = vi.fn();
+
     await TestBed.configureTestingModule({
       imports: [HeaderToolbarComponent],
-      providers: [provideRouter([])],
+      providers: [
+        provideRouter([]),
+        { provide: DialogService, useValue: { open: openDialog } },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(HeaderToolbarComponent);
@@ -37,12 +48,39 @@ describe('HeaderToolbarComponent', () => {
     trigger?.click();
     fixture.detectChanges();
 
-    const disconnectButton = fixture.debugElement.query(
+    const menuItems = fixture.debugElement.queryAll(
       By.css('button[mat-menu-item]'),
     );
-    expect(disconnectButton).not.toBeNull();
+    const disconnectButton = menuItems.find((item) =>
+      item.nativeElement.textContent?.includes('Web Serial DisConnect'),
+    );
+    expect(disconnectButton).toBeDefined();
 
-    const tooltip = disconnectButton.injector.get(MatTooltip);
+    const tooltip = disconnectButton!.injector.get(MatTooltip);
     expect(tooltip.message).toBe('Web Serial の切断');
+  });
+
+  it('should open recommended environment dialog from menu', () => {
+    const trigger: HTMLElement | null = fixture.nativeElement.querySelector(
+      '.mat-mdc-menu-trigger',
+    );
+    trigger?.click();
+    fixture.detectChanges();
+
+    const menuItems = fixture.debugElement.queryAll(
+      By.css('button[mat-menu-item]'),
+    );
+    const recommendedButton = menuItems.find((item) =>
+      item.nativeElement.textContent?.includes('推奨環境'),
+    );
+    expect(recommendedButton).toBeDefined();
+
+    const tooltip = recommendedButton!.injector.get(MatTooltip);
+    expect(tooltip.message).toBe('推奨環境を表示');
+
+    recommendedButton!.nativeElement.click();
+    expect(openDialog).toHaveBeenCalledWith(
+      RecommendedEnvironmentDialogComponent,
+    );
   });
 });

--- a/libs/console-shell/src/lib/component/header-toolbar/header-toolbar.component.ts
+++ b/libs/console-shell/src/lib/component/header-toolbar/header-toolbar.component.ts
@@ -1,8 +1,12 @@
-import { Component, output } from '@angular/core';
+import { Component, inject, output } from '@angular/core';
 import { MatIcon } from '@angular/material/icon';
 import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
 import { MatTooltip } from '@angular/material/tooltip';
 import { RouterLink } from '@angular/router';
+import {
+  DialogService,
+  RecommendedEnvironmentDialogComponent,
+} from '@libs-dialogs';
 
 @Component({
   selector: 'lib-header-toolbar',
@@ -10,6 +14,12 @@ import { RouterLink } from '@angular/router';
   templateUrl: './header-toolbar.component.html',
 })
 export class HeaderToolbarComponent {
+  private readonly dialog = inject(DialogService);
+
   eventConnect = output<void>();
   eventDisConnect = output<void>();
+
+  openRecommendedEnvironment(): void {
+    this.dialog.open(RecommendedEnvironmentDialogComponent);
+  }
 }

--- a/libs/dialogs/src/lib/dialogs/index.ts
+++ b/libs/dialogs/src/lib/dialogs/index.ts
@@ -1,3 +1,4 @@
 export * from './confirm-dialog/confirm-dialog.component';
 export * from './progress-dialog/progress-dialog.component';
+export * from './recommended-environment-dialog/recommended-environment-dialog.component';
 export * from './wait-dialog/wait-dialog.component';

--- a/libs/dialogs/src/lib/dialogs/recommended-environment-dialog/recommended-environment-dialog.component.html
+++ b/libs/dialogs/src/lib/dialogs/recommended-environment-dialog/recommended-environment-dialog.component.html
@@ -1,0 +1,17 @@
+<div class="dialog-content">
+  <h2>{{ title }}</h2>
+  <dl>
+    <dt>{{ hardwareLabel }}</dt>
+    <dd>{{ hardware }}</dd>
+    <dt>{{ softwareLabel }}</dt>
+    <dd>
+      <a [href]="softwareUrl" target="_blank" rel="noopener noreferrer">{{
+        softwareName
+      }}</a>
+    </dd>
+  </dl>
+  <p class="dialog-note">{{ note }}</p>
+  <div class="dialog-actions">
+    <button type="button" (click)="close()">{{ closeLabel }}</button>
+  </div>
+</div>

--- a/libs/dialogs/src/lib/dialogs/recommended-environment-dialog/recommended-environment-dialog.component.spec.ts
+++ b/libs/dialogs/src/lib/dialogs/recommended-environment-dialog/recommended-environment-dialog.component.spec.ts
@@ -1,0 +1,44 @@
+import { DialogRef } from '@angular/cdk/dialog';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RecommendedEnvironmentDialogComponent } from './recommended-environment-dialog.component';
+
+describe('RecommendedEnvironmentDialogComponent', () => {
+  let fixture: ComponentFixture<RecommendedEnvironmentDialogComponent>;
+  let close: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    close = vi.fn();
+
+    await TestBed.configureTestingModule({
+      imports: [RecommendedEnvironmentDialogComponent],
+      providers: [{ provide: DialogRef, useValue: { close } }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RecommendedEnvironmentDialogComponent);
+    fixture.detectChanges();
+  });
+
+  it('shows recommended hardware and software with release link', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).toContain('推奨環境');
+    expect(el.textContent).toContain('Raspberry Pi Zero 2 W');
+    expect(el.textContent).toContain('chirimen-lite v2.0.0');
+
+    const link = el.querySelector('a');
+    expect(link?.getAttribute('href')).toBe(
+      'https://github.com/chirimen-oh/chirimen-lite/releases/tag/v2.0.0',
+    );
+    expect(link?.getAttribute('target')).toBe('_blank');
+    expect(link?.getAttribute('rel')).toContain('noopener');
+  });
+
+  it('closes when close button is clicked', () => {
+    const button = (fixture.nativeElement as HTMLElement).querySelector(
+      'button',
+    );
+    expect(button?.textContent?.trim()).toBe('閉じる');
+    button?.dispatchEvent(new MouseEvent('click'));
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/libs/dialogs/src/lib/dialogs/recommended-environment-dialog/recommended-environment-dialog.component.ts
+++ b/libs/dialogs/src/lib/dialogs/recommended-environment-dialog/recommended-environment-dialog.component.ts
@@ -1,0 +1,88 @@
+import { DialogRef } from '@angular/cdk/dialog';
+import { Component, inject } from '@angular/core';
+
+@Component({
+  selector: 'lib-recommended-environment-dialog',
+  templateUrl: './recommended-environment-dialog.component.html',
+  styles: [
+    `
+      .dialog-content {
+        min-width: 280px;
+        max-width: 100%;
+        padding: 1.25rem 1.5rem;
+        background: #fff;
+        color: rgba(0, 0, 0, 0.87);
+        border-radius: 8px;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+      }
+      .dialog-content h2 {
+        margin: 0 0 0.75rem;
+        font-size: 1.125rem;
+        font-weight: 500;
+        line-height: 1.4;
+      }
+      .dialog-content dl {
+        margin: 0;
+      }
+      .dialog-content dt {
+        margin-top: 0.75rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: rgba(0, 0, 0, 0.6);
+      }
+      .dialog-content dt:first-of-type {
+        margin-top: 0;
+      }
+      .dialog-content dd {
+        margin: 0.25rem 0 0;
+        line-height: 1.5;
+      }
+      .dialog-content a {
+        color: #1565c0;
+        text-decoration: underline;
+      }
+      .dialog-note {
+        margin: 1rem 0 0;
+        font-size: 0.875rem;
+        line-height: 1.5;
+        color: rgba(0, 0, 0, 0.7);
+      }
+      .dialog-actions {
+        display: flex;
+        gap: 0.5rem;
+        margin-top: 1.25rem;
+        justify-content: flex-end;
+      }
+      .dialog-actions button {
+        padding: 0.4rem 0.85rem;
+        border: 1px solid rgba(0, 0, 0, 0.24);
+        border-radius: 4px;
+        background: #fff;
+        color: inherit;
+        cursor: pointer;
+        font: inherit;
+      }
+      .dialog-actions button:hover {
+        background: rgba(0, 0, 0, 0.04);
+      }
+    `,
+  ],
+})
+export class RecommendedEnvironmentDialogComponent {
+  private dialogRef = inject(DialogRef<void>, { optional: true });
+
+  readonly title = '推奨環境';
+  readonly hardwareLabel = 'ハードウェア';
+  readonly hardware = 'Raspberry Pi Zero 2 W';
+  readonly softwareLabel = 'ソフトウェア';
+  readonly softwareName = 'chirimen-lite v2.0.0';
+  readonly softwareUrl =
+    'https://github.com/chirimen-oh/chirimen-lite/releases/tag/v2.0.0';
+  readonly note =
+    'v2.0.0 は 64-bit（Pi 4B / 5 / Zero 2 向け）です。初代 Zero W / WH をご利用の場合は v1.6 をご使用ください。';
+  readonly closeLabel = '閉じる';
+
+  close(): void {
+    this.dialogRef?.close();
+  }
+}


### PR DESCRIPTION
## Summary

- header-toolbar のメニューから「推奨環境」を開けるようにしました
- ハードウェア（Raspberry Pi Zero 2 W）とソフトウェア（chirimen-lite v2.0.0）をダイアログで表示します
- ソフトウェア名はリリースページへの外部リンクです

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #841

## What changed?

- `libs/dialogs` に推奨環境専用ダイアログ（`RecommendedEnvironmentDialogComponent`）を追加
- `header-toolbar` の `mat-menu` に「推奨環境」項目を追加し、`DialogService` でダイアログを開くように変更
- 各 lib のユニットテストを追加・更新

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
 - Details: `@libs-dialogs` から `RecommendedEnvironmentDialogComponent` を export
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
 - Migration notes:

## How to test

1. コンソールを開き、ヘッダー右上のメニューを開く
2. 「推奨環境」を選択する
3. ダイアログにハードウェア「Raspberry Pi Zero 2 W」、ソフトウェア「chirimen-lite v2.0.0」が表示されることを確認する
4. ソフトウェアリンクが https://github.com/chirimen-oh/chirimen-lite/releases/tag/v2.0.0 を開くことを確認する
5. 「閉じる」でダイアログが閉じ、既存の「Web Serial DisConnect」が問題なく動作することを確認する

## Environment (if relevant)

- Browser:
- OS: macOS / Windows / Linux
- Node version:
- pnpm version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I updated docs/README if needed
- [x] I considered error handling where relevant

Made with [Cursor](https://cursor.com)